### PR TITLE
Add release workflow: cross-compiled binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Run CI checks first
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: ci
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross (for cross-compilation)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build release binaries
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --workspace --release --target ${{ matrix.target }}
+          else
+            cargo build --workspace --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package binaries
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          ARCHIVE_NAME="seidrum-${VERSION}-${{ matrix.target }}"
+          mkdir -p "${ARCHIVE_NAME}"
+
+          # Copy all binaries
+          for bin in target/${{ matrix.target }}/release/seidrum-*; do
+            # Skip .d files and other non-executables
+            if [ -f "$bin" ] && [ -x "$bin" ] && [[ ! "$bin" =~ \. ]]; then
+              cp "$bin" "${ARCHIVE_NAME}/"
+            fi
+          done
+
+          # Include docs
+          cp LICENSE README.md "${ARCHIVE_NAME}/"
+          cp .env.example "${ARCHIVE_NAME}/"
+
+          tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
+          echo "ARCHIVE=${ARCHIVE_NAME}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: seidrum-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/**/*.tar.gz


### PR DESCRIPTION
## Summary

- New GitHub Actions release workflow triggered on `v*` tag push
- Builds release binaries for 4 targets:
  - `x86_64-unknown-linux-gnu` (most servers)
  - `aarch64-unknown-linux-gnu` (ARM servers, Raspberry Pi)
  - `x86_64-apple-darwin` (Intel Mac)
  - `aarch64-apple-darwin` (Apple Silicon Mac)
- Packages all 20 binaries into `seidrum-{version}-{target}.tar.gz` tarballs
- Creates GitHub Release with auto-generated release notes
- CI checks (check, clippy, test, fmt) run first before building
- Added `workflow_call` trigger to CI workflow so release can reuse it

## Usage

```bash
git tag v0.1.0
git push origin v0.1.0
```

This triggers the workflow which builds, packages, and creates a release with downloadable binaries.

## Test plan

- [ ] Verify CI passes on PR
- [ ] After merge, tag a release and verify binaries are built and attached