### PR TITLE
Fix aarch64 release build: OpenSSL cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build release binaries
+        env:
+          OPENSSL_STATIC: "1"
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --workspace --release --target ${{ matrix.target }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update && apt-get install -y libssl-dev:arm64 pkg-config"
+]


### PR DESCRIPTION
## Summary

- Add `Cross.toml` with pre-build step to install `libssl-dev:arm64` in the cross container
- Set `OPENSSL_STATIC=1` for static linking in release builds
- Fixes the `aarch64-unknown-linux-gnu` build failure in the v0.1.0 release

## Context

The v0.1.0 release workflow failed on the aarch64 Linux target because `openssl-sys` couldn't find the cross-compiled OpenSSL library. The `seidrum-email` plugin depends on `native-tls` → `openssl`.