### PR TITLE
Remove PII from docs, source, and tests

### DIFF
--- a/crates/plugins/seidrum-llm-router/src/context_assembly.rs
+++ b/crates/plugins/seidrum-llm-router/src/context_assembly.rs
@@ -487,12 +487,12 @@ mod tests {
     fn make_test_context() -> AgentContextLoaded {
         let inbound_payload = serde_json::json!({
             "platform": "cli",
-            "user_id": "luis",
+            "user_id": "user-1",
             "chat_id": "chat-1",
             "text": "What tasks do I have?",
             "reply_to": null,
             "attachments": [],
-            "metadata": {"user_name": "Luis"}
+            "metadata": {"user_name": "Alice"}
         });
 
         AgentContextLoaded {
@@ -509,13 +509,13 @@ mod tests {
             entities: vec![],
             facts: vec![
                 serde_json::json!({
-                    "subject_name": "Luis",
+                    "subject_name": "Alice",
                     "predicate": "works_at",
                     "object_name": "Acme Corp",
                     "confidence": 0.95
                 }),
                 serde_json::json!({
-                    "subject_name": "Luis",
+                    "subject_name": "Alice",
                     "predicate": "lives_in",
                     "value": "San Francisco",
                     "confidence": 0.8
@@ -545,13 +545,13 @@ mod tests {
     #[test]
     fn test_format_facts() {
         let facts = vec![serde_json::json!({
-            "subject_name": "Luis",
+            "subject_name": "Alice",
             "predicate": "works_at",
             "object_name": "Acme",
             "confidence": 0.95
         })];
         let result = format_facts(&facts);
-        assert!(result.contains("Luis"));
+        assert!(result.contains("Alice"));
         assert!(result.contains("works_at"));
         assert!(result.contains("Acme"));
         assert!(result.contains("95%"));
@@ -591,7 +591,7 @@ mod tests {
         let template = "Hello {{ user_name }}, time is {{ current_time }}.";
         let ctx = make_test_context();
         let result = render_prompt(template, &ctx).unwrap();
-        assert!(result.contains("Hello Luis"));
+        assert!(result.contains("Hello Alice"));
     }
 
     #[test]
@@ -605,7 +605,7 @@ mod tests {
 
         let assembled = assemble_context(&config, &ctx).unwrap();
         assert!(!assembled.system_prompt.is_empty());
-        assert!(assembled.system_prompt.contains("Luis"));
+        assert!(assembled.system_prompt.contains("Alice"));
         // Should have at least the user message
         assert!(!assembled.messages.is_empty());
         // Last message should be the user's current message
@@ -619,6 +619,6 @@ mod tests {
     fn test_extract_user_name_from_metadata() {
         let ctx = make_test_context();
         let name = extract_user_name(&ctx);
-        assert_eq!(name, "Luis");
+        assert_eq!(name, "Alice");
     }
 }

--- a/crates/plugins/seidrum-telegram/src/main.rs
+++ b/crates/plugins/seidrum-telegram/src/main.rs
@@ -37,7 +37,7 @@ struct Cli {
     #[arg(
         long,
         env = "WHISPER_CLI_PATH",
-        default_value = "/home/luisj/bin/whisper.cpp/build/bin/whisper-cli"
+        default_value = "whisper-cli"
     )]
     whisper_cli_path: String,
 
@@ -45,7 +45,7 @@ struct Cli {
     #[arg(
         long,
         env = "WHISPER_MODEL_PATH",
-        default_value = "/home/luisj/bin/whisper.cpp/models/ggml-small.en.bin"
+        default_value = "ggml-small.en.bin"
     )]
     whisper_model_path: String,
 }

--- a/docs/BRAIN_SCHEMA.md
+++ b/docs/BRAIN_SCHEMA.md
@@ -37,15 +37,14 @@ Core nodes: people, organizations, projects, tools, locations, concepts.
 
 ```json
 {
-  "_key": "entity_luis",
+  "_key": "entity_alice",
   "type": "person",
-  "name": "Luis Palomo",
-  "aliases": ["Luis Jose Palomo Fleming", "luis-palomo-f"],
+  "name": "Alice Smith",
+  "aliases": ["alice-s"],
   "properties": {
-    "email": "luis@mindysm.com",
-    "linkedin": "linkedin.com/in/luis-palomo-f",
-    "location": "Tallinn, Estonia",
-    "role": "Fractional CTO"
+    "email": "alice@example.com",
+    "location": "Berlin, Germany",
+    "role": "Software Engineer"
   },
   "embedding": [0.12, -0.34, ...],
   "created_at": "2024-01-15T10:00:00Z",
@@ -67,17 +66,17 @@ Raw ingested content. Messages, emails, documents, files. Immutable.
   "type": "message",
   "channel": "telegram",
   "channel_id": "chat_12345",
-  "raw_text": "Hey Luis, the MindSpa migration to Hetzner is done...",
-  "summary": "MindSpa infrastructure migration to Hetzner completed",
+  "raw_text": "Hey Alice, the Acme API migration is done...",
+  "summary": "Acme API infrastructure migration completed",
   "language": "en",
   "sentiment": 0.7,
   "embedding": [0.45, -0.12, ...],
   "timestamp": "2026-03-08T09:15:00Z",
   "ingested_at": "2026-03-08T09:15:02Z",
   "metadata": {
-    "from": "entity_platon",
-    "to": "entity_luis",
-    "thread_id": "thread_mindspa_migration",
+    "from": "entity_bob",
+    "to": "entity_alice",
+    "thread_id": "thread_api_migration",
     "has_attachments": false
   }
 }
@@ -139,7 +138,7 @@ Context boundaries for knowledge isolation.
 scope_root (identity — always accessible)
 ├── scope_career
 │   ├── scope_job_search
-│   └── scope_mindysm
+│   └── scope_acme
 ├── scope_projects
 │   ├── scope_talk_careers
 │   └── scope_seidrum
@@ -154,11 +153,11 @@ Persistent task objects that survive agent sessions.
 ```json
 {
   "_key": "task_001",
-  "title": "Migrate MindSpa DNS to Hetzner",
+  "title": "Migrate Acme DNS to new provider",
   "status": "in_progress",
   "priority": "high",
   "assigned_agent": "personal-assistant",
-  "created_by": "entity_luis",
+  "created_by": "entity_alice",
   "created_from": "content_msg_20260308_001",
   "due_date": "2026-03-10T00:00:00Z",
   "completion_event": "task.completed.task_001",
@@ -196,15 +195,15 @@ Registry of all event types in the system.
 
 ```json
 {
-  "_from": "entities/entity_luis",
-  "_to": "entities/entity_mindysm",
-  "type": "owns",
-  "properties": { "ownership_pct": 100 },
-  "valid_from": "2020-01-01T00:00:00Z",
+  "_from": "entities/entity_alice",
+  "_to": "entities/entity_acme",
+  "type": "works_at",
+  "properties": { "role": "engineer" },
+  "valid_from": "2024-01-01T00:00:00Z",
   "valid_to": null,
   "confidence": 1.0,
   "source_content": "content_registration_doc",
-  "scopes": ["scope_career", "scope_mindysm"]
+  "scopes": ["scope_career", "scope_acme"]
 }
 ```
 
@@ -213,11 +212,11 @@ Registry of all event types in the system.
 ```json
 {
   "_from": "content/content_msg_20260308_001",
-  "_to": "entities/entity_mindspa",
-  "context_snippet": "...the MindSpa migration...",
+  "_to": "entities/entity_acme",
+  "context_snippet": "...the Acme API migration...",
   "mention_type": "direct",
   "sentiment_toward": 0.3,
-  "scopes": ["scope_mindspa"]
+  "scopes": ["scope_acme"]
 }
 ```
 
@@ -225,8 +224,8 @@ Registry of all event types in the system.
 
 ```json
 {
-  "_from": "entities/entity_infrahub",
-  "_to": "scopes/scope_job_search",
+  "_from": "entities/entity_some_tool",
+  "_to": "scopes/scope_projects",
   "relevance": 0.9,
   "added_at": "2026-02-17T00:00:00Z",
   "added_by": "system"
@@ -252,7 +251,7 @@ Registry of all event types in the system.
 {
   "_from": "facts/fact_042",
   "_to": "facts/fact_001",
-  "reason": "User confirmed MindSpa wind-down complete",
+  "reason": "User confirmed project shutdown complete",
   "superseded_at": "2026-01-15T00:00:00Z"
 }
 ```
@@ -261,7 +260,7 @@ Registry of all event types in the system.
 
 ```json
 {
-  "_from": "entities/entity_luis",
+  "_from": "entities/entity_alice",
   "_to": "content/content_msg_20260308_001",
   "role": "recipient",
   "channel": "telegram",

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -58,7 +58,7 @@ Rust binary. Plugins can be written in any language that speaks NATS.
 
 - **The brain is a graph, not a log.** Relationships between entities matter
   more than chronological message history. The graph enables traversal:
-  "Luis mentioned Infrahub in a Telegram message to Damien, referencing a
+  "Alice mentioned a tool in a Telegram message to Bob, referencing a
   GitHub repo" — that's a graph query.
 
 - **Scopes are boundaries.** An agent operating in the "job search" scope


### PR DESCRIPTION
## Summary

- Replace real names, email, LinkedIn URL, company name, and location in `docs/BRAIN_SCHEMA.md` with generic examples (Alice, Bob, Acme)
- Anonymize graph traversal example in `docs/PROJECT.md`
- Replace hardcoded `/home/luisj/` paths in `seidrum-telegram/src/main.rs` with generic defaults (`whisper-cli`, `ggml-small.en.bin`)
- Replace real name in test fixtures in `seidrum-llm-router/src/context_assembly.rs` with "Alice"

## Test plan

- [x] All tests pass (`cargo test --workspace`)
- [x] `grep -r` confirms no PII remains (only LICENSE copyright)