### PR TITLE
Admin dashboard + plugin config schema system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -514,6 +516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +537,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -1079,6 +1093,9 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1193,6 +1210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1557,6 +1595,12 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -1950,6 +1994,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex 0.14.0",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2257,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2310,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2299,6 +2438,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -2767,6 +2912,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +3025,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -2906,6 +3086,40 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3125,6 +3339,9 @@ dependencies = [
  "clap",
  "dashmap",
  "futures",
+ "jsonschema",
+ "mime_guess",
+ "rust-embed",
  "seidrum-common",
  "serde",
  "serde_json",
@@ -4375,7 +4592,12 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -4609,6 +4831,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4625,6 +4858,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/crates/plugins/seidrum-api-gateway/Cargo.toml
+++ b/crates/plugins/seidrum-api-gateway/Cargo.toml
@@ -19,7 +19,10 @@ clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 axum = { version = "0.8", features = ["ws"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
 futures = "0.3"
 dashmap = "6"
 ulid = "1"
+jsonschema = "0.28"
+rust-embed = "8"
+mime_guess = "2"

--- a/crates/plugins/seidrum-api-gateway/src/dashboard.rs
+++ b/crates/plugins/seidrum-api-gateway/src/dashboard.rs
@@ -1,0 +1,360 @@
+//! Dashboard backend handlers.
+//!
+//! These endpoints power the admin web dashboard and are mounted
+//! under `/api/v1/`.
+
+use std::time::Duration;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use chrono::Utc;
+use seidrum_common::events::{
+    ConfigUpdated, PluginHealthRequest, PluginHealthResponse, PluginRegister, StorageGetRequest,
+    StorageGetResponse, StorageSetRequest, StorageSetResponse,
+};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::AppState;
+
+// ---------------------------------------------------------------------------
+// Registry query types (mirror of kernel's RegistryQuery)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(tag = "query_type")]
+enum RegistryQuery {
+    #[serde(rename = "list_plugins")]
+    ListPlugins,
+    #[serde(rename = "get_plugin")]
+    GetPlugin { plugin_id: String },
+    #[serde(rename = "get_config_schema")]
+    GetConfigSchema { plugin_id: String },
+}
+
+#[derive(Deserialize)]
+struct RegistryQueryResponse {
+    #[allow(dead_code)]
+    success: bool,
+    plugin: Option<PluginRegister>,
+    plugins: Option<Vec<PluginRegister>>,
+    config_schema: Option<serde_json::Value>,
+    #[allow(dead_code)]
+    error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct DashboardOverview {
+    pub uptime_seconds: u64,
+    pub plugins: Vec<PluginSummary>,
+}
+
+#[derive(Serialize)]
+pub struct PluginSummary {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub health_status: String,
+    pub has_config_schema: bool,
+}
+
+#[derive(Serialize)]
+pub struct PluginConfigResponse {
+    pub plugin_id: String,
+    pub config: Option<serde_json::Value>,
+    pub schema: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+pub struct ConfigUpdateBody {
+    pub config: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/dashboard/overview`
+///
+/// Returns system overview with all plugins and their health status.
+pub async fn overview(State(state): State<AppState>) -> impl IntoResponse {
+    // Get all registered plugins from the kernel registry
+    let plugins_result: Result<RegistryQueryResponse, _> = tokio::time::timeout(
+        Duration::from_secs(3),
+        state
+            .nats
+            .request::<_, RegistryQueryResponse>("registry.query", &RegistryQuery::ListPlugins),
+    )
+    .await
+    .map_err(|_| "timeout")
+    .and_then(|r| r.map_err(|_| "nats error"));
+
+    let registered_plugins = plugins_result
+        .ok()
+        .and_then(|r| r.plugins)
+        .unwrap_or_default();
+
+    // Health-check all plugins in parallel with short timeout
+    let health_futures: Vec<_> = registered_plugins
+        .iter()
+        .map(|p| {
+            let nats = state.nats.clone();
+            let health_subject = p.health_subject.clone();
+            let plugin_id = p.id.clone();
+            async move {
+                let req = PluginHealthRequest {};
+                let result = tokio::time::timeout(
+                    Duration::from_secs(2),
+                    nats.request::<_, PluginHealthResponse>(&health_subject, &req),
+                )
+                .await;
+                match result {
+                    Ok(Ok(resp)) => (plugin_id, resp.status),
+                    _ => (plugin_id, "unreachable".to_string()),
+                }
+            }
+        })
+        .collect();
+
+    let health_results = futures::future::join_all(health_futures).await;
+    let health_map: std::collections::HashMap<String, String> =
+        health_results.into_iter().collect();
+
+    let plugins: Vec<PluginSummary> = registered_plugins
+        .iter()
+        .map(|p| PluginSummary {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            version: p.version.clone(),
+            description: p.description.clone(),
+            health_status: health_map
+                .get(&p.id)
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string()),
+            has_config_schema: p.config_schema.is_some(),
+        })
+        .collect();
+
+    Json(DashboardOverview {
+        uptime_seconds: state.start_time.elapsed().as_secs(),
+        plugins,
+    })
+}
+
+/// `GET /api/v1/dashboard/plugins/:id/health`
+pub async fn plugin_health(
+    State(state): State<AppState>,
+    Path(plugin_id): Path<String>,
+) -> impl IntoResponse {
+    let health_subject = format!("plugin.{}.health", plugin_id);
+    let req = PluginHealthRequest {};
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, PluginHealthResponse>(&health_subject, &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Err(err)) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": err.to_string()})),
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({"error": "Health check timed out"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/v1/dashboard/plugins/:id/config`
+///
+/// Returns current config + schema for a plugin.
+pub async fn get_plugin_config(
+    State(state): State<AppState>,
+    Path(plugin_id): Path<String>,
+) -> impl IntoResponse {
+    // Get schema from registry
+    let schema = get_schema(&state, &plugin_id).await;
+
+    // Get current config from storage
+    let config = get_stored_config(&state, &plugin_id).await;
+
+    Json(PluginConfigResponse {
+        plugin_id,
+        config,
+        schema,
+    })
+}
+
+/// `GET /api/v1/dashboard/plugins/:id/config/schema`
+pub async fn get_config_schema(
+    State(state): State<AppState>,
+    Path(plugin_id): Path<String>,
+) -> impl IntoResponse {
+    match get_schema(&state, &plugin_id).await {
+        Some(schema) => Json(schema).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "No config schema for this plugin"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `PUT /api/v1/dashboard/plugins/:id/config`
+///
+/// Validates config against schema, persists, and notifies the plugin.
+pub async fn update_plugin_config(
+    State(state): State<AppState>,
+    Path(plugin_id): Path<String>,
+    Json(body): Json<ConfigUpdateBody>,
+) -> impl IntoResponse {
+    // 1. Get schema
+    let schema = match get_schema(&state, &plugin_id).await {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Plugin does not have a config schema"})),
+            )
+                .into_response()
+        }
+    };
+
+    // 2. Validate against schema
+    match jsonschema::validator_for(&schema) {
+        Ok(validator) => {
+            let error_messages: Vec<String> = validator
+                .iter_errors(&body.config)
+                .map(|e| e.to_string())
+                .collect();
+
+            if !error_messages.is_empty() {
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(serde_json::json!({
+                        "error": "Config validation failed",
+                        "details": error_messages
+                    })),
+                )
+                    .into_response();
+            }
+        }
+        Err(err) => {
+            warn!(%err, %plugin_id, "Invalid config schema");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Invalid schema: {}", err)})),
+            )
+                .into_response();
+        }
+    }
+
+    // 3. Persist to storage
+    let store_req = StorageSetRequest {
+        plugin_id: plugin_id.clone(),
+        namespace: "config".to_string(),
+        key: "current".to_string(),
+        value: body.config.clone(),
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, StorageSetResponse>("storage.set", &store_req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) if resp.success => {}
+        Ok(Ok(resp)) => {
+            let err = resp.error.unwrap_or_else(|| "unknown".to_string());
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Storage error: {}", err)})),
+            )
+                .into_response();
+        }
+        Ok(Err(err)) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({"error": format!("Storage error: {}", err)})),
+            )
+                .into_response()
+        }
+        Err(_) => {
+            return (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(serde_json::json!({"error": "Storage request timed out"})),
+            )
+                .into_response()
+        }
+    }
+
+    // 4. Notify the plugin
+    let update = ConfigUpdated {
+        plugin_id: plugin_id.clone(),
+        config: body.config,
+        updated_by: "dashboard".to_string(),
+        timestamp: Utc::now(),
+    };
+
+    let subject = format!("plugin.{}.config.update", plugin_id);
+    if let Ok(bytes) = serde_json::to_vec(&update) {
+        let _ = state.nats.inner().publish(subject, bytes.into()).await;
+    }
+
+    Json(serde_json::json!({"success": true})).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn get_schema(state: &AppState, plugin_id: &str) -> Option<serde_json::Value> {
+    let query = RegistryQuery::GetConfigSchema {
+        plugin_id: plugin_id.to_string(),
+    };
+    match tokio::time::timeout(
+        Duration::from_secs(3),
+        state
+            .nats
+            .request::<_, RegistryQueryResponse>("registry.query", &query),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp.config_schema,
+        _ => None,
+    }
+}
+
+async fn get_stored_config(state: &AppState, plugin_id: &str) -> Option<serde_json::Value> {
+    let req = StorageGetRequest {
+        plugin_id: plugin_id.to_string(),
+        namespace: "config".to_string(),
+        key: "current".to_string(),
+    };
+    match tokio::time::timeout(
+        Duration::from_secs(3),
+        state
+            .nats
+            .request::<_, StorageGetResponse>("storage.get", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) if resp.found => resp.value,
+        _ => None,
+    }
+}

--- a/crates/plugins/seidrum-api-gateway/src/main.rs
+++ b/crates/plugins/seidrum-api-gateway/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod connections;
+mod dashboard;
 mod protocol;
 mod rest;
 mod ws;
@@ -9,12 +10,13 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::{Query, Request, State};
-use axum::http::StatusCode;
+use axum::http::{header, StatusCode, Uri};
 use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, put};
 use axum::Router;
 use clap::Parser;
+use rust_embed::Embed;
 use seidrum_common::events::PluginRegister;
 use seidrum_common::nats_utils::NatsClient;
 use tower_http::cors::CorsLayer;
@@ -82,6 +84,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     nats.publish_envelope("plugin.register", None, None, &register)
@@ -107,7 +110,7 @@ async fn main() -> Result<()> {
     });
 
     // Build axum router
-    // Authenticated REST routes
+    // Authenticated REST + dashboard API routes
     let api_routes = Router::new()
         .route("/plugins", get(rest::list_plugins))
         .route("/plugins/{id}", delete(rest::deregister_plugin))
@@ -117,6 +120,20 @@ async fn main() -> Result<()> {
         .route("/storage/set", post(rest::storage_set))
         .route("/storage/delete", post(rest::storage_delete))
         .route("/storage/list", post(rest::storage_list))
+        // Dashboard endpoints
+        .route("/dashboard/overview", get(dashboard::overview))
+        .route(
+            "/dashboard/plugins/{id}/health",
+            get(dashboard::plugin_health),
+        )
+        .route(
+            "/dashboard/plugins/{id}/config",
+            get(dashboard::get_plugin_config).put(dashboard::update_plugin_config),
+        )
+        .route(
+            "/dashboard/plugins/{id}/config/schema",
+            get(dashboard::get_config_schema),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             bearer_auth_middleware,
@@ -126,6 +143,16 @@ async fn main() -> Result<()> {
         .route("/ws", get(ws_handler))
         .route("/api/v1/health", get(rest::health))
         .nest("/api/v1", api_routes)
+        // Dashboard static files (no auth — HTML/CSS/JS)
+        .route("/dashboard/{*path}", get(serve_static))
+        .route(
+            "/dashboard",
+            get(|| async { axum::response::Redirect::permanent("/dashboard/") }),
+        )
+        .route(
+            "/",
+            get(|| async { axum::response::Redirect::temporary("/dashboard/") }),
+        )
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state);
@@ -179,4 +206,40 @@ async fn bearer_auth_middleware(
     }
 
     next.run(req).await.into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Static file serving (dashboard frontend)
+// ---------------------------------------------------------------------------
+
+#[derive(Embed)]
+#[folder = "static/"]
+struct StaticAssets;
+
+/// Serve embedded static files for the dashboard.
+async fn serve_static(uri: Uri) -> impl IntoResponse {
+    let path = uri.path().trim_start_matches("/dashboard/");
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    match StaticAssets::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            (
+                [(header::CONTENT_TYPE, mime.as_ref())],
+                content.data.into_owned(),
+            )
+                .into_response()
+        }
+        None => {
+            // SPA fallback: serve index.html for unknown paths
+            match StaticAssets::get("index.html") {
+                Some(content) => (
+                    [(header::CONTENT_TYPE, "text/html")],
+                    content.data.into_owned(),
+                )
+                    .into_response(),
+                None => StatusCode::NOT_FOUND.into_response(),
+            }
+        }
+    }
 }

--- a/crates/plugins/seidrum-api-gateway/src/ws.rs
+++ b/crates/plugins/seidrum-api-gateway/src/ws.rs
@@ -212,6 +212,7 @@ async fn handle_register(
         health_subject: format!("plugin.{}.health", plugin.id),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     nats.publish_envelope("plugin.register", None, None, &register)

--- a/crates/plugins/seidrum-api-gateway/static/app.js
+++ b/crates/plugins/seidrum-api-gateway/static/app.js
@@ -1,0 +1,432 @@
+// Seidrum Dashboard - Vanilla JS
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+function getApiKey() { return sessionStorage.getItem('seidrum_api_key') || ''; }
+function setApiKey(key) { sessionStorage.setItem('seidrum_api_key', key); }
+
+function handleLogin(e) {
+    e.preventDefault();
+    const key = document.getElementById('api-key-input').value.trim();
+    if (key) {
+        setApiKey(key);
+        document.getElementById('login-prompt').style.display = 'none';
+        showPage('overview');
+    }
+}
+
+async function api(path, options = {}) {
+    const resp = await fetch(path, {
+        ...options,
+        headers: {
+            'Authorization': `Bearer ${getApiKey()}`,
+            'Content-Type': 'application/json',
+            ...options.headers,
+        },
+    });
+    if (resp.status === 401) {
+        document.getElementById('login-prompt').style.display = 'block';
+        document.getElementById('page-content').innerHTML = '';
+        throw new Error('Unauthorized');
+    }
+    return resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+function showPage(page) {
+    document.querySelectorAll('#sidebar a').forEach(a => a.classList.remove('active'));
+    const link = document.querySelector(`#sidebar a[onclick="showPage('${page}')"]`);
+    if (link) link.classList.add('active');
+
+    const pages = { overview: renderOverview, plugins: renderPlugins, capabilities: renderCapabilities, storage: renderStorage, events: renderEvents };
+    if (pages[page]) pages[page]();
+}
+
+function showToast(msg, type = 'success') {
+    const el = document.createElement('div');
+    el.className = `toast toast-${type}`;
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3000);
+}
+
+// ---------------------------------------------------------------------------
+// Overview
+// ---------------------------------------------------------------------------
+
+async function renderOverview() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const data = await api('/api/v1/dashboard/overview');
+        const hours = Math.floor(data.uptime_seconds / 3600);
+        const mins = Math.floor((data.uptime_seconds % 3600) / 60);
+
+        const healthy = data.plugins.filter(p => p.health_status === 'healthy').length;
+        const total = data.plugins.length;
+
+        el.innerHTML = `
+            <h2>System Overview</h2>
+            <div class="grid">
+                <div class="stat"><div class="value">${total}</div><div class="label">Plugins</div></div>
+                <div class="stat"><div class="value">${healthy}</div><div class="label">Healthy</div></div>
+                <div class="stat"><div class="value">${hours}h ${mins}m</div><div class="label">Uptime</div></div>
+            </div>
+            <div class="card">
+                <h3>Registered Plugins</h3>
+                <table>
+                    <thead><tr><th>Name</th><th>Version</th><th>Status</th><th>Config</th></tr></thead>
+                    <tbody>
+                        ${data.plugins.map(p => `
+                            <tr class="clickable" onclick="renderPluginDetail('${p.id}')">
+                                <td><strong>${p.name}</strong><br><span style="color:var(--text-muted);font-size:12px">${p.id}</span></td>
+                                <td>${p.version}</td>
+                                <td><span class="badge badge-${p.health_status}">${p.health_status}</span></td>
+                                <td>${p.has_config_schema ? '<span class="badge badge-tool">schema</span>' : ''}</td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>
+            </div>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugins
+// ---------------------------------------------------------------------------
+
+async function renderPlugins() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const data = await api('/api/v1/dashboard/overview');
+
+        el.innerHTML = `
+            <h2>Plugins (${data.plugins.length})</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Name</th><th>Version</th><th>Status</th><th>Description</th></tr></thead>
+                <tbody>
+                    ${data.plugins.map(p => `
+                        <tr class="clickable" onclick="renderPluginDetail('${p.id}')">
+                            <td><code>${p.id}</code></td>
+                            <td>${p.name}</td>
+                            <td>${p.version}</td>
+                            <td><span class="badge badge-${p.health_status}">${p.health_status}</span></td>
+                            <td style="color:var(--text-muted)">${p.description}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+async function renderPluginDetail(pluginId) {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const [configData, healthData] = await Promise.allSettled([
+            api(`/api/v1/dashboard/plugins/${pluginId}/config`),
+            api(`/api/v1/dashboard/plugins/${pluginId}/health`),
+        ]);
+
+        const config = configData.status === 'fulfilled' ? configData.value : {};
+        const health = healthData.status === 'fulfilled' ? healthData.value : { status: 'unknown' };
+
+        let html = `
+            <h2>${pluginId}</h2>
+            <p><a href="#" onclick="renderPlugins()">&larr; Back to plugins</a></p>
+
+            <div class="card">
+                <h3>Health</h3>
+                <p>Status: <span class="badge badge-${health.status || 'unknown'}">${health.status || 'unknown'}</span></p>
+                ${health.uptime_seconds ? `<p>Uptime: ${Math.floor(health.uptime_seconds / 60)} minutes</p>` : ''}
+                ${health.events_processed ? `<p>Events processed: ${health.events_processed}</p>` : ''}
+                ${health.last_error ? `<p style="color:var(--error)">Last error: ${health.last_error}</p>` : ''}
+            </div>
+        `;
+
+        // Config form
+        if (config.schema) {
+            html += `<div class="card"><h3>Configuration</h3>`;
+            html += renderConfigForm(config.schema, config.config || {}, pluginId);
+            html += `</div>`;
+        }
+
+        el.innerHTML = html;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config form generator
+// ---------------------------------------------------------------------------
+
+function renderConfigForm(schema, currentConfig, pluginId) {
+    if (!schema.properties) return '<p style="color:var(--text-muted)">No configurable properties.</p>';
+
+    const required = schema.required || [];
+    let html = `<form id="config-form" onsubmit="submitConfig(event, '${pluginId}')">`;
+
+    for (const [key, prop] of Object.entries(schema.properties)) {
+        const value = currentConfig[key] !== undefined ? currentConfig[key] : (prop.default || '');
+        const isRequired = required.includes(key);
+        const label = key + (isRequired ? ' *' : '');
+
+        html += `<div class="form-group">`;
+        html += `<label for="cfg-${key}">${label}</label>`;
+
+        if (prop.enum) {
+            html += `<select id="cfg-${key}" name="${key}">`;
+            for (const opt of prop.enum) {
+                const selected = opt === value ? 'selected' : '';
+                html += `<option value="${opt}" ${selected}>${opt}</option>`;
+            }
+            html += `</select>`;
+        } else if (prop.type === 'boolean') {
+            const checked = value ? 'checked' : '';
+            html += `<input type="checkbox" id="cfg-${key}" name="${key}" ${checked} style="width:auto">`;
+        } else if (prop.type === 'number' || prop.type === 'integer') {
+            html += `<input type="number" id="cfg-${key}" name="${key}" value="${value}" step="${prop.type === 'integer' ? 1 : 'any'}">`;
+        } else if (prop.type === 'object' || prop.type === 'array') {
+            html += `<textarea id="cfg-${key}" name="${key}" rows="4">${typeof value === 'object' ? JSON.stringify(value, null, 2) : value}</textarea>`;
+        } else {
+            html += `<input type="text" id="cfg-${key}" name="${key}" value="${value}">`;
+        }
+
+        if (prop.description) html += `<div class="description">${prop.description}</div>`;
+        html += `</div>`;
+    }
+
+    html += `<button type="submit">Save Configuration</button></form>`;
+    return html;
+}
+
+async function submitConfig(e, pluginId) {
+    e.preventDefault();
+    const form = document.getElementById('config-form');
+    const formData = new FormData(form);
+    const config = {};
+
+    // Get schema to know types
+    const schemaResp = await api(`/api/v1/dashboard/plugins/${pluginId}/config/schema`);
+
+    for (const [key, value] of formData.entries()) {
+        const prop = schemaResp.properties?.[key] || {};
+        if (prop.type === 'number') config[key] = parseFloat(value);
+        else if (prop.type === 'integer') config[key] = parseInt(value, 10);
+        else if (prop.type === 'boolean') config[key] = value === 'on';
+        else if (prop.type === 'object' || prop.type === 'array') {
+            try { config[key] = JSON.parse(value); } catch { config[key] = value; }
+        } else config[key] = value;
+    }
+
+    // Handle unchecked checkboxes
+    if (schemaResp.properties) {
+        for (const [key, prop] of Object.entries(schemaResp.properties)) {
+            if (prop.type === 'boolean' && !(key in config)) config[key] = false;
+        }
+    }
+
+    try {
+        const resp = await api(`/api/v1/dashboard/plugins/${pluginId}/config`, {
+            method: 'PUT',
+            body: JSON.stringify({ config }),
+        });
+        if (resp.success) showToast('Configuration saved');
+        else showToast(resp.error || 'Save failed', 'error');
+    } catch (e) {
+        showToast(e.message, 'error');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+async function renderCapabilities() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const data = await api('/api/v1/capabilities?limit=100');
+
+        el.innerHTML = `
+            <h2>Capabilities (${data.tools.length})</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Name</th><th>Kind</th><th>Summary</th></tr></thead>
+                <tbody>
+                    ${data.tools.map(t => `
+                        <tr>
+                            <td><code>${t.tool_id}</code></td>
+                            <td>${t.name}</td>
+                            <td><span class="badge badge-${t.kind}">${t.kind}</span></td>
+                            <td style="color:var(--text-muted)">${t.summary_md}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+async function renderStorage() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = `
+        <h2>Plugin Storage</h2>
+        <div class="card">
+            <div style="display:flex;gap:8px;margin-bottom:16px">
+                <input type="text" id="storage-plugin" placeholder="Plugin ID" style="flex:1">
+                <input type="text" id="storage-namespace" placeholder="Namespace" value="default" style="flex:1">
+                <button onclick="listStorageKeys()">List Keys</button>
+            </div>
+            <div id="storage-results"></div>
+        </div>
+    `;
+}
+
+async function listStorageKeys() {
+    const pluginId = document.getElementById('storage-plugin').value.trim();
+    const namespace = document.getElementById('storage-namespace').value.trim() || 'default';
+    const results = document.getElementById('storage-results');
+
+    if (!pluginId) { results.innerHTML = '<p style="color:var(--text-muted)">Enter a plugin ID</p>'; return; }
+
+    try {
+        const data = await api('/api/v1/storage/list', {
+            method: 'POST',
+            body: JSON.stringify({ plugin_id: pluginId, namespace }),
+        });
+
+        if (data.keys.length === 0) {
+            results.innerHTML = '<p style="color:var(--text-muted)">No keys found.</p>';
+            return;
+        }
+
+        results.innerHTML = `
+            <table>
+                <thead><tr><th>Key</th><th>Actions</th></tr></thead>
+                <tbody>
+                    ${data.keys.map(k => `
+                        <tr>
+                            <td><code>${k}</code></td>
+                            <td><button class="btn-sm" onclick="viewStorageKey('${pluginId}', '${namespace}', '${k}')">View</button></td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        `;
+    } catch (e) {
+        results.innerHTML = `<p style="color:var(--error)">${e.message}</p>`;
+    }
+}
+
+async function viewStorageKey(pluginId, namespace, key) {
+    try {
+        const data = await api('/api/v1/storage/get', {
+            method: 'POST',
+            body: JSON.stringify({ plugin_id: pluginId, namespace, key }),
+        });
+        const value = data.found ? JSON.stringify(data.value, null, 2) : '(not found)';
+        alert(`${pluginId}/${namespace}/${key}:\n\n${value}`);
+    } catch (e) {
+        alert('Error: ' + e.message);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Events (live stream)
+// ---------------------------------------------------------------------------
+
+let eventWs = null;
+
+function renderEvents() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = `
+        <h2>Live Events</h2>
+        <div class="card">
+            <div style="display:flex;gap:8px;margin-bottom:16px">
+                <input type="text" id="event-subject" placeholder="Subject pattern (e.g., channel.*.inbound)" value="channel.*.inbound" style="flex:1">
+                <button onclick="startEventStream()">Subscribe</button>
+                <button class="btn-danger" onclick="stopEventStream()">Stop</button>
+            </div>
+            <div id="event-log" class="event-log"></div>
+        </div>
+    `;
+}
+
+function startEventStream() {
+    stopEventStream();
+    const subject = document.getElementById('event-subject').value.trim();
+    if (!subject) return;
+
+    const wsUrl = `ws://${location.host}/ws?api_key=${encodeURIComponent(getApiKey())}`;
+    eventWs = new WebSocket(wsUrl);
+
+    eventWs.onopen = () => {
+        eventWs.send(JSON.stringify({
+            type: 'register',
+            plugin: { id: 'dashboard-monitor', name: 'Dashboard Monitor', version: '0.1.0', description: 'Live event viewer' }
+        }));
+        setTimeout(() => {
+            eventWs.send(JSON.stringify({ type: 'subscribe', subjects: [subject] }));
+        }, 500);
+    };
+
+    eventWs.onmessage = (msg) => {
+        const data = JSON.parse(msg.data);
+        if (data.type === 'event') {
+            const log = document.getElementById('event-log');
+            const time = new Date().toLocaleTimeString();
+            const entry = document.createElement('div');
+            entry.className = 'event-entry';
+            entry.innerHTML = `<span class="event-time">${time}</span><span class="event-subject">${data.subject}</span>
+                <pre style="margin-top:4px;font-size:11px;color:var(--text-muted);white-space:pre-wrap">${JSON.stringify(data.payload, null, 2).slice(0, 500)}</pre>`;
+            log.prepend(entry);
+            // Keep max 100 entries
+            while (log.children.length > 100) log.lastChild.remove();
+        }
+    };
+
+    eventWs.onerror = () => showToast('WebSocket error', 'error');
+}
+
+function stopEventStream() {
+    if (eventWs) {
+        try { eventWs.send(JSON.stringify({ type: 'deregister' })); } catch {}
+        eventWs.close();
+        eventWs = null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+(function init() {
+    if (!getApiKey()) {
+        document.getElementById('login-prompt').style.display = 'block';
+    } else {
+        showPage('overview');
+    }
+})();

--- a/crates/plugins/seidrum-api-gateway/static/index.html
+++ b/crates/plugins/seidrum-api-gateway/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Seidrum Dashboard</title>
+    <link rel="stylesheet" href="/dashboard/style.css">
+</head>
+<body>
+    <div id="app">
+        <nav id="sidebar">
+            <h1>Seidrum</h1>
+            <ul>
+                <li><a href="#" onclick="showPage('overview')">Overview</a></li>
+                <li><a href="#" onclick="showPage('plugins')">Plugins</a></li>
+                <li><a href="#" onclick="showPage('capabilities')">Capabilities</a></li>
+                <li><a href="#" onclick="showPage('storage')">Storage</a></li>
+                <li><a href="#" onclick="showPage('events')">Events</a></li>
+            </ul>
+        </nav>
+        <main id="content">
+            <div id="login-prompt" style="display:none">
+                <h2>API Key Required</h2>
+                <form onsubmit="handleLogin(event)">
+                    <input type="password" id="api-key-input" placeholder="Enter API key" autofocus>
+                    <button type="submit">Connect</button>
+                </form>
+            </div>
+            <div id="page-content"></div>
+        </main>
+    </div>
+    <script src="/dashboard/app.js"></script>
+</body>
+</html>

--- a/crates/plugins/seidrum-api-gateway/static/style.css
+++ b/crates/plugins/seidrum-api-gateway/static/style.css
@@ -1,0 +1,191 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e1e4ed;
+    --text-muted: #8b8fa3;
+    --accent: #6c7ee1;
+    --accent-hover: #8591e8;
+    --success: #4ade80;
+    --warning: #fbbf24;
+    --error: #f87171;
+    --radius: 8px;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+}
+
+#app { display: flex; min-height: 100vh; }
+
+#sidebar {
+    width: 220px;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    padding: 24px 16px;
+    flex-shrink: 0;
+}
+
+#sidebar h1 {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 24px;
+    letter-spacing: 1px;
+}
+
+#sidebar ul { list-style: none; }
+
+#sidebar li a {
+    display: block;
+    padding: 8px 12px;
+    color: var(--text-muted);
+    text-decoration: none;
+    border-radius: var(--radius);
+    font-size: 14px;
+    transition: all 0.15s;
+}
+
+#sidebar li a:hover,
+#sidebar li a.active {
+    background: var(--border);
+    color: var(--text);
+}
+
+#content {
+    flex: 1;
+    padding: 32px;
+    overflow-y: auto;
+}
+
+h2 { font-size: 22px; margin-bottom: 20px; font-weight: 600; }
+h3 { font-size: 16px; margin: 16px 0 8px; font-weight: 600; color: var(--text-muted); }
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+    margin-bottom: 16px;
+}
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; margin-bottom: 24px; }
+
+.stat {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    text-align: center;
+}
+
+.stat .value { font-size: 28px; font-weight: 700; color: var(--accent); }
+.stat .label { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; }
+
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); }
+th { font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-muted); }
+tr:hover td { background: rgba(108, 126, 225, 0.05); }
+
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.badge-healthy { background: rgba(74, 222, 128, 0.15); color: var(--success); }
+.badge-unhealthy, .badge-unreachable { background: rgba(248, 113, 113, 0.15); color: var(--error); }
+.badge-unknown { background: rgba(139, 143, 163, 0.15); color: var(--text-muted); }
+.badge-tool { background: rgba(108, 126, 225, 0.15); color: var(--accent); }
+.badge-command { background: rgba(251, 191, 36, 0.15); color: var(--warning); }
+.badge-both { background: rgba(74, 222, 128, 0.15); color: var(--success); }
+
+input, textarea, select {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 8px 12px;
+    border-radius: var(--radius);
+    font-size: 14px;
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+input:focus, textarea:focus { outline: none; border-color: var(--accent); }
+
+button {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 8px 20px;
+    border-radius: var(--radius);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+button:hover { background: var(--accent-hover); }
+
+.btn-sm { padding: 4px 12px; font-size: 12px; }
+.btn-danger { background: var(--error); }
+.btn-danger:hover { background: #ef4444; }
+
+.clickable { cursor: pointer; }
+.clickable:hover { background: rgba(108, 126, 225, 0.08); }
+
+.toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    padding: 12px 20px;
+    border-radius: var(--radius);
+    font-size: 14px;
+    z-index: 1000;
+    animation: fadeIn 0.2s;
+}
+
+.toast-success { background: var(--success); color: #000; }
+.toast-error { background: var(--error); color: #fff; }
+
+@keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+.event-log {
+    max-height: 500px;
+    overflow-y: auto;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 12px;
+}
+
+.event-entry {
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+}
+
+.event-subject { color: var(--accent); font-weight: 600; }
+.event-time { color: var(--text-muted); font-size: 11px; margin-right: 8px; }
+
+.form-group { margin-bottom: 12px; }
+.form-group label { display: block; font-size: 13px; color: var(--text-muted); margin-bottom: 4px; }
+.form-group .description { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+
+#login-prompt {
+    max-width: 360px;
+    margin: 100px auto;
+    text-align: center;
+}
+
+#login-prompt form {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+#login-prompt input { flex: 1; }

--- a/crates/plugins/seidrum-calendar/src/main.rs
+++ b/crates/plugins/seidrum-calendar/src/main.rs
@@ -362,6 +362,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.calendar.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     let register_envelope =
         EventEnvelope::new("plugin.register", "calendar", None, None, &register)?;

--- a/crates/plugins/seidrum-claude-code/src/main.rs
+++ b/crates/plugins/seidrum-claude-code/src/main.rs
@@ -102,6 +102,41 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "working_dir": {
+                    "type": "string",
+                    "description": "Default working directory for Claude Code",
+                    "default": "."
+                },
+                "allowed_tools": {
+                    "type": "string",
+                    "description": "Comma-separated list of allowed tools",
+                    "default": "Read,Edit,Bash,Glob,Grep,Write"
+                },
+                "max_turns": {
+                    "type": "integer",
+                    "description": "Maximum agentic turns",
+                    "default": 25
+                },
+                "max_budget_usd": {
+                    "type": "number",
+                    "description": "Maximum budget in USD (0 = unlimited)",
+                    "default": 1.0
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": "Subprocess timeout in seconds",
+                    "default": 300
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model to use (empty = default)",
+                    "default": ""
+                }
+            }
+        })),
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-cli/src/main.rs
+++ b/crates/plugins/seidrum-cli/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.cli.health".into(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     nats.publish_envelope("plugin.register", None, None, &registration)
         .await?;

--- a/crates/plugins/seidrum-code-executor/src/main.rs
+++ b/crates/plugins/seidrum-code-executor/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-content-ingester/src/main.rs
+++ b/crates/plugins/seidrum-content-ingester/src/main.rs
@@ -130,6 +130,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.content-ingester.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-email/src/main.rs
+++ b/crates/plugins/seidrum-email/src/main.rs
@@ -303,6 +303,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.email.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     let register_envelope = EventEnvelope::new("plugin.register", "email", None, None, &register)?;
     let register_bytes = serde_json::to_vec(&register_envelope)?;

--- a/crates/plugins/seidrum-entity-extractor/src/main.rs
+++ b/crates/plugins/seidrum-entity-extractor/src/main.rs
@@ -143,6 +143,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-event-emitter/src/main.rs
+++ b/crates/plugins/seidrum-event-emitter/src/main.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-fact-extractor/src/main.rs
+++ b/crates/plugins/seidrum-fact-extractor/src/main.rs
@@ -146,6 +146,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-graph-context-loader/src/main.rs
+++ b/crates/plugins/seidrum-graph-context-loader/src/main.rs
@@ -351,6 +351,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.graph-context-loader.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope = EventEnvelope::new(

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -130,6 +130,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.llm-google.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     let register_envelope =
         EventEnvelope::new("plugin.register", "llm-google", None, None, &register)?;

--- a/crates/plugins/seidrum-notification/src/main.rs
+++ b/crates/plugins/seidrum-notification/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-response-formatter/src/main.rs
+++ b/crates/plugins/seidrum-response-formatter/src/main.rs
@@ -146,6 +146,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.response-formatter.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     nats.publish_envelope("plugin.register", None, None, &register)
         .await?;

--- a/crates/plugins/seidrum-scope-classifier/src/main.rs
+++ b/crates/plugins/seidrum-scope-classifier/src/main.rs
@@ -138,6 +138,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{}.health", PLUGIN_ID),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-task-detector/src/main.rs
+++ b/crates/plugins/seidrum-task-detector/src/main.rs
@@ -144,6 +144,7 @@ async fn main() -> Result<()> {
         health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
 
     let register_envelope =

--- a/crates/plugins/seidrum-telegram/src/main.rs
+++ b/crates/plugins/seidrum-telegram/src/main.rs
@@ -34,19 +34,11 @@ struct Cli {
     allowed_users: String,
 
     /// Path to whisper-cli binary for voice transcription
-    #[arg(
-        long,
-        env = "WHISPER_CLI_PATH",
-        default_value = "whisper-cli"
-    )]
+    #[arg(long, env = "WHISPER_CLI_PATH", default_value = "whisper-cli")]
     whisper_cli_path: String,
 
     /// Path to whisper model file
-    #[arg(
-        long,
-        env = "WHISPER_MODEL_PATH",
-        default_value = "ggml-small.en.bin"
-    )]
+    #[arg(long, env = "WHISPER_MODEL_PATH", default_value = "ggml-small.en.bin")]
     whisper_model_path: String,
 }
 
@@ -90,6 +82,26 @@ async fn main() -> Result<()> {
         health_subject: "plugin.telegram.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "allowed_users": {
+                    "type": "string",
+                    "description": "Comma-separated list of allowed Telegram user IDs (empty = allow all)",
+                    "default": ""
+                },
+                "whisper_cli_path": {
+                    "type": "string",
+                    "description": "Path to whisper-cli binary for voice transcription",
+                    "default": "whisper-cli"
+                },
+                "whisper_model_path": {
+                    "type": "string",
+                    "description": "Path to whisper model file",
+                    "default": "ggml-small.en.bin"
+                }
+            }
+        })),
     };
     nats.publish_envelope("plugin.register", None, None, &register)
         .await?;

--- a/crates/plugins/seidrum-tool-dispatcher/src/main.rs
+++ b/crates/plugins/seidrum-tool-dispatcher/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<()> {
         health_subject: "plugin.tool-dispatcher.health".to_string(),
         consumed_event_types: vec![],
         produced_event_types: vec![],
+        config_schema: None,
     };
     nats.publish_envelope("plugin.register", None, None, &register)
         .await?;

--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -396,6 +396,19 @@ pub struct PluginRegister {
     /// Event types this plugin produces (e.g., "LlmResponse").
     #[serde(default)]
     pub produced_event_types: Vec<String>,
+    /// JSON Schema describing this plugin's configurable parameters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_schema: Option<serde_json::Value>,
+}
+
+/// Notification that a plugin's configuration was updated.
+/// Subject: `plugin.{id}.config.update` (publish)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigUpdated {
+    pub plugin_id: String,
+    pub config: serde_json::Value,
+    pub updated_by: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
 }
 
 /// Plugin announces it is shutting down.

--- a/crates/seidrum-kernel/src/registry/service.rs
+++ b/crates/seidrum-kernel/src/registry/service.rs
@@ -38,6 +38,9 @@ pub enum RegistryQuery {
     /// Get plugin IDs that produce a given event type.
     #[serde(rename = "get_producers")]
     GetProducers { event_type: String },
+    /// Get the config schema for a plugin.
+    #[serde(rename = "get_config_schema")]
+    GetConfigSchema { plugin_id: String },
 }
 
 /// Response to a registry query.
@@ -50,6 +53,8 @@ pub struct RegistryQueryResponse {
     pub plugins: Option<Vec<PluginRegister>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plugin_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_schema: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -149,6 +154,7 @@ impl RegistryService {
                     plugin,
                     plugins: None,
                     plugin_ids: None,
+                    config_schema: None,
                     error: None,
                 }
             }
@@ -159,6 +165,7 @@ impl RegistryService {
                     plugin: None,
                     plugins: Some(plugins),
                     plugin_ids: None,
+                    config_schema: None,
                     error: None,
                 }
             }
@@ -169,6 +176,7 @@ impl RegistryService {
                     plugin: None,
                     plugins: None,
                     plugin_ids: Some(ids),
+                    config_schema: None,
                     error: None,
                 }
             }
@@ -179,7 +187,24 @@ impl RegistryService {
                     plugin: None,
                     plugins: None,
                     plugin_ids: Some(ids),
+                    config_schema: None,
                     error: None,
+                }
+            }
+            RegistryQuery::GetConfigSchema { plugin_id } => {
+                let plugin = self.get_plugin(&plugin_id).await;
+                let schema = plugin.as_ref().and_then(|p| p.config_schema.clone());
+                RegistryQueryResponse {
+                    success: plugin.is_some(),
+                    plugin: None,
+                    plugins: None,
+                    plugin_ids: None,
+                    config_schema: schema,
+                    error: if plugin.is_none() {
+                        Some(format!("Plugin '{}' not found", plugin_id))
+                    } else {
+                        None
+                    },
                 }
             }
         }
@@ -288,6 +313,7 @@ impl RegistryService {
                                         plugin: None,
                                         plugins: None,
                                         plugin_ids: None,
+                                        config_schema: None,
                                         error: Some(format!("invalid query: {e}")),
                                     };
                                     if let Ok(bytes) = serde_json::to_vec(&err_resp) {
@@ -325,6 +351,7 @@ mod tests {
             health_subject: "plugin.telegram.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         };
 
         svc.register_plugin(reg.clone()).await;
@@ -354,6 +381,7 @@ mod tests {
             health_subject: "plugin.a.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -367,6 +395,7 @@ mod tests {
             health_subject: "plugin.b.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -388,6 +417,7 @@ mod tests {
             health_subject: "plugin.ingester.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -401,6 +431,7 @@ mod tests {
             health_subject: "plugin.context-loader.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -433,6 +464,7 @@ mod tests {
             health_subject: "plugin.test.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -446,6 +478,7 @@ mod tests {
             health_subject: "plugin.test.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 
@@ -472,6 +505,7 @@ mod tests {
             health_subject: "plugin.telegram.health".into(),
             consumed_event_types: vec![],
             produced_event_types: vec![],
+            config_schema: None,
         })
         .await;
 


### PR DESCRIPTION
## Summary

Adds two related features: plugin config schemas for runtime configuration, and an admin web dashboard for monitoring and managing the platform.

### Config Schema System
- `config_schema` field added to `PluginRegister` (backward-compatible `Option<Value>`)
- `ConfigUpdated` event for notifying plugins of config changes
- `GetConfigSchema` registry query
- Config validated against JSON Schema before persisting
- Config persisted via plugin storage (`namespace: "config"`)
- Plugins notified via `plugin.{id}.config.update` NATS subject

### Admin Dashboard
- Dark-themed vanilla JS SPA at `/dashboard/` (no npm, no build step)
- Pages: System Overview, Plugins, Plugin Detail + Config, Capabilities, Storage Browser, Live Events
- Dynamic config form generation from JSON Schema
- Live event stream via WebSocket
- API key auth via sessionStorage
- Static files embedded in binary via `rust-embed`

### Plugin Config Schemas
- Telegram: allowed_users, whisper_cli_path, whisper_model_path
- Claude Code: working_dir, allowed_tools, max_turns, max_budget_usd, timeout_seconds, model

## Files changed
- 27 files, +1446/-14 lines
- New: `dashboard.rs`, `static/index.html`, `static/style.css`, `static/app.js`
- Modified: all 20 plugin `main.rs` files (add `config_schema: None`)

## Test plan
- [x] All 183 tests pass
- [x] `cargo build --workspace` clean
- [ ] Start api-gateway, open `http://localhost:8080/dashboard/`
- [ ] Verify overview shows plugins with health status
- [ ] Navigate to plugin detail, verify config form renders from schema
- [ ] Save config, verify stored in plugin storage