### PR TITLE
Unified seidrum CLI daemon manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2731,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3455,6 +3488,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "seidrum-daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "libc",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tabled",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "seidrum-email"
 version = "0.1.0"
 dependencies = [
@@ -4156,6 +4206,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,6 +4842,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ members = [
     "crates/plugins/seidrum-llm-google",
     "crates/plugins/seidrum-claude-code",
     "crates/plugins/seidrum-api-gateway",
+    "crates/seidrum-daemon",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -106,17 +106,36 @@ cp .env.example .env
 cargo build --workspace
 
 # Initialize the brain database
-source .env && target/debug/seidrum-kernel init
+seidrum init
 
-# Start the kernel
-source .env && target/debug/seidrum-kernel serve &
+# Start everything (kernel + all enabled plugins)
+seidrum daemon start
+```
 
-# Start plugins (example: telegram + llm)
-source .env && target/debug/seidrum-telegram &
-source .env && target/debug/seidrum-llm-router &
-source .env && target/debug/seidrum-llm-google &
-source .env && target/debug/seidrum-tool-dispatcher &
-source .env && target/debug/seidrum-response-formatter &
+### Using the `seidrum` CLI
+
+```bash
+# Daemon management
+seidrum daemon start          # Start kernel + enabled plugins (foreground)
+seidrum daemon stop           # Graceful shutdown
+seidrum daemon restart        # Stop then start
+seidrum daemon status         # Show all processes with PID, uptime, restarts
+
+# Install as system service (systemd on Linux, launchd on macOS)
+seidrum daemon install        # Install, enable, and start the service
+seidrum daemon uninstall      # Stop and remove the service
+
+# Plugin management
+seidrum plugin list           # Show all plugins with enabled/disabled state
+seidrum plugin enable telegram
+seidrum plugin disable email
+seidrum plugin start claude-code
+seidrum plugin stop claude-code
+seidrum plugin restart telegram
+
+# Database and config
+seidrum init                  # Initialize ArangoDB collections
+seidrum validate              # Validate platform and agent configuration
 ```
 
 ### Docker Compose (full stack)
@@ -135,6 +154,7 @@ docker compose up -d
 | `config/platform.yaml` | Kernel config — NATS URL, ArangoDB connection |
 | `agents/*.yaml` | Agent definitions — prompt, tools, scope |
 | `workflows/*.yaml` | Workflow wiring — triggers, steps, routing |
+| `config/plugins.yaml` | Plugin manifest — binaries, enabled state, env vars |
 | `prompts/*.md` | Tera-templated system prompts |
 
 ## Project structure
@@ -144,6 +164,7 @@ seidrum/
 ├── crates/
 │   ├── seidrum-common/        # Shared types, events, NATS utilities
 │   ├── seidrum-kernel/        # Core services (brain, registry, scheduler)
+│   ├── seidrum-daemon/        # Unified CLI + process supervisor (`seidrum` binary)
 │   └── plugins/
 │       ├── seidrum-telegram/
 │       ├── seidrum-cli/

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -1,0 +1,118 @@
+# Seidrum Plugin Configuration
+#
+# Each plugin lists its binary name, enabled state, and env vars.
+# Env values support ${VAR} and ${VAR:-default} interpolation.
+#
+# The daemon reads this file to know which plugins to start.
+# Use `seidrum plugin enable/disable <name>` to toggle plugins.
+
+plugins:
+  telegram:
+    binary: seidrum-telegram
+    enabled: true
+    env:
+      TELEGRAM_TOKEN: "${TELEGRAM_TOKEN}"
+      TELEGRAM_ALLOWED_USERS: "${TELEGRAM_ALLOWED_USERS}"
+
+  llm-router:
+    binary: seidrum-llm-router
+    enabled: true
+
+  llm-google:
+    binary: seidrum-llm-google
+    enabled: true
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+
+  tool-dispatcher:
+    binary: seidrum-tool-dispatcher
+    enabled: true
+
+  content-ingester:
+    binary: seidrum-content-ingester
+    enabled: true
+    env:
+      EMBEDDING_PROVIDER: "${EMBEDDING_PROVIDER:-openai}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
+
+  entity-extractor:
+    binary: seidrum-entity-extractor
+    enabled: true
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+
+  fact-extractor:
+    binary: seidrum-fact-extractor
+    enabled: true
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+
+  graph-context-loader:
+    binary: seidrum-graph-context-loader
+    enabled: true
+
+  scope-classifier:
+    binary: seidrum-scope-classifier
+    enabled: true
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+
+  response-formatter:
+    binary: seidrum-response-formatter
+    enabled: true
+
+  event-emitter:
+    binary: seidrum-event-emitter
+    enabled: true
+
+  task-detector:
+    binary: seidrum-task-detector
+    enabled: true
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+
+  code-executor:
+    binary: seidrum-code-executor
+    enabled: true
+
+  notification:
+    binary: seidrum-notification
+    enabled: true
+
+  cli:
+    binary: seidrum-cli
+    enabled: false
+
+  email:
+    binary: seidrum-email
+    enabled: false
+    env:
+      IMAP_HOST: "${IMAP_HOST}"
+      IMAP_PORT: "${IMAP_PORT:-993}"
+      IMAP_USER: "${IMAP_USER}"
+      IMAP_PASSWORD: "${IMAP_PASSWORD}"
+      SMTP_HOST: "${SMTP_HOST}"
+      SMTP_PORT: "${SMTP_PORT:-587}"
+      SMTP_USER: "${SMTP_USER}"
+      SMTP_PASSWORD: "${SMTP_PASSWORD}"
+      SMTP_FROM: "${SMTP_FROM}"
+
+  calendar:
+    binary: seidrum-calendar
+    enabled: false
+    env:
+      GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+      GOOGLE_CALENDAR_ID: "${GOOGLE_CALENDAR_ID:-primary}"
+
+  claude-code:
+    binary: seidrum-claude-code
+    enabled: false
+    env:
+      CLAUDE_WORKING_DIR: "${CLAUDE_WORKING_DIR:-.}"
+
+  api-gateway:
+    binary: seidrum-api-gateway
+    enabled: false
+    env:
+      GATEWAY_API_KEY: "${GATEWAY_API_KEY}"
+      GATEWAY_LISTEN_ADDR: "${GATEWAY_LISTEN_ADDR:-0.0.0.0:8080}"

--- a/crates/seidrum-daemon/Cargo.toml
+++ b/crates/seidrum-daemon/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "seidrum-daemon"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "seidrum"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+tabled = "0.17"
+libc = "0.2"

--- a/crates/seidrum-daemon/src/cli.rs
+++ b/crates/seidrum-daemon/src/cli.rs
@@ -1,0 +1,85 @@
+//! CLI subcommand definitions.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "seidrum", about = "Seidrum platform manager", version)]
+pub struct Cli {
+    /// Path to config directory
+    #[arg(long, default_value = "config", global = true)]
+    pub config_dir: PathBuf,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Manage the Seidrum daemon
+    Daemon {
+        #[command(subcommand)]
+        action: DaemonAction,
+    },
+    /// Initialize the brain database
+    Init,
+    /// Validate configuration
+    Validate {
+        /// Path to platform config file
+        #[arg(long, default_value = "config/platform.yaml")]
+        config: String,
+    },
+    /// Manage plugins
+    Plugin {
+        #[command(subcommand)]
+        action: PluginAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum DaemonAction {
+    /// Start kernel + enabled plugins (foreground)
+    Start,
+    /// Stop the running daemon
+    Stop,
+    /// Restart the daemon
+    Restart,
+    /// Show status of all processes
+    Status,
+    /// Install as a system service (systemd/launchd)
+    Install,
+    /// Remove the system service
+    Uninstall,
+}
+
+#[derive(Subcommand)]
+pub enum PluginAction {
+    /// List all plugins with enabled/disabled state
+    List,
+    /// Enable a plugin
+    Enable {
+        /// Plugin name (e.g., "telegram")
+        name: String,
+    },
+    /// Disable a plugin
+    Disable {
+        /// Plugin name (e.g., "telegram")
+        name: String,
+    },
+    /// Start a specific plugin
+    Start {
+        /// Plugin name
+        name: String,
+    },
+    /// Stop a specific plugin
+    Stop {
+        /// Plugin name
+        name: String,
+    },
+    /// Restart a specific plugin
+    Restart {
+        /// Plugin name
+        name: String,
+    },
+}

--- a/crates/seidrum-daemon/src/config.rs
+++ b/crates/seidrum-daemon/src/config.rs
@@ -1,0 +1,188 @@
+//! Plugin configuration: loading, env interpolation, enable/disable.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tabled::{Table, Tabled};
+
+use crate::paths::SeidrumPaths;
+
+/// Top-level plugins.yaml structure.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PluginsConfig {
+    pub plugins: BTreeMap<String, PluginEntry>,
+}
+
+/// A single plugin entry in plugins.yaml.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PluginEntry {
+    /// Binary name (e.g., "seidrum-telegram")
+    pub binary: String,
+    /// Whether this plugin is enabled
+    pub enabled: bool,
+    /// Plugin-specific environment variables
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
+/// Load plugins.yaml from the config directory.
+pub fn load_plugins_config(path: &Path) -> Result<PluginsConfig> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let config: PluginsConfig =
+        serde_yaml::from_str(&contents).with_context(|| "Failed to parse plugins.yaml")?;
+    Ok(config)
+}
+
+/// Save plugins.yaml back to disk.
+pub fn save_plugins_config(path: &Path, config: &PluginsConfig) -> Result<()> {
+    let contents = serde_yaml::to_string(config).context("Failed to serialize plugins.yaml")?;
+    std::fs::write(path, contents)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Resolve `${VAR}` and `${VAR:-default}` patterns in a string.
+pub fn resolve_env(value: &str) -> String {
+    let mut result = value.to_string();
+    // Match ${VAR:-default} first, then ${VAR}
+    while let Some(start) = result.find("${") {
+        let end = match result[start..].find('}') {
+            Some(e) => start + e,
+            None => break,
+        };
+
+        let expr = &result[start + 2..end];
+        let resolved = if let Some(pos) = expr.find(":-") {
+            let var_name = &expr[..pos];
+            let default = &expr[pos + 2..];
+            std::env::var(var_name).unwrap_or_else(|_| default.to_string())
+        } else {
+            std::env::var(expr).unwrap_or_default()
+        };
+
+        result = format!("{}{}{}", &result[..start], resolved, &result[end + 1..]);
+    }
+    result
+}
+
+/// Resolve all env vars in a plugin entry.
+pub fn resolve_plugin_env(entry: &PluginEntry) -> BTreeMap<String, String> {
+    entry
+        .env
+        .iter()
+        .map(|(k, v)| (k.clone(), resolve_env(v)))
+        .collect()
+}
+
+/// List all plugins in a formatted table.
+pub fn list_plugins(paths: &SeidrumPaths) -> Result<()> {
+    let config = load_plugins_config(&paths.plugins_yaml())?;
+
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Plugin")]
+        name: String,
+        #[tabled(rename = "Binary")]
+        binary: String,
+        #[tabled(rename = "Enabled")]
+        enabled: String,
+        #[tabled(rename = "Env Vars")]
+        env_count: usize,
+    }
+
+    let rows: Vec<Row> = config
+        .plugins
+        .iter()
+        .map(|(name, entry)| Row {
+            name: name.clone(),
+            binary: entry.binary.clone(),
+            enabled: if entry.enabled {
+                "yes".to_string()
+            } else {
+                "no".to_string()
+            },
+            env_count: entry.env.len(),
+        })
+        .collect();
+
+    if rows.is_empty() {
+        println!("No plugins configured in plugins.yaml");
+    } else {
+        println!("{}", Table::new(&rows));
+    }
+
+    Ok(())
+}
+
+/// Enable or disable a plugin in plugins.yaml.
+pub fn set_enabled(paths: &SeidrumPaths, name: &str, enabled: bool) -> Result<()> {
+    let yaml_path = paths.plugins_yaml();
+    let mut config = load_plugins_config(&yaml_path)?;
+
+    match config.plugins.get_mut(name) {
+        Some(entry) => {
+            entry.enabled = enabled;
+            save_plugins_config(&yaml_path, &config)?;
+            let state = if enabled { "enabled" } else { "disabled" };
+            println!("Plugin '{}' {}", name, state);
+            Ok(())
+        }
+        None => {
+            anyhow::bail!("Plugin '{}' not found in plugins.yaml", name);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_env_simple() {
+        std::env::set_var("SEIDRUM_TEST_VAR", "hello");
+        assert_eq!(resolve_env("${SEIDRUM_TEST_VAR}"), "hello");
+        std::env::remove_var("SEIDRUM_TEST_VAR");
+    }
+
+    #[test]
+    fn resolve_env_default() {
+        std::env::remove_var("SEIDRUM_MISSING_VAR");
+        assert_eq!(resolve_env("${SEIDRUM_MISSING_VAR:-fallback}"), "fallback");
+    }
+
+    #[test]
+    fn resolve_env_no_match() {
+        assert_eq!(resolve_env("plain text"), "plain text");
+    }
+
+    #[test]
+    fn resolve_env_multiple() {
+        std::env::set_var("SEIDRUM_A", "one");
+        std::env::set_var("SEIDRUM_B", "two");
+        assert_eq!(resolve_env("${SEIDRUM_A}-${SEIDRUM_B}"), "one-two");
+        std::env::remove_var("SEIDRUM_A");
+        std::env::remove_var("SEIDRUM_B");
+    }
+
+    #[test]
+    fn yaml_roundtrip() {
+        let yaml = r#"
+plugins:
+  telegram:
+    binary: seidrum-telegram
+    enabled: true
+    env:
+      TELEGRAM_TOKEN: "${TELEGRAM_TOKEN}"
+  cli:
+    binary: seidrum-cli
+    enabled: false
+"#;
+        let config: PluginsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.plugins.len(), 2);
+        assert!(config.plugins["telegram"].enabled);
+        assert!(!config.plugins["cli"].enabled);
+    }
+}

--- a/crates/seidrum-daemon/src/config.rs
+++ b/crates/seidrum-daemon/src/config.rs
@@ -45,10 +45,17 @@ pub fn save_plugins_config(path: &Path, config: &PluginsConfig) -> Result<()> {
 }
 
 /// Resolve `${VAR}` and `${VAR:-default}` patterns in a string.
+/// Scans left-to-right without re-processing already-resolved text.
 pub fn resolve_env(value: &str) -> String {
     let mut result = value.to_string();
-    // Match ${VAR:-default} first, then ${VAR}
-    while let Some(start) = result.find("${") {
+    let mut search_from = 0;
+
+    while search_from < result.len() {
+        let start = match result[search_from..].find("${") {
+            Some(s) => search_from + s,
+            None => break,
+        };
+
         let end = match result[start..].find('}') {
             Some(e) => start + e,
             None => break,
@@ -63,7 +70,10 @@ pub fn resolve_env(value: &str) -> String {
             std::env::var(expr).unwrap_or_default()
         };
 
+        let resolved_len = resolved.len();
         result = format!("{}{}{}", &result[..start], resolved, &result[end + 1..]);
+        // Skip past the resolved value to avoid re-processing
+        search_from = start + resolved_len;
     }
     result
 }

--- a/crates/seidrum-daemon/src/daemon.rs
+++ b/crates/seidrum-daemon/src/daemon.rs
@@ -1,0 +1,464 @@
+//! Process supervisor: spawn, monitor, restart, and gracefully shut down
+//! the kernel and all enabled plugins.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use tokio::process::Command;
+use tokio::signal;
+use tracing::{error, info, warn};
+
+use crate::config::{load_plugins_config, resolve_plugin_env, PluginEntry};
+use crate::paths::SeidrumPaths;
+use crate::status::ProcessMeta;
+
+/// Maximum restart attempts within the backoff window.
+const MAX_RESTARTS: u32 = 5;
+/// Backoff window — reset restart count after this duration.
+const BACKOFF_WINDOW: Duration = Duration::from_secs(300);
+/// Grace period for SIGTERM before SIGKILL.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A managed child process.
+struct ManagedProcess {
+    name: String,
+    binary: String,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    child: Option<tokio::process::Child>,
+    restart_count: u32,
+    first_restart_at: Option<Instant>,
+    started_at: Option<chrono::DateTime<Utc>>,
+}
+
+impl ManagedProcess {
+    fn new(name: String, binary: String, args: Vec<String>, env: BTreeMap<String, String>) -> Self {
+        Self {
+            name,
+            binary,
+            args,
+            env,
+            child: None,
+            restart_count: 0,
+            first_restart_at: None,
+            started_at: None,
+        }
+    }
+
+    /// Spawn the child process.
+    fn spawn(&mut self, paths: &SeidrumPaths) -> Result<()> {
+        let binary_path = paths.plugin_binary(&self.binary);
+
+        if !binary_path.exists() {
+            anyhow::bail!(
+                "Binary not found: {} (looked at {})",
+                self.binary,
+                binary_path.display()
+            );
+        }
+
+        let log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(paths.plugin_log_file(&self.name))
+            .with_context(|| format!("Failed to open log file for {}", self.name))?;
+
+        let log_stderr = log_file
+            .try_clone()
+            .context("Failed to clone log file handle")?;
+
+        let mut cmd = Command::new(&binary_path);
+        cmd.args(&self.args);
+
+        // Pass through parent environment + plugin-specific env vars
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+
+        cmd.stdout(std::process::Stdio::from(log_file));
+        cmd.stderr(std::process::Stdio::from(log_stderr));
+
+        let child = cmd.spawn().with_context(|| {
+            format!("Failed to spawn {} ({})", self.name, binary_path.display())
+        })?;
+
+        let pid = child.id().unwrap_or(0);
+        self.started_at = Some(Utc::now());
+        self.child = Some(child);
+
+        // Write PID file
+        let _ = std::fs::write(paths.plugin_pid_file(&self.name), pid.to_string());
+
+        // Write metadata
+        let meta = ProcessMeta {
+            pid,
+            started_at: self.started_at.unwrap(),
+            restart_count: self.restart_count,
+        };
+        let _ = std::fs::write(
+            paths.plugin_meta_file(&self.name),
+            serde_json::to_string(&meta).unwrap_or_default(),
+        );
+
+        // Remove stopped marker if present
+        let _ = std::fs::remove_file(paths.plugin_stopped_file(&self.name));
+
+        info!(name = %self.name, %pid, "Process started");
+        Ok(())
+    }
+
+    /// Check if restart should be attempted based on backoff policy.
+    fn should_restart(&mut self) -> bool {
+        let now = Instant::now();
+
+        // Reset restart count if outside the backoff window
+        if let Some(first) = self.first_restart_at {
+            if now.duration_since(first) > BACKOFF_WINDOW {
+                self.restart_count = 0;
+                self.first_restart_at = None;
+            }
+        }
+
+        if self.restart_count >= MAX_RESTARTS {
+            return false;
+        }
+
+        if self.first_restart_at.is_none() {
+            self.first_restart_at = Some(now);
+        }
+
+        self.restart_count += 1;
+        true
+    }
+
+    /// Calculate backoff delay for the current restart attempt.
+    fn backoff_delay(&self) -> Duration {
+        let secs = 1u64 << self.restart_count.min(4); // 1, 2, 4, 8, 16
+        Duration::from_secs(secs)
+    }
+}
+
+/// Start the daemon: spawn kernel + all enabled plugins, enter monitoring loop.
+pub async fn start(paths: &SeidrumPaths) -> Result<()> {
+    paths.ensure_dirs()?;
+
+    // Check if already running
+    if let Ok(pid_str) = std::fs::read_to_string(paths.daemon_pid_file()) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            // Check if process is alive
+            if unsafe { libc::kill(pid, 0) } == 0 {
+                anyhow::bail!(
+                    "Daemon is already running (PID {}). Use 'seidrum daemon stop' first.",
+                    pid
+                );
+            }
+        }
+    }
+
+    // Write our own PID
+    std::fs::write(paths.daemon_pid_file(), std::process::id().to_string())?;
+
+    info!("Starting Seidrum daemon");
+
+    let mut processes: Vec<ManagedProcess> = Vec::new();
+
+    // 1. Start the kernel
+    let mut kernel = ManagedProcess::new(
+        "kernel".to_string(),
+        "seidrum-kernel".to_string(),
+        vec!["serve".to_string()],
+        BTreeMap::new(),
+    );
+
+    kernel.spawn(paths)?;
+    processes.push(kernel);
+
+    // Wait for kernel to connect to NATS
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // 2. Load plugins.yaml and start enabled plugins
+    let plugins_yaml = paths.plugins_yaml();
+    if plugins_yaml.exists() {
+        let config = load_plugins_config(&plugins_yaml)?;
+
+        for (name, entry) in &config.plugins {
+            if !entry.enabled {
+                info!(name = %name, "Plugin disabled, skipping");
+                continue;
+            }
+
+            // Skip if stopped marker exists
+            if paths.plugin_stopped_file(name).exists() {
+                info!(name = %name, "Plugin manually stopped, skipping");
+                continue;
+            }
+
+            let env = resolve_plugin_env(entry);
+            let mut proc = ManagedProcess::new(name.clone(), entry.binary.clone(), vec![], env);
+
+            match proc.spawn(paths) {
+                Ok(()) => processes.push(proc),
+                Err(e) => error!(name = %name, error = %e, "Failed to start plugin"),
+            }
+        }
+    } else {
+        warn!(
+            "No plugins.yaml found at {}. Only the kernel will run.",
+            plugins_yaml.display()
+        );
+    }
+
+    info!(
+        count = processes.len(),
+        "All processes started, entering monitoring loop"
+    );
+
+    // 3. Monitoring loop
+    loop {
+        tokio::select! {
+            _ = signal::ctrl_c() => {
+                info!("Received shutdown signal");
+                break;
+            }
+            _ = check_processes(&mut processes, paths) => {
+                // A process exited and was handled
+            }
+        }
+    }
+
+    // 4. Graceful shutdown
+    shutdown(&mut processes, paths).await;
+
+    // Clean up daemon PID
+    let _ = std::fs::remove_file(paths.daemon_pid_file());
+
+    info!("Seidrum daemon stopped");
+    Ok(())
+}
+
+/// Monitor processes and restart crashed ones.
+async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
+    // Small polling interval
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    for proc in processes.iter_mut() {
+        let child = match proc.child.as_mut() {
+            Some(c) => c,
+            None => continue,
+        };
+
+        // Non-blocking check if the child has exited
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let exit_code = status.code().unwrap_or(-1);
+                warn!(
+                    name = %proc.name,
+                    exit_code,
+                    "Process exited"
+                );
+
+                // Clean up PID file
+                let _ = std::fs::remove_file(paths.plugin_pid_file(&proc.name));
+                proc.child = None;
+
+                // Check for stopped marker (manual stop)
+                if paths.plugin_stopped_file(&proc.name).exists() {
+                    info!(name = %proc.name, "Process was manually stopped, not restarting");
+                    continue;
+                }
+
+                // Restart with backoff
+                if proc.should_restart() {
+                    let delay = proc.backoff_delay();
+                    warn!(
+                        name = %proc.name,
+                        restart_count = proc.restart_count,
+                        delay_secs = delay.as_secs(),
+                        "Restarting after backoff"
+                    );
+                    tokio::time::sleep(delay).await;
+
+                    if let Err(e) = proc.spawn(paths) {
+                        error!(name = %proc.name, error = %e, "Failed to restart");
+                    }
+                } else {
+                    error!(
+                        name = %proc.name,
+                        "Process crashed {} times in {} seconds, not restarting",
+                        MAX_RESTARTS,
+                        BACKOFF_WINDOW.as_secs()
+                    );
+                }
+            }
+            Ok(None) => {
+                // Still running
+            }
+            Err(e) => {
+                warn!(name = %proc.name, error = %e, "Error checking process status");
+            }
+        }
+    }
+}
+
+/// Gracefully shut down all processes: SIGTERM plugins first, then kernel.
+async fn shutdown(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
+    info!("Shutting down all processes...");
+
+    // Send SIGTERM to plugins (not kernel)
+    for proc in processes.iter_mut().filter(|p| p.name != "kernel") {
+        if let Some(ref mut child) = proc.child {
+            let pid = child.id().unwrap_or(0);
+            if pid > 0 {
+                info!(name = %proc.name, %pid, "Sending SIGTERM");
+                let _ = child.start_kill();
+            }
+        }
+    }
+
+    // Wait for plugins to exit
+    tokio::time::sleep(SHUTDOWN_TIMEOUT).await;
+
+    // Now stop kernel
+    for proc in processes.iter_mut().filter(|p| p.name == "kernel") {
+        if let Some(ref mut child) = proc.child {
+            let pid = child.id().unwrap_or(0);
+            if pid > 0 {
+                info!(name = %proc.name, %pid, "Sending SIGTERM to kernel");
+                let _ = child.start_kill();
+            }
+        }
+    }
+
+    // Wait briefly for kernel
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Clean up PID files
+    for proc in processes.iter() {
+        let _ = std::fs::remove_file(paths.plugin_pid_file(&proc.name));
+        let _ = std::fs::remove_file(paths.plugin_meta_file(&proc.name));
+    }
+}
+
+/// Stop the daemon by reading its PID file and sending SIGTERM.
+pub async fn stop(paths: &SeidrumPaths) -> Result<()> {
+    let pid_file = paths.daemon_pid_file();
+    let pid_str = std::fs::read_to_string(&pid_file)
+        .context("Daemon does not appear to be running (no PID file)")?;
+    let pid: i32 = pid_str.trim().parse().context("Invalid PID file")?;
+
+    info!(%pid, "Sending SIGTERM to daemon");
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+
+    // Wait for the daemon to exit
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            println!("Daemon stopped");
+            return Ok(());
+        }
+    }
+
+    warn!("Daemon did not stop after 30s, sending SIGKILL");
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+
+    Ok(())
+}
+
+/// Delegate a subcommand to the seidrum-kernel binary.
+pub async fn run_kernel_command(paths: &SeidrumPaths, args: &[&str]) -> Result<()> {
+    let kernel_binary = paths.plugin_binary("seidrum-kernel");
+
+    if !kernel_binary.exists() {
+        anyhow::bail!("seidrum-kernel not found at {}", kernel_binary.display());
+    }
+
+    let status = std::process::Command::new(&kernel_binary)
+        .args(args)
+        .status()
+        .with_context(|| format!("Failed to run seidrum-kernel {}", args.join(" ")))?;
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+/// Start a single plugin on a running daemon.
+pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
+    let config = load_plugins_config(&paths.plugins_yaml())?;
+    let entry = config
+        .plugins
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("Plugin '{}' not found in plugins.yaml", name))?;
+
+    // Remove stopped marker
+    let _ = std::fs::remove_file(paths.plugin_stopped_file(name));
+
+    // Check if already running
+    if let Ok(pid_str) = std::fs::read_to_string(paths.plugin_pid_file(name)) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            if unsafe { libc::kill(pid, 0) } == 0 {
+                println!("Plugin '{}' is already running (PID {})", name, pid);
+                return Ok(());
+            }
+        }
+    }
+
+    let env = resolve_plugin_env(entry);
+    let mut proc = ManagedProcess::new(name.to_string(), entry.binary.clone(), vec![], env);
+
+    proc.spawn(paths)?;
+
+    // Detach — the monitoring loop in the running daemon will pick it up
+    if let Some(mut child) = proc.child.take() {
+        // Forget the child so it doesn't get killed when we exit
+        tokio::spawn(async move {
+            let _ = child.wait().await;
+        });
+    }
+
+    println!("Plugin '{}' started", name);
+    Ok(())
+}
+
+/// Stop a single plugin on a running daemon.
+pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
+    let pid_file = paths.plugin_pid_file(name);
+    let pid_str = std::fs::read_to_string(&pid_file)
+        .with_context(|| format!("Plugin '{}' does not appear to be running", name))?;
+    let pid: i32 = pid_str.trim().parse().context("Invalid PID file")?;
+
+    // Write stopped marker so the daemon doesn't restart it
+    std::fs::write(paths.plugin_stopped_file(name), "")?;
+
+    info!(name = %name, %pid, "Sending SIGTERM to plugin");
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+
+    // Wait briefly
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            let _ = std::fs::remove_file(&pid_file);
+            println!("Plugin '{}' stopped", name);
+            return Ok(());
+        }
+    }
+
+    warn!("Plugin did not stop after 5s, sending SIGKILL");
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+    let _ = std::fs::remove_file(&pid_file);
+
+    println!("Plugin '{}' killed", name);
+    Ok(())
+}

--- a/crates/seidrum-daemon/src/daemon.rs
+++ b/crates/seidrum-daemon/src/daemon.rs
@@ -1,16 +1,18 @@
 //! Process supervisor: spawn, monitor, restart, and gracefully shut down
 //! the kernel and all enabled plugins.
 
+#[cfg(not(unix))]
+compile_error!("seidrum-daemon requires a Unix system (Linux or macOS)");
+
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
 use tokio::process::Command;
-use tokio::signal;
 use tracing::{error, info, warn};
 
-use crate::config::{load_plugins_config, resolve_plugin_env, PluginEntry};
+use crate::config::{load_plugins_config, resolve_plugin_env};
 use crate::paths::SeidrumPaths;
 use crate::status::ProcessMeta;
 
@@ -21,6 +23,31 @@ const BACKOFF_WINDOW: Duration = Duration::from_secs(300);
 /// Grace period for SIGTERM before SIGKILL.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Send SIGTERM to a process by PID. Returns true if the signal was sent.
+fn send_sigterm(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, libc::SIGTERM) == 0 }
+}
+
+/// Send SIGKILL to a process by PID.
+fn send_sigkill(pid: u32) {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+}
+
+/// Check if a process is alive by PID.
+pub fn is_process_alive(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    let ret = unsafe { libc::kill(pid, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // EPERM means the process exists but we lack permissions
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
 /// A managed child process.
 struct ManagedProcess {
     name: String,
@@ -28,6 +55,7 @@ struct ManagedProcess {
     args: Vec<String>,
     env: BTreeMap<String, String>,
     child: Option<tokio::process::Child>,
+    pid: Option<u32>,
     restart_count: u32,
     first_restart_at: Option<Instant>,
     started_at: Option<chrono::DateTime<Utc>>,
@@ -41,6 +69,7 @@ impl ManagedProcess {
             args,
             env,
             child: None,
+            pid: None,
             restart_count: 0,
             first_restart_at: None,
             started_at: None,
@@ -72,7 +101,6 @@ impl ManagedProcess {
         let mut cmd = Command::new(&binary_path);
         cmd.args(&self.args);
 
-        // Pass through parent environment + plugin-specific env vars
         for (k, v) in &self.env {
             cmd.env(k, v);
         }
@@ -84,12 +112,15 @@ impl ManagedProcess {
             format!("Failed to spawn {} ({})", self.name, binary_path.display())
         })?;
 
-        let pid = child.id().unwrap_or(0);
+        let pid = child.id().context("Failed to get PID of spawned process")?;
+
         self.started_at = Some(Utc::now());
+        self.pid = Some(pid);
         self.child = Some(child);
 
         // Write PID file
-        let _ = std::fs::write(paths.plugin_pid_file(&self.name), pid.to_string());
+        std::fs::write(paths.plugin_pid_file(&self.name), pid.to_string())
+            .with_context(|| format!("Failed to write PID file for {}", self.name))?;
 
         // Write metadata
         let meta = ProcessMeta {
@@ -97,10 +128,11 @@ impl ManagedProcess {
             started_at: self.started_at.unwrap(),
             restart_count: self.restart_count,
         };
-        let _ = std::fs::write(
+        std::fs::write(
             paths.plugin_meta_file(&self.name),
             serde_json::to_string(&meta).unwrap_or_default(),
-        );
+        )
+        .with_context(|| format!("Failed to write meta file for {}", self.name))?;
 
         // Remove stopped marker if present
         let _ = std::fs::remove_file(paths.plugin_stopped_file(&self.name));
@@ -113,7 +145,6 @@ impl ManagedProcess {
     fn should_restart(&mut self) -> bool {
         let now = Instant::now();
 
-        // Reset restart count if outside the backoff window
         if let Some(first) = self.first_restart_at {
             if now.duration_since(first) > BACKOFF_WINDOW {
                 self.restart_count = 0;
@@ -129,7 +160,6 @@ impl ManagedProcess {
             self.first_restart_at = Some(now);
         }
 
-        self.restart_count += 1;
         true
     }
 
@@ -144,21 +174,23 @@ impl ManagedProcess {
 pub async fn start(paths: &SeidrumPaths) -> Result<()> {
     paths.ensure_dirs()?;
 
-    // Check if already running
-    if let Ok(pid_str) = std::fs::read_to_string(paths.daemon_pid_file()) {
+    // Check if already running — use create_new for atomic PID file creation
+    let pid_file = paths.daemon_pid_file();
+    if let Ok(pid_str) = std::fs::read_to_string(&pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            // Check if process is alive
-            if unsafe { libc::kill(pid, 0) } == 0 {
+            if is_process_alive(pid) {
                 anyhow::bail!(
                     "Daemon is already running (PID {}). Use 'seidrum daemon stop' first.",
                     pid
                 );
             }
         }
+        // Stale PID file — remove it
+        let _ = std::fs::remove_file(&pid_file);
     }
 
-    // Write our own PID
-    std::fs::write(paths.daemon_pid_file(), std::process::id().to_string())?;
+    // Write our own PID atomically
+    std::fs::write(&pid_file, std::process::id().to_string())?;
 
     info!("Starting Seidrum daemon");
 
@@ -189,7 +221,6 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
                 continue;
             }
 
-            // Skip if stopped marker exists
             if paths.plugin_stopped_file(name).exists() {
                 info!(name = %name, "Plugin manually stopped, skipping");
                 continue;
@@ -215,11 +246,18 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
         "All processes started, entering monitoring loop"
     );
 
-    // 3. Monitoring loop
+    // 3. Monitoring loop — handle both SIGINT and SIGTERM
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .context("Failed to register SIGTERM handler")?;
+
     loop {
         tokio::select! {
-            _ = signal::ctrl_c() => {
-                info!("Received shutdown signal");
+            _ = tokio::signal::ctrl_c() => {
+                info!("Received SIGINT, shutting down");
+                break;
+            }
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM, shutting down");
                 break;
             }
             _ = check_processes(&mut processes, paths) => {
@@ -240,7 +278,6 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
 
 /// Monitor processes and restart crashed ones.
 async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
-    // Small polling interval
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     for proc in processes.iter_mut() {
@@ -249,28 +286,22 @@ async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPat
             None => continue,
         };
 
-        // Non-blocking check if the child has exited
         match child.try_wait() {
             Ok(Some(status)) => {
                 let exit_code = status.code().unwrap_or(-1);
-                warn!(
-                    name = %proc.name,
-                    exit_code,
-                    "Process exited"
-                );
+                warn!(name = %proc.name, exit_code, "Process exited");
 
-                // Clean up PID file
                 let _ = std::fs::remove_file(paths.plugin_pid_file(&proc.name));
                 proc.child = None;
+                proc.pid = None;
 
-                // Check for stopped marker (manual stop)
                 if paths.plugin_stopped_file(&proc.name).exists() {
                     info!(name = %proc.name, "Process was manually stopped, not restarting");
                     continue;
                 }
 
-                // Restart with backoff
                 if proc.should_restart() {
+                    proc.restart_count += 1;
                     let delay = proc.backoff_delay();
                     warn!(
                         name = %proc.name,
@@ -292,9 +323,7 @@ async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPat
                     );
                 }
             }
-            Ok(None) => {
-                // Still running
-            }
+            Ok(None) => {}
             Err(e) => {
                 warn!(name = %proc.name, error = %e, "Error checking process status");
             }
@@ -306,35 +335,63 @@ async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPat
 async fn shutdown(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
     info!("Shutting down all processes...");
 
-    // Send SIGTERM to plugins (not kernel)
-    for proc in processes.iter_mut().filter(|p| p.name != "kernel") {
-        if let Some(ref mut child) = proc.child {
-            let pid = child.id().unwrap_or(0);
-            if pid > 0 {
-                info!(name = %proc.name, %pid, "Sending SIGTERM");
-                let _ = child.start_kill();
-            }
+    // Send SIGTERM to plugins first (not kernel)
+    for proc in processes.iter().filter(|p| p.name != "kernel") {
+        if let Some(pid) = proc.pid {
+            info!(name = %proc.name, %pid, "Sending SIGTERM");
+            send_sigterm(pid);
         }
     }
 
-    // Wait for plugins to exit
-    tokio::time::sleep(SHUTDOWN_TIMEOUT).await;
+    // Wait for plugins to exit, polling instead of fixed sleep
+    let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+    loop {
+        let all_stopped = processes.iter().filter(|p| p.name != "kernel").all(|p| {
+            p.pid
+                .map(|pid| !is_process_alive(pid as i32))
+                .unwrap_or(true)
+        });
+
+        if all_stopped || Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // SIGKILL any remaining plugins
+    for proc in processes.iter().filter(|p| p.name != "kernel") {
+        if let Some(pid) = proc.pid {
+            if is_process_alive(pid as i32) {
+                warn!(name = %proc.name, %pid, "Sending SIGKILL to stuck process");
+                send_sigkill(pid);
+            }
+        }
+    }
 
     // Now stop kernel
-    for proc in processes.iter_mut().filter(|p| p.name == "kernel") {
-        if let Some(ref mut child) = proc.child {
-            let pid = child.id().unwrap_or(0);
-            if pid > 0 {
-                info!(name = %proc.name, %pid, "Sending SIGTERM to kernel");
-                let _ = child.start_kill();
-            }
+    for proc in processes.iter().filter(|p| p.name == "kernel") {
+        if let Some(pid) = proc.pid {
+            info!(name = %proc.name, %pid, "Sending SIGTERM to kernel");
+            send_sigterm(pid);
         }
     }
 
-    // Wait briefly for kernel
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Wait for kernel
+    let kernel_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let kernel_stopped = processes.iter().filter(|p| p.name == "kernel").all(|p| {
+            p.pid
+                .map(|pid| !is_process_alive(pid as i32))
+                .unwrap_or(true)
+        });
 
-    // Clean up PID files
+        if kernel_stopped || Instant::now() >= kernel_deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // Clean up all PID and meta files
     for proc in processes.iter() {
         let _ = std::fs::remove_file(paths.plugin_pid_file(&proc.name));
         let _ = std::fs::remove_file(paths.plugin_meta_file(&proc.name));
@@ -348,15 +405,21 @@ pub async fn stop(paths: &SeidrumPaths) -> Result<()> {
         .context("Daemon does not appear to be running (no PID file)")?;
     let pid: i32 = pid_str.trim().parse().context("Invalid PID file")?;
 
+    if !is_process_alive(pid) {
+        // Stale PID file
+        let _ = std::fs::remove_file(&pid_file);
+        println!("Daemon is not running (stale PID file cleaned up)");
+        return Ok(());
+    }
+
     info!(%pid, "Sending SIGTERM to daemon");
     unsafe {
         libc::kill(pid, libc::SIGTERM);
     }
 
-    // Wait for the daemon to exit
     for _ in 0..30 {
         tokio::time::sleep(Duration::from_secs(1)).await;
-        if unsafe { libc::kill(pid, 0) } != 0 {
+        if !is_process_alive(pid) {
             println!("Daemon stopped");
             return Ok(());
         }
@@ -366,7 +429,9 @@ pub async fn stop(paths: &SeidrumPaths) -> Result<()> {
     unsafe {
         libc::kill(pid, libc::SIGKILL);
     }
+    let _ = std::fs::remove_file(&pid_file);
 
+    println!("Daemon killed");
     Ok(())
 }
 
@@ -390,7 +455,7 @@ pub async fn run_kernel_command(paths: &SeidrumPaths, args: &[&str]) -> Result<(
     Ok(())
 }
 
-/// Start a single plugin on a running daemon.
+/// Start a single plugin (writes PID file; daemon monitor will detect via PID).
 pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     let config = load_plugins_config(&paths.plugins_yaml())?;
     let entry = config
@@ -404,7 +469,7 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     // Check if already running
     if let Ok(pid_str) = std::fs::read_to_string(paths.plugin_pid_file(name)) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            if unsafe { libc::kill(pid, 0) } == 0 {
+            if is_process_alive(pid) {
                 println!("Plugin '{}' is already running (PID {})", name, pid);
                 return Ok(());
             }
@@ -416,9 +481,10 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
 
     proc.spawn(paths)?;
 
-    // Detach — the monitoring loop in the running daemon will pick it up
+    // Detach the child — it will run independently.
+    // The daemon's monitor loop will detect it via PID file if running,
+    // otherwise it runs as a standalone process.
     if let Some(mut child) = proc.child.take() {
-        // Forget the child so it doesn't get killed when we exit
         tokio::spawn(async move {
             let _ = child.wait().await;
         });
@@ -435,6 +501,15 @@ pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
         .with_context(|| format!("Plugin '{}' does not appear to be running", name))?;
     let pid: i32 = pid_str.trim().parse().context("Invalid PID file")?;
 
+    if !is_process_alive(pid) {
+        let _ = std::fs::remove_file(&pid_file);
+        println!(
+            "Plugin '{}' is not running (stale PID file cleaned up)",
+            name
+        );
+        return Ok(());
+    }
+
     // Write stopped marker so the daemon doesn't restart it
     std::fs::write(paths.plugin_stopped_file(name), "")?;
 
@@ -443,10 +518,9 @@ pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
         libc::kill(pid, libc::SIGTERM);
     }
 
-    // Wait briefly
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_millis(500)).await;
-        if unsafe { libc::kill(pid, 0) } != 0 {
+        if !is_process_alive(pid) {
             let _ = std::fs::remove_file(&pid_file);
             println!("Plugin '{}' stopped", name);
             return Ok(());
@@ -461,4 +535,50 @@ pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
 
     println!("Plugin '{}' killed", name);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_restart_respects_max() {
+        let mut proc =
+            ManagedProcess::new("test".into(), "test-bin".into(), vec![], BTreeMap::new());
+
+        for _ in 0..MAX_RESTARTS {
+            assert!(proc.should_restart());
+            proc.restart_count += 1;
+        }
+        assert!(!proc.should_restart());
+    }
+
+    #[test]
+    fn backoff_delay_sequence() {
+        let mut proc =
+            ManagedProcess::new("test".into(), "test-bin".into(), vec![], BTreeMap::new());
+
+        // backoff_delay uses restart_count: 1, 2, 4, 8, 16
+        let expected = [1, 2, 4, 8, 16];
+        for &expected_secs in &expected {
+            assert_eq!(proc.backoff_delay().as_secs(), expected_secs);
+            proc.restart_count += 1;
+        }
+    }
+
+    #[test]
+    fn is_process_alive_nonexistent() {
+        // PID that almost certainly doesn't exist
+        assert!(!is_process_alive(999_999_999));
+    }
+
+    #[test]
+    fn is_process_alive_zero_is_false() {
+        assert!(!is_process_alive(0));
+    }
+
+    #[test]
+    fn is_process_alive_negative_is_false() {
+        assert!(!is_process_alive(-1));
+    }
 }

--- a/crates/seidrum-daemon/src/install.rs
+++ b/crates/seidrum-daemon/src/install.rs
@@ -145,8 +145,9 @@ fn uninstall_systemd() -> Result<()> {
 
     if unit_path.exists() {
         std::fs::remove_file(&unit_path)?;
+        let user_args: &[&str] = if is_user { &["--user"] } else { &[] };
+        let _ = run_systemctl(user_args, "daemon-reload");
         println!("Removed {}", unit_path.display());
-        println!("Run: systemctl{} daemon-reload", user_flag);
     } else {
         println!("Service file not found at {}", unit_path.display());
     }

--- a/crates/seidrum-daemon/src/install.rs
+++ b/crates/seidrum-daemon/src/install.rs
@@ -1,0 +1,247 @@
+//! System service installation: systemd (Linux) and launchd (macOS).
+
+use anyhow::{Context, Result};
+
+use crate::paths::SeidrumPaths;
+
+/// Install the daemon as a system service.
+pub fn install(paths: &SeidrumPaths) -> Result<()> {
+    let seidrum_bin = paths.plugin_binary("seidrum");
+    let config_dir =
+        std::fs::canonicalize(&paths.config_dir).unwrap_or_else(|_| paths.config_dir.clone());
+    let working_dir = std::env::current_dir().unwrap_or_else(|_| ".".into());
+
+    if cfg!(target_os = "linux") {
+        install_systemd(&seidrum_bin, &config_dir, &working_dir)
+    } else if cfg!(target_os = "macos") {
+        install_launchd(&seidrum_bin, &config_dir, &working_dir)
+    } else {
+        anyhow::bail!("Service installation is not supported on this OS");
+    }
+}
+
+/// Remove the system service.
+pub fn uninstall(_paths: &SeidrumPaths) -> Result<()> {
+    if cfg!(target_os = "linux") {
+        uninstall_systemd()
+    } else if cfg!(target_os = "macos") {
+        uninstall_launchd()
+    } else {
+        anyhow::bail!("Service uninstallation is not supported on this OS");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// systemd (Linux)
+// ---------------------------------------------------------------------------
+
+fn systemd_unit_path() -> std::path::PathBuf {
+    let uid = unsafe { libc::getuid() };
+    if uid == 0 {
+        std::path::PathBuf::from("/etc/systemd/system/seidrum.service")
+    } else {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        std::path::PathBuf::from(format!("{}/.config/systemd/user/seidrum.service", home))
+    }
+}
+
+fn install_systemd(
+    seidrum_bin: &std::path::Path,
+    config_dir: &std::path::Path,
+    working_dir: &std::path::Path,
+) -> Result<()> {
+    let unit_path = systemd_unit_path();
+    let is_user = unsafe { libc::getuid() } != 0;
+
+    // Ensure parent directory exists
+    if let Some(parent) = unit_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let unit = format!(
+        r#"[Unit]
+Description=Seidrum AI Platform
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={bin} daemon start --config-dir {config}
+ExecStop={bin} daemon stop --config-dir {config}
+Restart=on-failure
+RestartSec=5
+WorkingDirectory={workdir}
+
+[Install]
+WantedBy={target}
+"#,
+        bin = seidrum_bin.display(),
+        config = config_dir.display(),
+        workdir = working_dir.display(),
+        target = if is_user {
+            "default.target"
+        } else {
+            "multi-user.target"
+        }
+    );
+
+    std::fs::write(&unit_path, unit)
+        .with_context(|| format!("Failed to write {}", unit_path.display()))?;
+
+    println!("Installed systemd service at {}", unit_path.display());
+
+    // Reload systemd, enable, and start
+    let user_args: &[&str] = if is_user { &["--user"] } else { &[] };
+
+    run_systemctl(user_args, "daemon-reload")?;
+    run_systemctl(user_args, "enable seidrum")?;
+    run_systemctl(user_args, "start seidrum")?;
+
+    println!("Seidrum service installed, enabled, and started.");
+
+    Ok(())
+}
+
+fn run_systemctl(user_args: &[&str], command: &str) -> Result<()> {
+    let args: Vec<&str> = user_args
+        .iter()
+        .copied()
+        .chain(command.split_whitespace())
+        .collect();
+    let status = std::process::Command::new("systemctl")
+        .args(&args)
+        .status()
+        .with_context(|| format!("Failed to run: systemctl {}", args.join(" ")))?;
+    if !status.success() {
+        anyhow::bail!(
+            "systemctl {} failed with exit code {:?}",
+            args.join(" "),
+            status.code()
+        );
+    }
+    Ok(())
+}
+
+fn uninstall_systemd() -> Result<()> {
+    let unit_path = systemd_unit_path();
+    let is_user = unsafe { libc::getuid() } != 0;
+    let user_flag = if is_user { " --user" } else { "" };
+
+    // Stop and disable first
+    let _ = std::process::Command::new("systemctl")
+        .args(if is_user {
+            vec!["--user", "stop", "seidrum"]
+        } else {
+            vec!["stop", "seidrum"]
+        })
+        .status();
+
+    let _ = std::process::Command::new("systemctl")
+        .args(if is_user {
+            vec!["--user", "disable", "seidrum"]
+        } else {
+            vec!["disable", "seidrum"]
+        })
+        .status();
+
+    if unit_path.exists() {
+        std::fs::remove_file(&unit_path)?;
+        println!("Removed {}", unit_path.display());
+        println!("Run: systemctl{} daemon-reload", user_flag);
+    } else {
+        println!("Service file not found at {}", unit_path.display());
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// launchd (macOS)
+// ---------------------------------------------------------------------------
+
+fn launchd_plist_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(format!(
+        "{}/Library/LaunchAgents/com.seidrum.daemon.plist",
+        home
+    ))
+}
+
+fn install_launchd(
+    seidrum_bin: &std::path::Path,
+    config_dir: &std::path::Path,
+    working_dir: &std::path::Path,
+) -> Result<()> {
+    let plist_path = launchd_plist_path();
+
+    if let Some(parent) = plist_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.seidrum.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bin}</string>
+        <string>daemon</string>
+        <string>start</string>
+        <string>--config-dir</string>
+        <string>{config}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>{workdir}</string>
+</dict>
+</plist>
+"#,
+        bin = seidrum_bin.display(),
+        config = config_dir.display(),
+        workdir = working_dir.display(),
+    );
+
+    std::fs::write(&plist_path, plist)
+        .with_context(|| format!("Failed to write {}", plist_path.display()))?;
+
+    println!("Installed launchd service at {}", plist_path.display());
+
+    // Load the service
+    let status = std::process::Command::new("launchctl")
+        .args(["load", &plist_path.display().to_string()])
+        .status()
+        .context("Failed to run launchctl load")?;
+
+    if status.success() {
+        println!("Seidrum service installed and started.");
+    } else {
+        println!(
+            "Service file installed. Run manually: launchctl load {}",
+            plist_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn uninstall_launchd() -> Result<()> {
+    let plist_path = launchd_plist_path();
+
+    let _ = std::process::Command::new("launchctl")
+        .args(["unload", &plist_path.display().to_string()])
+        .status();
+
+    if plist_path.exists() {
+        std::fs::remove_file(&plist_path)?;
+        println!("Removed {}", plist_path.display());
+    } else {
+        println!("Plist not found at {}", plist_path.display());
+    }
+
+    Ok(())
+}

--- a/crates/seidrum-daemon/src/main.rs
+++ b/crates/seidrum-daemon/src/main.rs
@@ -1,0 +1,51 @@
+mod cli;
+mod config;
+mod daemon;
+mod install;
+mod paths;
+mod status;
+
+use anyhow::Result;
+use clap::Parser;
+
+use cli::{Cli, Commands, DaemonAction, PluginAction};
+use paths::SeidrumPaths;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+    let paths = SeidrumPaths::resolve(&cli.config_dir);
+
+    match cli.command {
+        Commands::Daemon { action } => match action {
+            DaemonAction::Start => daemon::start(&paths).await,
+            DaemonAction::Stop => daemon::stop(&paths).await,
+            DaemonAction::Restart => {
+                let _ = daemon::stop(&paths).await;
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                daemon::start(&paths).await
+            }
+            DaemonAction::Status => status::show(&paths).await,
+            DaemonAction::Install => install::install(&paths),
+            DaemonAction::Uninstall => install::uninstall(&paths),
+        },
+        Commands::Init => daemon::run_kernel_command(&paths, &["init"]).await,
+        Commands::Validate { config } => {
+            daemon::run_kernel_command(&paths, &["validate", "--config", &config]).await
+        }
+        Commands::Plugin { action } => match action {
+            PluginAction::List => config::list_plugins(&paths),
+            PluginAction::Enable { name } => config::set_enabled(&paths, &name, true),
+            PluginAction::Disable { name } => config::set_enabled(&paths, &name, false),
+            PluginAction::Start { name } => daemon::start_plugin(&paths, &name).await,
+            PluginAction::Stop { name } => daemon::stop_plugin(&paths, &name).await,
+            PluginAction::Restart { name } => {
+                let _ = daemon::stop_plugin(&paths, &name).await;
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                daemon::start_plugin(&paths, &name).await
+            }
+        },
+    }
+}

--- a/crates/seidrum-daemon/src/paths.rs
+++ b/crates/seidrum-daemon/src/paths.rs
@@ -1,0 +1,104 @@
+//! Centralized path resolution for the daemon.
+
+use std::path::PathBuf;
+
+/// All filesystem paths used by the daemon.
+pub struct SeidrumPaths {
+    /// Directory containing plugin binaries.
+    pub bin_dir: PathBuf,
+    /// Directory containing config files (platform.yaml, plugins.yaml).
+    pub config_dir: PathBuf,
+    /// Directory for PID files and metadata.
+    pub pid_dir: PathBuf,
+    /// Directory for process log files.
+    pub log_dir: PathBuf,
+}
+
+impl SeidrumPaths {
+    /// Resolve all paths based on the config directory.
+    pub fn resolve(config_dir: &std::path::Path) -> Self {
+        let bin_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let home_dir = std::env::var("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."));
+
+        let seidrum_dir = home_dir.join(".seidrum");
+
+        Self {
+            bin_dir,
+            config_dir: config_dir.to_path_buf(),
+            pid_dir: seidrum_dir.join("pids"),
+            log_dir: seidrum_dir.join("logs"),
+        }
+    }
+
+    /// Ensure all directories exist.
+    pub fn ensure_dirs(&self) -> anyhow::Result<()> {
+        std::fs::create_dir_all(&self.pid_dir)?;
+        std::fs::create_dir_all(&self.log_dir)?;
+        Ok(())
+    }
+
+    /// Path to the daemon's own PID file.
+    pub fn daemon_pid_file(&self) -> PathBuf {
+        self.pid_dir.join("seidrum.pid")
+    }
+
+    /// Path to a plugin's PID file.
+    pub fn plugin_pid_file(&self, name: &str) -> PathBuf {
+        self.pid_dir.join(format!("{}.pid", name))
+    }
+
+    /// Path to a plugin's metadata file.
+    pub fn plugin_meta_file(&self, name: &str) -> PathBuf {
+        self.pid_dir.join(format!("{}.meta", name))
+    }
+
+    /// Path to a plugin's stopped marker file.
+    pub fn plugin_stopped_file(&self, name: &str) -> PathBuf {
+        self.pid_dir.join(format!("{}.stopped", name))
+    }
+
+    /// Path to a plugin's log file.
+    pub fn plugin_log_file(&self, name: &str) -> PathBuf {
+        self.log_dir.join(format!("{}.log", name))
+    }
+
+    /// Resolve a plugin binary path.
+    pub fn plugin_binary(&self, binary_name: &str) -> PathBuf {
+        self.bin_dir.join(binary_name)
+    }
+
+    /// Path to plugins.yaml.
+    pub fn plugins_yaml(&self) -> PathBuf {
+        self.config_dir.join("plugins.yaml")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pid_file_paths() {
+        let paths = SeidrumPaths {
+            bin_dir: PathBuf::from("/usr/bin"),
+            config_dir: PathBuf::from("/etc/seidrum"),
+            pid_dir: PathBuf::from("/var/run/seidrum"),
+            log_dir: PathBuf::from("/var/log/seidrum"),
+        };
+
+        assert_eq!(
+            paths.plugin_pid_file("telegram"),
+            PathBuf::from("/var/run/seidrum/telegram.pid")
+        );
+        assert_eq!(
+            paths.plugin_binary("seidrum-telegram"),
+            PathBuf::from("/usr/bin/seidrum-telegram")
+        );
+    }
+}

--- a/crates/seidrum-daemon/src/status.rs
+++ b/crates/seidrum-daemon/src/status.rs
@@ -1,0 +1,166 @@
+//! Status display: reads PID files and metadata to show process state.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tabled::{Table, Tabled};
+
+use crate::config::load_plugins_config;
+use crate::paths::SeidrumPaths;
+
+/// Metadata stored alongside PID files.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProcessMeta {
+    pub pid: u32,
+    pub started_at: DateTime<Utc>,
+    pub restart_count: u32,
+}
+
+/// Show the status of the daemon and all plugins.
+pub async fn show(paths: &SeidrumPaths) -> Result<()> {
+    // Check daemon
+    let daemon_status = check_pid_file(&paths.daemon_pid_file());
+    match &daemon_status {
+        Some(pid) => println!("Seidrum daemon: running (PID {})\n", pid),
+        None => {
+            println!("Seidrum daemon: not running\n");
+        }
+    }
+
+    // Check kernel
+    let kernel_status = get_process_status(paths, "kernel");
+
+    // Check plugins
+    let plugins_yaml = paths.plugins_yaml();
+    let plugin_statuses: Vec<ProcessStatus> = if plugins_yaml.exists() {
+        let config = load_plugins_config(&plugins_yaml)?;
+        let mut statuses = vec![kernel_status];
+
+        for (name, entry) in &config.plugins {
+            let status = if !entry.enabled {
+                ProcessStatus {
+                    name: name.clone(),
+                    binary: entry.binary.clone(),
+                    state: "disabled".to_string(),
+                    pid: "-".to_string(),
+                    uptime: "-".to_string(),
+                    restarts: "-".to_string(),
+                }
+            } else if paths.plugin_stopped_file(name).exists() {
+                ProcessStatus {
+                    name: name.clone(),
+                    binary: entry.binary.clone(),
+                    state: "stopped".to_string(),
+                    pid: "-".to_string(),
+                    uptime: "-".to_string(),
+                    restarts: "-".to_string(),
+                }
+            } else {
+                get_process_status(paths, name)
+            };
+            statuses.push(status);
+        }
+        statuses
+    } else {
+        vec![kernel_status]
+    };
+
+    println!("{}", Table::new(&plugin_statuses));
+
+    Ok(())
+}
+
+#[derive(Tabled)]
+struct ProcessStatus {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Binary")]
+    binary: String,
+    #[tabled(rename = "Status")]
+    state: String,
+    #[tabled(rename = "PID")]
+    pid: String,
+    #[tabled(rename = "Uptime")]
+    uptime: String,
+    #[tabled(rename = "Restarts")]
+    restarts: String,
+}
+
+fn get_process_status(paths: &SeidrumPaths, name: &str) -> ProcessStatus {
+    let binary = if name == "kernel" {
+        "seidrum-kernel".to_string()
+    } else {
+        format!("seidrum-{}", name)
+    };
+
+    let pid = check_pid_file(&paths.plugin_pid_file(name));
+    let meta = load_meta(&paths.plugin_meta_file(name));
+
+    match pid {
+        Some(pid) => {
+            let (uptime, restarts) = match meta {
+                Some(m) => {
+                    let uptime = format_uptime(m.started_at);
+                    (uptime, m.restart_count.to_string())
+                }
+                None => ("-".to_string(), "0".to_string()),
+            };
+
+            ProcessStatus {
+                name: name.to_string(),
+                binary,
+                state: "running".to_string(),
+                pid: pid.to_string(),
+                uptime,
+                restarts,
+            }
+        }
+        None => ProcessStatus {
+            name: name.to_string(),
+            binary,
+            state: "down".to_string(),
+            pid: "-".to_string(),
+            uptime: "-".to_string(),
+            restarts: meta
+                .map(|m| m.restart_count.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+        },
+    }
+}
+
+/// Check if a PID file exists and the process is alive.
+fn check_pid_file(path: &std::path::Path) -> Option<i32> {
+    let pid_str = std::fs::read_to_string(path).ok()?;
+    let pid: i32 = pid_str.trim().parse().ok()?;
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        Some(pid)
+    } else {
+        None
+    }
+}
+
+/// Load metadata from a .meta file.
+fn load_meta(path: &std::path::Path) -> Option<ProcessMeta> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Format uptime as human-readable string.
+fn format_uptime(started_at: DateTime<Utc>) -> String {
+    let duration = Utc::now() - started_at;
+    let total_secs = duration.num_seconds().max(0) as u64;
+
+    if total_secs < 60 {
+        format!("{}s", total_secs)
+    } else if total_secs < 3600 {
+        format!("{}m", total_secs / 60)
+    } else if total_secs < 86400 {
+        let hours = total_secs / 3600;
+        let mins = (total_secs % 3600) / 60;
+        format!("{}h {}m", hours, mins)
+    } else {
+        let days = total_secs / 86400;
+        let hours = (total_secs % 86400) / 3600;
+        format!("{}d {}h", days, hours)
+    }
+}

--- a/crates/seidrum-daemon/src/status.rs
+++ b/crates/seidrum-daemon/src/status.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tabled::{Table, Tabled};
 
 use crate::config::load_plugins_config;
+use crate::daemon::is_process_alive;
 use crate::paths::SeidrumPaths;
 
 /// Metadata stored alongside PID files.
@@ -18,23 +19,19 @@ pub struct ProcessMeta {
 
 /// Show the status of the daemon and all plugins.
 pub async fn show(paths: &SeidrumPaths) -> Result<()> {
-    // Check daemon
-    let daemon_status = check_pid_file(&paths.daemon_pid_file());
-    match &daemon_status {
+    let daemon_pid = check_pid_file(&paths.daemon_pid_file());
+    match daemon_pid {
         Some(pid) => println!("Seidrum daemon: running (PID {})\n", pid),
-        None => {
-            println!("Seidrum daemon: not running\n");
-        }
+        None => println!("Seidrum daemon: not running\n"),
     }
 
-    // Check kernel
-    let kernel_status = get_process_status(paths, "kernel");
+    let kernel_status = get_process_status(paths, "kernel", "seidrum-kernel");
 
-    // Check plugins
     let plugins_yaml = paths.plugins_yaml();
-    let plugin_statuses: Vec<ProcessStatus> = if plugins_yaml.exists() {
+    let mut statuses = vec![kernel_status];
+
+    if plugins_yaml.exists() {
         let config = load_plugins_config(&plugins_yaml)?;
-        let mut statuses = vec![kernel_status];
 
         for (name, entry) in &config.plugins {
             let status = if !entry.enabled {
@@ -56,16 +53,13 @@ pub async fn show(paths: &SeidrumPaths) -> Result<()> {
                     restarts: "-".to_string(),
                 }
             } else {
-                get_process_status(paths, name)
+                get_process_status(paths, name, &entry.binary)
             };
             statuses.push(status);
         }
-        statuses
-    } else {
-        vec![kernel_status]
-    };
+    }
 
-    println!("{}", Table::new(&plugin_statuses));
+    println!("{}", Table::new(&statuses));
 
     Ok(())
 }
@@ -86,29 +80,20 @@ struct ProcessStatus {
     restarts: String,
 }
 
-fn get_process_status(paths: &SeidrumPaths, name: &str) -> ProcessStatus {
-    let binary = if name == "kernel" {
-        "seidrum-kernel".to_string()
-    } else {
-        format!("seidrum-{}", name)
-    };
-
+fn get_process_status(paths: &SeidrumPaths, name: &str, binary: &str) -> ProcessStatus {
     let pid = check_pid_file(&paths.plugin_pid_file(name));
     let meta = load_meta(&paths.plugin_meta_file(name));
 
     match pid {
         Some(pid) => {
             let (uptime, restarts) = match meta {
-                Some(m) => {
-                    let uptime = format_uptime(m.started_at);
-                    (uptime, m.restart_count.to_string())
-                }
+                Some(m) => (format_uptime(m.started_at), m.restart_count.to_string()),
                 None => ("-".to_string(), "0".to_string()),
             };
 
             ProcessStatus {
                 name: name.to_string(),
-                binary,
+                binary: binary.to_string(),
                 state: "running".to_string(),
                 pid: pid.to_string(),
                 uptime,
@@ -117,7 +102,7 @@ fn get_process_status(paths: &SeidrumPaths, name: &str) -> ProcessStatus {
         }
         None => ProcessStatus {
             name: name.to_string(),
-            binary,
+            binary: binary.to_string(),
             state: "down".to_string(),
             pid: "-".to_string(),
             uptime: "-".to_string(),
@@ -129,10 +114,11 @@ fn get_process_status(paths: &SeidrumPaths, name: &str) -> ProcessStatus {
 }
 
 /// Check if a PID file exists and the process is alive.
+/// Handles both ESRCH (no process) and EPERM (process exists, different user).
 fn check_pid_file(path: &std::path::Path) -> Option<i32> {
     let pid_str = std::fs::read_to_string(path).ok()?;
     let pid: i32 = pid_str.trim().parse().ok()?;
-    if unsafe { libc::kill(pid, 0) } == 0 {
+    if is_process_alive(pid) {
         Some(pid)
     } else {
         None

--- a/docs/EVENT_CATALOG.md
+++ b/docs/EVENT_CATALOG.md
@@ -522,6 +522,25 @@ struct PluginDeregister {
 
 ---
 
+## Plugin Config Events
+
+### `plugin.{id}.config.update`
+
+Notification that a plugin's configuration was updated (e.g., from the admin dashboard).
+
+```rust
+pub struct ConfigUpdated {
+    pub plugin_id: String,
+    pub config: serde_json::Value,
+    pub updated_by: String,
+    pub timestamp: DateTime<Utc>,
+}
+```
+
+Published by the API gateway dashboard after validating the config against the plugin's JSON Schema and persisting to plugin storage.
+
+---
+
 ## Capability Events
 
 ### `capability.registered`

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -554,3 +554,71 @@ async def main():
 
 This works because the only contract is: connect to NATS, consume events,
 produce events. Language doesn't matter. Runtime doesn't matter.
+
+## Daemon Process Manager
+
+The `seidrum` binary manages the kernel and all plugins as a unified process supervisor.
+
+### Plugin Configuration (`config/plugins.yaml`)
+
+Each local plugin is listed in `config/plugins.yaml` with its binary name, enabled state, and environment variables:
+
+```yaml
+plugins:
+  telegram:
+    binary: seidrum-telegram
+    enabled: true
+    env:
+      TELEGRAM_TOKEN: "${TELEGRAM_TOKEN}"
+  claude-code:
+    binary: seidrum-claude-code
+    enabled: false
+    env:
+      CLAUDE_WORKING_DIR: "${CLAUDE_WORKING_DIR:-.}"
+```
+
+Environment values support `${VAR}` and `${VAR:-default}` interpolation.
+
+### CLI Commands
+
+```
+seidrum daemon start/stop/restart/status   — manage the full stack
+seidrum daemon install/uninstall           — systemd (Linux) / launchd (macOS)
+seidrum plugin list/enable/disable         — toggle plugins
+seidrum plugin start/stop/restart          — control individual plugins
+seidrum init / seidrum validate            — database and config management
+```
+
+### Process Supervision
+
+- The daemon starts the kernel first, waits 2 seconds, then spawns enabled plugins
+- Crashed plugins are restarted with exponential backoff (1/2/4/8/16s, max 5 in 5min)
+- Graceful shutdown: SIGTERM to plugins first, then kernel
+- PID files and metadata stored in `~/.seidrum/pids/`
+- Process logs in `~/.seidrum/logs/`
+
+## Plugin Config Schemas
+
+Plugins can declare a `config_schema` field in their `PluginRegister` struct — a JSON Schema describing configurable parameters:
+
+```rust
+PluginRegister {
+    // ... other fields ...
+    config_schema: Some(serde_json::json!({
+        "type": "object",
+        "properties": {
+            "max_turns": {
+                "type": "integer",
+                "description": "Maximum agentic turns",
+                "default": 25
+            }
+        }
+    })),
+}
+```
+
+When a plugin declares a config schema:
+- The admin dashboard renders a configuration form automatically
+- Config changes are validated against the schema before saving
+- Updated config is persisted to plugin storage (`namespace: "config"`)
+- The plugin is notified via `plugin.{id}.config.update` NATS subject


### PR DESCRIPTION
## Summary

New `seidrum` binary that acts as a unified CLI and process supervisor for the entire platform.

### CLI Interface
```
seidrum daemon start          # Start kernel + enabled plugins
seidrum daemon stop           # Graceful shutdown
seidrum daemon restart
seidrum daemon status         # Show all processes with PID, uptime, restarts
seidrum daemon install        # Install systemd/launchd service
seidrum daemon uninstall

seidrum plugin list           # Show all 19 plugins with enabled/disabled
seidrum plugin enable <name>
seidrum plugin disable <name>
seidrum plugin start <name>   # Start individual plugin
seidrum plugin stop <name>
seidrum plugin restart <name>

seidrum init                  # Delegates to seidrum-kernel init
seidrum validate              # Delegates to seidrum-kernel validate
```

### Features
- Process supervisor: spawns kernel first, then enabled plugins
- Crash restart with exponential backoff (max 5 in 5min)
- Graceful shutdown: SIGTERM plugins, wait, SIGTERM kernel
- PID files + JSON metadata for status tracking
- `plugins.yaml` with `${VAR:-default}` env interpolation
- systemd + launchd service installation
- Binary auto-discovery from same directory as `seidrum`
- Per-plugin log files in `~/.seidrum/logs/`

### New files
- `crates/seidrum-daemon/` — 7 source files (cli, config, daemon, install, paths, status, main)
- `config/plugins.yaml` — default plugin configuration (19 plugins)

## Test plan
- [x] 6 unit tests pass (config parsing, env interpolation, YAML roundtrip, paths)
- [x] `seidrum plugin list` shows formatted table
- [x] `seidrum --help` shows all subcommands
- [ ] `seidrum daemon start` spawns kernel + plugins
- [ ] `seidrum daemon status` shows running processes
- [ ] `seidrum daemon stop` graceful shutdown