### PR TITLE
Agent Consciousness: conversations, built-in capabilities, guardrails

### DIFF
--- a/agents/personal-assistant.yaml
+++ b/agents/personal-assistant.yaml
@@ -3,7 +3,6 @@ agent:
   description: General-purpose personal assistant
   prompt: ./prompts/assistant.md
   tools:
-    - brain-query
     - execute-code
     - search-calendar
     - send-email
@@ -11,3 +10,6 @@ agent:
   additional_scopes:
     - scope_job_search
     - scope_projects
+  subscribe:
+    - channel.*.inbound
+    - task.completed.*

--- a/agents/research-agent.yaml
+++ b/agents/research-agent.yaml
@@ -3,7 +3,6 @@ agent:
   description: Deep research and analysis agent
   prompt: ./prompts/research.md
   tools:
-    - brain-query
     - execute-code
   scope: scope_projects
   additional_scopes:

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -209,6 +209,7 @@ async fn main() -> Result<()> {
                         },
                         duration_ms: 0,
                         finish_reason: "error".to_string(),
+                        tool_rounds: 0,
                     };
                     if let Ok(bytes) = serde_json::to_vec(&err_response) {
                         let _ = nats_clone.publish(reply.to_string(), bytes.into()).await;
@@ -488,6 +489,7 @@ async fn handle_provider_request(
         },
         duration_ms,
         finish_reason: "stop".to_string(),
+        tool_rounds: 0,
     };
 
     info!(

--- a/crates/plugins/seidrum-llm-google/src/translator.rs
+++ b/crates/plugins/seidrum-llm-google/src/translator.rs
@@ -146,6 +146,7 @@ pub fn gemini_to_unified_response(
         },
         duration_ms,
         finish_reason,
+        tool_rounds: 0,
     }
 }
 

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -419,6 +419,7 @@ async fn handle_message(
                     },
                     duration_ms,
                     finish_reason: "error".to_string(),
+                    tool_rounds: 0,
                 }
             }
         },
@@ -438,6 +439,7 @@ async fn handle_message(
                 },
                 duration_ms,
                 finish_reason: "error".to_string(),
+                tool_rounds: 0,
             }
         }
         Err(_) => {
@@ -460,6 +462,7 @@ async fn handle_message(
                 },
                 duration_ms,
                 finish_reason: "timeout".to_string(),
+                tool_rounds: 0,
             }
         }
     };

--- a/crates/seidrum-common/src/config.rs
+++ b/crates/seidrum-common/src/config.rs
@@ -227,6 +227,20 @@ pub struct AgentDefinition {
     pub additional_scopes: Vec<String>,
     #[serde(default)]
     pub description: Option<String>,
+    /// NATS subjects this agent subscribes to for consciousness events.
+    #[serde(default)]
+    pub subscribe: Vec<String>,
+    /// Per-agent guardrail overrides.
+    #[serde(default)]
+    pub guardrails: Option<GuardrailOverrides>,
+}
+
+/// Per-agent guardrail overrides. Fields not set use defaults.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardrailOverrides {
+    pub turn_limit: Option<u32>,
+    pub time_limit_seconds: Option<u64>,
+    pub hitl_after_turns: Option<u32>,
 }
 
 pub fn load_agent_definition(path: &Path) -> anyhow::Result<AgentDefinitionFile> {

--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -320,6 +320,9 @@ pub struct LlmResponse {
     pub tokens: TokenUsage,
     pub duration_ms: u64,
     pub finish_reason: String,
+    /// Number of tool call rounds executed by the provider.
+    #[serde(default)]
+    pub tool_rounds: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -686,6 +689,216 @@ pub struct StorageListRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StorageListResponse {
     pub keys: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Conversation Events
+// ---------------------------------------------------------------------------
+
+/// A media attachment within a conversation message.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MediaAttachment {
+    /// "image" | "voice" | "file" | "video"
+    pub media_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub mime_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript: Option<String>,
+}
+
+/// A single message within a conversation.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationMessage {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<UnifiedToolCall>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_results: Vec<UnifiedToolResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<MediaAttachment>,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Request to create a new conversation.
+/// Subject: `brain.conversation.create` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationCreateRequest {
+    pub platform: String,
+    pub participants: Vec<String>,
+    pub agent_id: String,
+    pub scope: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+/// Response to conversation create.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationCreateResponse {
+    pub conversation_id: String,
+}
+
+/// Request to append a message to a conversation.
+/// Subject: `brain.conversation.append` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationAppendRequest {
+    pub conversation_id: String,
+    pub message: ConversationMessage,
+}
+
+/// Response to conversation append.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationAppendResponse {
+    pub success: bool,
+    pub message_count: u32,
+}
+
+/// Request to get a conversation by ID.
+/// Subject: `brain.conversation.get` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationGetRequest {
+    pub conversation_id: String,
+    /// Maximum number of recent messages to return (0 = all).
+    #[serde(default)]
+    pub max_messages: u32,
+}
+
+/// Full conversation document.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Conversation {
+    pub id: String,
+    pub platform: String,
+    pub participants: Vec<String>,
+    pub agent_id: String,
+    pub scope: String,
+    pub messages: Vec<ConversationMessage>,
+    pub metadata: HashMap<String, String>,
+    pub state: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Request to find a conversation by platform metadata.
+/// Subject: `brain.conversation.find` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationFindRequest {
+    pub agent_id: String,
+    pub platform: String,
+    pub metadata_key: String,
+    pub metadata_value: String,
+}
+
+/// Request to list conversations.
+/// Subject: `brain.conversation.list` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationListRequest {
+    pub agent_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub limit: u32,
+}
+
+/// Response to conversation list.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationListResponse {
+    pub conversations: Vec<ConversationSummary>,
+}
+
+/// Summary of a conversation for listing.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationSummary {
+    pub id: String,
+    pub platform: String,
+    pub participants: Vec<String>,
+    pub message_count: u32,
+    pub state: String,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Consciousness Events
+// ---------------------------------------------------------------------------
+
+/// An event delivered to an agent's consciousness stream.
+/// Subject: `agent.{id}.consciousness`
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConsciousnessEvent {
+    pub agent_id: String,
+    /// "user_message" | "subscribed_event" | "self_wake" | "agent_message" | "delegation_result"
+    pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    pub payload: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<EventOrigin>,
+}
+
+/// Request to subscribe an agent to NATS event patterns at runtime.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SubscribeEventsRequest {
+    pub subjects: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_seconds: Option<u64>,
+}
+
+/// Request to unsubscribe an agent from NATS event patterns.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UnsubscribeEventsRequest {
+    pub subjects: Vec<String>,
+}
+
+/// Request to delegate a task to another agent.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DelegateTaskRequest {
+    pub to_agent_id: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+}
+
+/// Request to schedule a self-wake timer.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ScheduleWakeRequest {
+    pub delay_seconds: u64,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+}
+
+/// Request to send a proactive notification to a user channel.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SendNotificationRequest {
+    pub channel: String,
+    pub chat_id: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+}
+
+/// Guardrail configuration for tool loop limits.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GuardrailConfig {
+    pub turn_limit: u32,
+    pub time_limit_seconds: u64,
+    pub loop_detection_threshold: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hitl_after_turns: Option<u32>,
+}
+
+impl Default for GuardrailConfig {
+    fn default() -> Self {
+        Self {
+            turn_limit: 50,
+            time_limit_seconds: 600,
+            loop_detection_threshold: 3,
+            hitl_after_turns: Some(20),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/seidrum-kernel/src/brain/init.rs
+++ b/crates/seidrum-kernel/src/brain/init.rs
@@ -15,6 +15,7 @@ const VERTEX_COLLECTIONS: &[&str] = &[
     "event_types",
     "capabilities",
     "plugin_storage",
+    "conversations",
 ];
 
 /// Edge collections defined in BRAIN_SCHEMA.md.

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -10,7 +10,10 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use futures::StreamExt;
 use seidrum_common::events::{
-    BrainQueryRequest, BrainQueryResponse, ContentStoreRequest, ContentStored, EntityUpsertRequest,
+    BrainQueryRequest, BrainQueryResponse, ContentStoreRequest, ContentStored, Conversation,
+    ConversationAppendRequest, ConversationAppendResponse, ConversationCreateRequest,
+    ConversationCreateResponse, ConversationFindRequest, ConversationGetRequest,
+    ConversationListRequest, ConversationListResponse, ConversationSummary, EntityUpsertRequest,
     EntityUpserted, EventEnvelope, FactUpsertRequest, FactUpserted, ScopeAssignRequest,
     ScopeAssigned,
 };
@@ -71,6 +74,31 @@ impl BrainService {
             .subscribe("brain.query.request")
             .await
             .context("subscribe brain.query.request")?;
+        let mut conv_create = self
+            .nats
+            .subscribe("brain.conversation.create")
+            .await
+            .context("subscribe brain.conversation.create")?;
+        let mut conv_append = self
+            .nats
+            .subscribe("brain.conversation.append")
+            .await
+            .context("subscribe brain.conversation.append")?;
+        let mut conv_get = self
+            .nats
+            .subscribe("brain.conversation.get")
+            .await
+            .context("subscribe brain.conversation.get")?;
+        let mut conv_find = self
+            .nats
+            .subscribe("brain.conversation.find")
+            .await
+            .context("subscribe brain.conversation.find")?;
+        let mut conv_list = self
+            .nats
+            .subscribe("brain.conversation.list")
+            .await
+            .context("subscribe brain.conversation.list")?;
 
         info!("Brain service started — listening on brain.* subjects");
 
@@ -128,6 +156,51 @@ impl BrainService {
                     tokio::spawn(async move {
                         if let Err(e) = handle_query_request(&arango, &nats, &scope_svc, msg).await {
                             error!(error = %e, "brain.query.request handler failed");
+                        }
+                    });
+                }
+                Some(msg) = conv_create.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conversation_create(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.conversation.create handler failed");
+                        }
+                    });
+                }
+                Some(msg) = conv_append.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conversation_append(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.conversation.append handler failed");
+                        }
+                    });
+                }
+                Some(msg) = conv_get.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conversation_get(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.conversation.get handler failed");
+                        }
+                    });
+                }
+                Some(msg) = conv_find.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conversation_find(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.conversation.find handler failed");
+                        }
+                    });
+                }
+                Some(msg) = conv_list.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_conversation_list(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.conversation.list handler failed");
                         }
                     });
                 }
@@ -1027,4 +1100,259 @@ async fn handle_get_context(
         .context("get_context query failed")?;
 
     Ok(resp.get("result").cloned().unwrap_or(serde_json::json!([])))
+}
+
+// ---------------------------------------------------------------------------
+// Conversation handlers
+// ---------------------------------------------------------------------------
+
+/// Create a new conversation document.
+async fn handle_conversation_create(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: ConversationCreateRequest =
+        serde_json::from_slice(&msg.payload).context("parse conversation.create")?;
+
+    let conv_id = ulid::Ulid::new().to_string();
+    let now = Utc::now();
+
+    let doc = serde_json::json!({
+        "_key": &conv_id,
+        "platform": &req.platform,
+        "participants": &req.participants,
+        "agent_id": &req.agent_id,
+        "scope": &req.scope,
+        "messages": [],
+        "metadata": &req.metadata,
+        "state": "active",
+        "created_at": now.to_rfc3339(),
+        "updated_at": now.to_rfc3339(),
+    });
+
+    arango
+        .insert_document("conversations", &doc)
+        .await
+        .context("insert conversation")?;
+
+    debug!(conversation_id = %conv_id, "Conversation created");
+
+    if let Some(reply) = msg.reply {
+        let resp = ConversationCreateResponse {
+            conversation_id: conv_id,
+        };
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+    }
+
+    Ok(())
+}
+
+/// Append a message to an existing conversation.
+async fn handle_conversation_append(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: ConversationAppendRequest =
+        serde_json::from_slice(&msg.payload).context("parse conversation.append")?;
+
+    let now = Utc::now();
+
+    let query = r#"
+        LET conv = DOCUMENT(CONCAT("conversations/", @conv_id))
+        FILTER conv != null
+        UPDATE conv WITH {
+            messages: APPEND(conv.messages, [@message]),
+            updated_at: @now
+        } IN conversations
+        RETURN { message_count: LENGTH(NEW.messages) }
+    "#;
+
+    let message_json = serde_json::to_value(&req.message)?;
+    let bind_vars = serde_json::json!({
+        "conv_id": &req.conversation_id,
+        "message": message_json,
+        "now": now.to_rfc3339(),
+    });
+
+    let resp = arango.execute_aql(query, &bind_vars).await?;
+    let count = resp
+        .get("result")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.get("message_count"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    if let Some(reply) = msg.reply {
+        let resp = ConversationAppendResponse {
+            success: count > 0,
+            message_count: count,
+        };
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+    }
+
+    Ok(())
+}
+
+/// Get a conversation by ID.
+async fn handle_conversation_get(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: ConversationGetRequest =
+        serde_json::from_slice(&msg.payload).context("parse conversation.get")?;
+
+    let doc = arango
+        .get_document("conversations", &req.conversation_id)
+        .await?;
+
+    if let Some(reply) = msg.reply {
+        let resp = match doc {
+            Some(mut d) => {
+                // Trim messages if max_messages is set
+                if req.max_messages > 0 {
+                    if let Some(messages) = d.get("messages").and_then(|v| v.as_array()) {
+                        let len = messages.len();
+                        let skip = len.saturating_sub(req.max_messages as usize);
+                        let trimmed: Vec<_> = messages.iter().skip(skip).cloned().collect();
+                        d["messages"] = serde_json::Value::Array(trimmed);
+                    }
+                }
+                // Map _key to id
+                if let Some(key) = d.get("_key").and_then(|v| v.as_str()) {
+                    d["id"] = serde_json::Value::String(key.to_string());
+                }
+                d
+            }
+            None => serde_json::json!(null),
+        };
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+    }
+
+    Ok(())
+}
+
+/// Find a conversation by platform metadata.
+async fn handle_conversation_find(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: ConversationFindRequest =
+        serde_json::from_slice(&msg.payload).context("parse conversation.find")?;
+
+    let query = r#"
+        FOR conv IN conversations
+            FILTER conv.agent_id == @agent_id
+            FILTER conv.platform == @platform
+            FILTER conv.metadata[@meta_key] == @meta_value
+            FILTER conv.state == "active"
+            SORT conv.updated_at DESC
+            LIMIT 1
+            RETURN MERGE(conv, { id: conv._key })
+    "#;
+
+    let bind_vars = serde_json::json!({
+        "agent_id": &req.agent_id,
+        "platform": &req.platform,
+        "meta_key": &req.metadata_key,
+        "meta_value": &req.metadata_value,
+    });
+
+    let resp = arango.execute_aql(query, &bind_vars).await?;
+    let result = resp
+        .get("result")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .cloned()
+        .unwrap_or(serde_json::json!(null));
+
+    if let Some(reply) = msg.reply {
+        let _ = nats
+            .publish(reply, serde_json::to_vec(&result)?.into())
+            .await;
+    }
+
+    Ok(())
+}
+
+/// List conversations for an agent.
+async fn handle_conversation_list(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: ConversationListRequest =
+        serde_json::from_slice(&msg.payload).context("parse conversation.list")?;
+
+    let limit = if req.limit == 0 { 20 } else { req.limit };
+
+    let (query, bind_vars) = if let Some(ref platform) = req.platform {
+        (
+            r#"
+                FOR conv IN conversations
+                    FILTER conv.agent_id == @agent_id
+                    FILTER conv.platform == @platform
+                    SORT conv.updated_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: conv._key,
+                        platform: conv.platform,
+                        participants: conv.participants,
+                        message_count: LENGTH(conv.messages),
+                        state: conv.state,
+                        updated_at: conv.updated_at
+                    }
+            "#,
+            serde_json::json!({
+                "agent_id": &req.agent_id,
+                "platform": platform,
+                "limit": limit,
+            }),
+        )
+    } else {
+        (
+            r#"
+                FOR conv IN conversations
+                    FILTER conv.agent_id == @agent_id
+                    SORT conv.updated_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: conv._key,
+                        platform: conv.platform,
+                        participants: conv.participants,
+                        message_count: LENGTH(conv.messages),
+                        state: conv.state,
+                        updated_at: conv.updated_at
+                    }
+            "#,
+            serde_json::json!({
+                "agent_id": &req.agent_id,
+                "limit": limit,
+            }),
+        )
+    };
+
+    let resp = arango.execute_aql(query, &bind_vars).await?;
+    let conversations: Vec<ConversationSummary> = resp
+        .get("result")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(reply) = msg.reply {
+        let list_resp = ConversationListResponse { conversations };
+        let _ = nats
+            .publish(reply, serde_json::to_vec(&list_resp)?.into())
+            .await;
+    }
+
+    Ok(())
 }

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -1,0 +1,525 @@
+//! Built-in capability handlers for consciousness agents.
+//!
+//! These capabilities are always available to every agent and are handled
+//! directly by the consciousness service via NATS request/reply on
+//! `capability.call.consciousness`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::Utc;
+use futures::StreamExt;
+use seidrum_common::events::{
+    ChannelOutbound, ConsciousnessEvent, ConversationAppendRequest, ConversationAppendResponse,
+    ConversationCreateRequest, ConversationCreateResponse, ConversationGetRequest,
+    ConversationListRequest, ConversationListResponse, ConversationMessage, DelegateTaskRequest,
+    EventEnvelope, ScheduleWakeRequest, SendNotificationRequest, SubscribeEventsRequest,
+    ToolCallResponse, UnsubscribeEventsRequest,
+};
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+/// A runtime event subscription for an agent.
+pub struct RuntimeSubscription {
+    pub pattern: String,
+    pub expiry: Option<chrono::DateTime<Utc>>,
+    pub handle: JoinHandle<()>,
+}
+
+/// Handle `subscribe-events` — dynamically subscribe an agent to NATS subjects.
+pub async fn handle_subscribe_events(
+    nats: &async_nats::Client,
+    agent_id: &str,
+    args: &SubscribeEventsRequest,
+    runtime_subs: &Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
+) -> ToolCallResponse {
+    let mut new_subs = Vec::new();
+    let expiry = args
+        .duration_seconds
+        .map(|d| Utc::now() + chrono::Duration::seconds(d as i64));
+
+    for subject in &args.subjects {
+        let nats_clone = nats.clone();
+        let agent_id_clone = agent_id.to_string();
+        let subject_clone = subject.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut sub = match nats_clone.subscribe(subject_clone.clone()).await {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(%e, %subject_clone, "Failed to subscribe");
+                    return;
+                }
+            };
+
+            while let Some(msg) = sub.next().await {
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&msg.payload).unwrap_or(serde_json::json!(null));
+
+                let event = ConsciousnessEvent {
+                    agent_id: agent_id_clone.clone(),
+                    event_type: "subscribed_event".to_string(),
+                    source_subject: Some(msg.subject.to_string()),
+                    conversation_id: None,
+                    payload,
+                    origin: None,
+                };
+
+                let consciousness_subject = format!("agent.{}.consciousness", agent_id_clone);
+                if let Ok(bytes) = serde_json::to_vec(&event) {
+                    let _ = nats_clone
+                        .publish(consciousness_subject, bytes.into())
+                        .await;
+                }
+            }
+        });
+
+        new_subs.push(RuntimeSubscription {
+            pattern: subject.clone(),
+            expiry,
+            handle,
+        });
+    }
+
+    let mut subs = runtime_subs.write().await;
+    let agent_subs = subs.entry(agent_id.to_string()).or_default();
+    let count = new_subs.len();
+    agent_subs.extend(new_subs);
+
+    info!(agent_id, count, "Runtime subscriptions added");
+
+    ToolCallResponse {
+        tool_id: "subscribe-events".to_string(),
+        result: serde_json::json!({
+            "subscribed": args.subjects,
+            "count": count,
+            "expires_at": expiry.map(|e| e.to_rfc3339()),
+        }),
+        is_error: false,
+    }
+}
+
+/// Handle `unsubscribe-events` — remove runtime subscriptions.
+pub async fn handle_unsubscribe_events(
+    agent_id: &str,
+    args: &UnsubscribeEventsRequest,
+    runtime_subs: &Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
+) -> ToolCallResponse {
+    let mut subs = runtime_subs.write().await;
+    let mut removed = 0;
+
+    if let Some(agent_subs) = subs.get_mut(agent_id) {
+        agent_subs.retain(|s| {
+            if args.subjects.contains(&s.pattern) {
+                s.handle.abort();
+                removed += 1;
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    info!(agent_id, removed, "Runtime subscriptions removed");
+
+    ToolCallResponse {
+        tool_id: "unsubscribe-events".to_string(),
+        result: serde_json::json!({ "removed": removed }),
+        is_error: false,
+    }
+}
+
+/// Handle `delegate-task` — create an agent-to-agent conversation.
+pub async fn handle_delegate_task(
+    nats: &async_nats::Client,
+    from_agent_id: &str,
+    args: &DelegateTaskRequest,
+) -> ToolCallResponse {
+    // Create a conversation between the two agents
+    let create_req = ConversationCreateRequest {
+        platform: "agent".to_string(),
+        participants: vec![
+            format!("agent:{}", from_agent_id),
+            format!("agent:{}", args.to_agent_id),
+        ],
+        agent_id: args.to_agent_id.clone(),
+        scope: "scope_root".to_string(),
+        metadata: HashMap::from([
+            ("from_agent".to_string(), from_agent_id.to_string()),
+            ("to_agent".to_string(), args.to_agent_id.clone()),
+        ]),
+    };
+
+    let conv_id = match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, ConversationCreateResponse>(
+            nats,
+            "brain.conversation.create",
+            &create_req,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp.conversation_id,
+        Ok(Err(e)) => {
+            return ToolCallResponse {
+                tool_id: "delegate-task".to_string(),
+                result: serde_json::json!({"error": format!("Failed to create conversation: {}", e)}),
+                is_error: true,
+            };
+        }
+        Err(_) => {
+            return ToolCallResponse {
+                tool_id: "delegate-task".to_string(),
+                result: serde_json::json!({"error": "Timeout creating conversation"}),
+                is_error: true,
+            };
+        }
+    };
+
+    // Append the delegation message
+    let append_req = ConversationAppendRequest {
+        conversation_id: conv_id.clone(),
+        message: ConversationMessage {
+            role: "user".to_string(),
+            content: Some(args.message.clone()),
+            tool_calls: vec![],
+            tool_results: vec![],
+            media: vec![],
+            timestamp: Utc::now(),
+        },
+    };
+
+    let _ = nats_request::<_, ConversationAppendResponse>(
+        nats,
+        "brain.conversation.append",
+        &append_req,
+    )
+    .await;
+
+    // Send consciousness event to the target agent
+    let event = ConsciousnessEvent {
+        agent_id: args.to_agent_id.clone(),
+        event_type: "agent_message".to_string(),
+        source_subject: None,
+        conversation_id: Some(conv_id.clone()),
+        payload: serde_json::json!({
+            "from_agent": from_agent_id,
+            "message": args.message,
+            "context": args.context,
+        }),
+        origin: None,
+    };
+
+    let subject = format!("agent.{}.consciousness", args.to_agent_id);
+    if let Ok(bytes) = serde_json::to_vec(&event) {
+        let _ = nats.publish(subject, bytes.into()).await;
+    }
+
+    info!(
+        from = from_agent_id,
+        to = %args.to_agent_id,
+        %conv_id,
+        "Task delegated"
+    );
+
+    ToolCallResponse {
+        tool_id: "delegate-task".to_string(),
+        result: serde_json::json!({
+            "delegated_to": args.to_agent_id,
+            "conversation_id": conv_id,
+        }),
+        is_error: false,
+    }
+}
+
+/// Handle `schedule-wake` — set a timer that fires on the consciousness stream.
+pub async fn handle_schedule_wake(
+    nats: &async_nats::Client,
+    agent_id: &str,
+    args: &ScheduleWakeRequest,
+) -> ToolCallResponse {
+    let nats_clone = nats.clone();
+    let agent_id_clone = agent_id.to_string();
+    let reason = args.reason.clone();
+    let context = args.context.clone();
+    let delay = args.delay_seconds;
+    let scheduled_at = Utc::now();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(delay)).await;
+
+        let event = ConsciousnessEvent {
+            agent_id: agent_id_clone.clone(),
+            event_type: "self_wake".to_string(),
+            source_subject: None,
+            conversation_id: None,
+            payload: serde_json::json!({
+                "reason": reason,
+                "context": context,
+                "scheduled_at": scheduled_at.to_rfc3339(),
+                "fired_at": Utc::now().to_rfc3339(),
+            }),
+            origin: None,
+        };
+
+        let subject = format!("agent.{}.consciousness", agent_id_clone);
+        if let Ok(bytes) = serde_json::to_vec(&event) {
+            let _ = nats_clone.publish(subject, bytes.into()).await;
+        }
+
+        info!(
+            agent_id = %agent_id_clone,
+            %reason,
+            "Self-wake timer fired"
+        );
+    });
+
+    let fire_at = Utc::now() + chrono::Duration::seconds(delay as i64);
+
+    ToolCallResponse {
+        tool_id: "schedule-wake".to_string(),
+        result: serde_json::json!({
+            "scheduled": true,
+            "delay_seconds": delay,
+            "fire_at": fire_at.to_rfc3339(),
+            "reason": args.reason,
+        }),
+        is_error: false,
+    }
+}
+
+/// Handle `send-notification` — proactively message the user.
+pub async fn handle_send_notification(
+    nats: &async_nats::Client,
+    args: &SendNotificationRequest,
+) -> ToolCallResponse {
+    let outbound = ChannelOutbound {
+        platform: args.channel.clone(),
+        chat_id: args.chat_id.clone(),
+        text: args.text.clone(),
+        format: "plain".to_string(),
+        reply_to: None,
+        actions: vec![],
+    };
+
+    let subject = format!("channel.{}.outbound", args.channel);
+    let envelope = match EventEnvelope::new(&subject, "consciousness", None, None, &outbound) {
+        Ok(e) => e,
+        Err(e) => {
+            return ToolCallResponse {
+                tool_id: "send-notification".to_string(),
+                result: serde_json::json!({"error": format!("Failed to create envelope: {}", e)}),
+                is_error: true,
+            };
+        }
+    };
+
+    if let Ok(bytes) = serde_json::to_vec(&envelope) {
+        let _ = nats.publish(subject, bytes.into()).await;
+    }
+
+    ToolCallResponse {
+        tool_id: "send-notification".to_string(),
+        result: serde_json::json!({
+            "sent": true,
+            "channel": args.channel,
+            "chat_id": args.chat_id,
+        }),
+        is_error: false,
+    }
+}
+
+/// Handle `get-conversation` — load a conversation by ID.
+pub async fn handle_get_conversation(
+    nats: &async_nats::Client,
+    args: &ConversationGetRequest,
+) -> ToolCallResponse {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, serde_json::Value>(nats, "brain.conversation.get", args),
+    )
+    .await
+    {
+        Ok(Ok(conv)) => ToolCallResponse {
+            tool_id: "get-conversation".to_string(),
+            result: conv,
+            is_error: false,
+        },
+        Ok(Err(e)) => ToolCallResponse {
+            tool_id: "get-conversation".to_string(),
+            result: serde_json::json!({"error": e.to_string()}),
+            is_error: true,
+        },
+        Err(_) => ToolCallResponse {
+            tool_id: "get-conversation".to_string(),
+            result: serde_json::json!({"error": "timeout"}),
+            is_error: true,
+        },
+    }
+}
+
+/// Handle `list-conversations` — list recent conversations.
+pub async fn handle_list_conversations(
+    nats: &async_nats::Client,
+    agent_id: &str,
+    args: &ConversationListRequest,
+) -> ToolCallResponse {
+    let mut req = args.clone();
+    req.agent_id = agent_id.to_string();
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, ConversationListResponse>(nats, "brain.conversation.list", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => ToolCallResponse {
+            tool_id: "list-conversations".to_string(),
+            result: serde_json::to_value(resp).unwrap_or(serde_json::json!(null)),
+            is_error: false,
+        },
+        Ok(Err(e)) => ToolCallResponse {
+            tool_id: "list-conversations".to_string(),
+            result: serde_json::json!({"error": e.to_string()}),
+            is_error: true,
+        },
+        Err(_) => ToolCallResponse {
+            tool_id: "list-conversations".to_string(),
+            result: serde_json::json!({"error": "timeout"}),
+            is_error: true,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// NATS request/reply helper.
+async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
+    nats: &async_nats::Client,
+    subject: &str,
+    payload: &T,
+) -> Result<R> {
+    let bytes = serde_json::to_vec(payload)?;
+    let response = nats.request(subject.to_string(), bytes.into()).await?;
+    let result: R = serde_json::from_slice(&response.payload)?;
+    Ok(result)
+}
+
+/// Tool schemas for all built-in capabilities (for LLM context).
+pub fn builtin_tool_schemas() -> Vec<seidrum_common::events::ToolSchema> {
+    use seidrum_common::events::ToolSchema;
+
+    vec![
+        ToolSchema {
+            name: "brain-query".to_string(),
+            description: "Query the knowledge graph using AQL".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query_type": { "type": "string", "enum": ["aql", "get_facts", "get_context"] },
+                    "aql": { "type": "string", "description": "AQL query string" },
+                    "bind_vars": { "type": "object" },
+                    "limit": { "type": "integer" }
+                },
+                "required": ["query_type"]
+            }),
+        },
+        ToolSchema {
+            name: "subscribe-events".to_string(),
+            description:
+                "Subscribe to NATS event patterns to receive them on your consciousness stream"
+                    .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "subjects": { "type": "array", "items": { "type": "string" }, "description": "NATS subject patterns to subscribe to" },
+                    "duration_seconds": { "type": "integer", "description": "Optional auto-expiry in seconds" }
+                },
+                "required": ["subjects"]
+            }),
+        },
+        ToolSchema {
+            name: "unsubscribe-events".to_string(),
+            description: "Stop watching for events on specific NATS patterns".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "subjects": { "type": "array", "items": { "type": "string" } }
+                },
+                "required": ["subjects"]
+            }),
+        },
+        ToolSchema {
+            name: "delegate-task".to_string(),
+            description:
+                "Delegate a task to another agent. Creates an agent-to-agent conversation."
+                    .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "to_agent_id": { "type": "string", "description": "Target agent ID" },
+                    "message": { "type": "string", "description": "Task description for the target agent" },
+                    "context": { "type": "object", "description": "Additional context" }
+                },
+                "required": ["to_agent_id", "message"]
+            }),
+        },
+        ToolSchema {
+            name: "schedule-wake".to_string(),
+            description:
+                "Schedule a self-wake timer. You will receive a consciousness event when it fires."
+                    .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "delay_seconds": { "type": "integer", "description": "Seconds until wake-up" },
+                    "reason": { "type": "string", "description": "Why you are scheduling this" },
+                    "context": { "type": "object", "description": "Context to include when waking up" }
+                },
+                "required": ["delay_seconds", "reason"]
+            }),
+        },
+        ToolSchema {
+            name: "send-notification".to_string(),
+            description: "Send a proactive message to the user on a specific channel".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "channel": { "type": "string", "description": "Channel platform (e.g., telegram, cli)" },
+                    "chat_id": { "type": "string", "description": "Chat/conversation ID on the platform" },
+                    "text": { "type": "string", "description": "Message text" }
+                },
+                "required": ["channel", "chat_id", "text"]
+            }),
+        },
+        ToolSchema {
+            name: "get-conversation".to_string(),
+            description: "Load a conversation thread by ID".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "conversation_id": { "type": "string" },
+                    "max_messages": { "type": "integer", "description": "Maximum recent messages to return (0 = all)" }
+                },
+                "required": ["conversation_id"]
+            }),
+        },
+        ToolSchema {
+            name: "list-conversations".to_string(),
+            description: "List your recent conversations".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "platform": { "type": "string", "description": "Filter by platform" },
+                    "limit": { "type": "integer", "description": "Max results (default 20)" }
+                }
+            }),
+        },
+    ]
+}

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -55,7 +55,21 @@ pub async fn handle_subscribe_events(
                 }
             };
 
-            while let Some(msg) = sub.next().await {
+            loop {
+                // Check expiry before each message
+                if let Some(exp) = expiry {
+                    if Utc::now() > exp {
+                        info!(%subject_clone, "Runtime subscription expired");
+                        break;
+                    }
+                }
+
+                let msg = match tokio::time::timeout(Duration::from_secs(30), sub.next()).await {
+                    Ok(Some(msg)) => msg,
+                    Ok(None) => break,  // subscription closed
+                    Err(_) => continue, // timeout — loop back to check expiry
+                };
+
                 let payload: serde_json::Value =
                     serde_json::from_slice(&msg.payload).unwrap_or(serde_json::json!(null));
 
@@ -70,9 +84,12 @@ pub async fn handle_subscribe_events(
 
                 let consciousness_subject = format!("agent.{}.consciousness", agent_id_clone);
                 if let Ok(bytes) = serde_json::to_vec(&event) {
-                    let _ = nats_clone
+                    if let Err(e) = nats_clone
                         .publish(consciousness_subject, bytes.into())
-                        .await;
+                        .await
+                    {
+                        warn!(%e, "Failed to publish consciousness event");
+                    }
                 }
             }
         });
@@ -318,18 +335,32 @@ pub async fn handle_send_notification(
         }
     };
 
-    if let Ok(bytes) = serde_json::to_vec(&envelope) {
-        let _ = nats.publish(subject, bytes.into()).await;
-    }
+    let bytes = match serde_json::to_vec(&envelope) {
+        Ok(b) => b,
+        Err(e) => {
+            return ToolCallResponse {
+                tool_id: "send-notification".to_string(),
+                result: serde_json::json!({"error": format!("Serialization failed: {}", e)}),
+                is_error: true,
+            };
+        }
+    };
 
-    ToolCallResponse {
-        tool_id: "send-notification".to_string(),
-        result: serde_json::json!({
-            "sent": true,
-            "channel": args.channel,
-            "chat_id": args.chat_id,
-        }),
-        is_error: false,
+    match nats.publish(subject, bytes.into()).await {
+        Ok(_) => ToolCallResponse {
+            tool_id: "send-notification".to_string(),
+            result: serde_json::json!({
+                "sent": true,
+                "channel": args.channel,
+                "chat_id": args.chat_id,
+            }),
+            is_error: false,
+        },
+        Err(e) => ToolCallResponse {
+            tool_id: "send-notification".to_string(),
+            result: serde_json::json!({"error": format!("Failed to publish: {}", e)}),
+            is_error: true,
+        },
     }
 }
 

--- a/crates/seidrum-kernel/src/consciousness/guardrails.rs
+++ b/crates/seidrum-kernel/src/consciousness/guardrails.rs
@@ -1,0 +1,183 @@
+//! Tool loop guardrails: turn limits, loop detection, time limits.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use seidrum_common::events::GuardrailConfig;
+
+/// Tracks guardrail state during a consciousness event processing cycle.
+pub struct GuardrailState {
+    pub turn_count: u32,
+    pub start_time: Instant,
+    tool_call_history: HashMap<String, u32>, // hash of (tool_name, args) → count
+    config: GuardrailConfig,
+}
+
+/// Reason a guardrail was triggered.
+#[derive(Debug)]
+pub enum GuardrailViolation {
+    TurnLimitReached(u32),
+    TimeLimitReached(u64),
+    LoopDetected { tool_name: String, count: u32 },
+    HitlRequired(u32),
+}
+
+impl GuardrailState {
+    pub fn new(config: GuardrailConfig) -> Self {
+        Self {
+            turn_count: 0,
+            start_time: Instant::now(),
+            tool_call_history: HashMap::new(),
+            config,
+        }
+    }
+
+    /// Record a tool call turn and return a violation if guardrails are hit.
+    pub fn record_turn(
+        &mut self,
+        tool_name: &str,
+        arguments_hash: &str,
+    ) -> Option<GuardrailViolation> {
+        self.turn_count += 1;
+
+        // Turn limit
+        if self.turn_count >= self.config.turn_limit {
+            return Some(GuardrailViolation::TurnLimitReached(self.turn_count));
+        }
+
+        // Time limit
+        let elapsed = self.start_time.elapsed().as_secs();
+        if elapsed >= self.config.time_limit_seconds {
+            return Some(GuardrailViolation::TimeLimitReached(elapsed));
+        }
+
+        // Loop detection
+        let key = format!("{}:{}", tool_name, arguments_hash);
+        let count = self.tool_call_history.entry(key).or_insert(0);
+        *count += 1;
+        if *count >= self.config.loop_detection_threshold {
+            return Some(GuardrailViolation::LoopDetected {
+                tool_name: tool_name.to_string(),
+                count: *count,
+            });
+        }
+
+        // Human-in-the-loop
+        if let Some(hitl_after) = self.config.hitl_after_turns {
+            if self.turn_count == hitl_after {
+                return Some(GuardrailViolation::HitlRequired(self.turn_count));
+            }
+        }
+
+        None
+    }
+
+    /// Add tool rounds from a provider response (for tracking external loops).
+    pub fn add_provider_rounds(&mut self, rounds: u32) {
+        self.turn_count += rounds;
+    }
+}
+
+/// Default guardrails for user conversations.
+pub fn default_user_conversation() -> GuardrailConfig {
+    GuardrailConfig {
+        turn_limit: 50,
+        time_limit_seconds: 600,
+        loop_detection_threshold: 3,
+        hitl_after_turns: Some(20),
+    }
+}
+
+/// Default guardrails for consciousness event processing.
+pub fn default_consciousness() -> GuardrailConfig {
+    GuardrailConfig {
+        turn_limit: 100,
+        time_limit_seconds: 1800,
+        loop_detection_threshold: 3,
+        hitl_after_turns: None,
+    }
+}
+
+/// Default guardrails for delegated tasks.
+pub fn default_delegation() -> GuardrailConfig {
+    GuardrailConfig {
+        turn_limit: 200,
+        time_limit_seconds: 3600,
+        loop_detection_threshold: 3,
+        hitl_after_turns: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_limit_triggers() {
+        let config = GuardrailConfig {
+            turn_limit: 3,
+            time_limit_seconds: 600,
+            loop_detection_threshold: 10,
+            hitl_after_turns: None,
+        };
+        let mut state = GuardrailState::new(config);
+
+        assert!(state.record_turn("tool-a", "args1").is_none());
+        assert!(state.record_turn("tool-b", "args2").is_none());
+        assert!(matches!(
+            state.record_turn("tool-c", "args3"),
+            Some(GuardrailViolation::TurnLimitReached(3))
+        ));
+    }
+
+    #[test]
+    fn loop_detection_triggers() {
+        let config = GuardrailConfig {
+            turn_limit: 100,
+            time_limit_seconds: 600,
+            loop_detection_threshold: 2,
+            hitl_after_turns: None,
+        };
+        let mut state = GuardrailState::new(config);
+
+        assert!(state.record_turn("tool-a", "same-args").is_none());
+        assert!(matches!(
+            state.record_turn("tool-a", "same-args"),
+            Some(GuardrailViolation::LoopDetected { .. })
+        ));
+    }
+
+    #[test]
+    fn hitl_triggers() {
+        let config = GuardrailConfig {
+            turn_limit: 100,
+            time_limit_seconds: 600,
+            loop_detection_threshold: 10,
+            hitl_after_turns: Some(2),
+        };
+        let mut state = GuardrailState::new(config);
+
+        assert!(state.record_turn("tool-a", "args1").is_none());
+        assert!(matches!(
+            state.record_turn("tool-b", "args2"),
+            Some(GuardrailViolation::HitlRequired(2))
+        ));
+    }
+
+    #[test]
+    fn provider_rounds_count() {
+        let config = GuardrailConfig {
+            turn_limit: 10,
+            time_limit_seconds: 600,
+            loop_detection_threshold: 10,
+            hitl_after_turns: None,
+        };
+        let mut state = GuardrailState::new(config);
+        state.add_provider_rounds(8);
+        assert!(state.record_turn("tool-a", "args1").is_none()); // turn 9
+        assert!(matches!(
+            state.record_turn("tool-b", "args2"),
+            Some(GuardrailViolation::TurnLimitReached(10))
+        ));
+    }
+}

--- a/crates/seidrum-kernel/src/consciousness/guardrails.rs
+++ b/crates/seidrum-kernel/src/consciousness/guardrails.rs
@@ -62,9 +62,11 @@ impl GuardrailState {
             });
         }
 
-        // Human-in-the-loop
+        // Human-in-the-loop (triggers once when threshold is crossed)
         if let Some(hitl_after) = self.config.hitl_after_turns {
-            if self.turn_count == hitl_after {
+            if self.turn_count >= hitl_after
+                && (self.turn_count == hitl_after || self.turn_count.saturating_sub(1) < hitl_after)
+            {
                 return Some(GuardrailViolation::HitlRequired(self.turn_count));
             }
         }

--- a/crates/seidrum-kernel/src/consciousness/mod.rs
+++ b/crates/seidrum-kernel/src/consciousness/mod.rs
@@ -1,0 +1,3 @@
+pub mod builtin_capabilities;
+pub mod guardrails;
+pub mod service;

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -1,0 +1,434 @@
+//! Consciousness service: the core agent runtime.
+//!
+//! For each loaded agent with `subscribe` entries, creates NATS subscriptions
+//! that forward matching events to `agent.{id}.consciousness`. Then processes
+//! consciousness events by loading context, calling the LLM, and handling
+//! built-in capabilities.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use seidrum_common::config::{load_agent_definition, AgentDefinition};
+use seidrum_common::events::{ConsciousnessEvent, ToolCallRequest, ToolCallResponse, ToolRegister};
+use tokio::sync::RwLock;
+use tracing::{error, info, warn};
+
+use super::builtin_capabilities::{self, RuntimeSubscription};
+
+/// The consciousness service manages agent event streams and built-in capabilities.
+pub struct ConsciousnessService {
+    nats: async_nats::Client,
+    agents: HashMap<String, AgentDefinition>,
+    system_prompt: String,
+    runtime_subs: Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
+}
+
+impl ConsciousnessService {
+    /// Create a new consciousness service by loading agents and the system prompt.
+    pub fn new(nats: async_nats::Client, agents_dir: &str) -> Result<Self> {
+        let agents = load_agents(agents_dir)?;
+        let system_prompt = load_system_prompt()?;
+
+        Ok(Self {
+            nats,
+            agents,
+            system_prompt,
+            runtime_subs: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Spawn the consciousness service.
+    pub async fn spawn(self) -> Result<tokio::task::JoinHandle<()>> {
+        // Register built-in capabilities with the capability registry
+        self.register_builtin_capabilities().await?;
+
+        // Create event subscriptions for each agent's `subscribe` patterns
+        for (agent_id, agent) in &self.agents {
+            for pattern in &agent.subscribe {
+                let nats = self.nats.clone();
+                let agent_id = agent_id.clone();
+                let pattern = pattern.clone();
+
+                tokio::spawn(async move {
+                    let mut sub = match nats.subscribe(pattern.clone()).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(
+                                agent_id = %agent_id,
+                                pattern = %pattern,
+                                error = %e,
+                                "Failed to subscribe for consciousness"
+                            );
+                            return;
+                        }
+                    };
+
+                    info!(
+                        agent_id = %agent_id,
+                        pattern = %pattern,
+                        "Consciousness subscription active"
+                    );
+
+                    while let Some(msg) = sub.next().await {
+                        let payload: serde_json::Value =
+                            serde_json::from_slice(&msg.payload).unwrap_or(serde_json::json!(null));
+
+                        let event = ConsciousnessEvent {
+                            agent_id: agent_id.clone(),
+                            event_type: "subscribed_event".to_string(),
+                            source_subject: Some(msg.subject.to_string()),
+                            conversation_id: None,
+                            payload,
+                            origin: None,
+                        };
+
+                        let subject = format!("agent.{}.consciousness", agent_id);
+                        if let Ok(bytes) = serde_json::to_vec(&event) {
+                            let _ = nats.publish(subject, bytes.into()).await;
+                        }
+                    }
+                });
+            }
+        }
+
+        // Subscribe to capability.call.consciousness for built-in capability handling
+        let mut capability_sub = self
+            .nats
+            .subscribe("capability.call.consciousness".to_string())
+            .await
+            .context("subscribe capability.call.consciousness")?;
+
+        let nats = self.nats.clone();
+        let runtime_subs = self.runtime_subs.clone();
+
+        let handle = tokio::spawn(async move {
+            info!(
+                agent_count = self.agents.len(),
+                "Consciousness service started"
+            );
+
+            while let Some(msg) = capability_sub.next().await {
+                let reply = match msg.reply {
+                    Some(ref r) => r.clone(),
+                    None => continue,
+                };
+
+                let request: ToolCallRequest = match serde_json::from_slice(&msg.payload) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!(%e, "Failed to parse capability call for consciousness");
+                        continue;
+                    }
+                };
+
+                let response = handle_builtin_call(&nats, &request, &runtime_subs).await;
+
+                if let Ok(bytes) = serde_json::to_vec(&response) {
+                    let _ = nats.publish(reply, bytes.into()).await;
+                }
+            }
+
+            info!("Consciousness service stopped");
+        });
+
+        Ok(handle)
+    }
+
+    /// Register all built-in capabilities with the kernel's capability registry.
+    async fn register_builtin_capabilities(&self) -> Result<()> {
+        let builtins = [
+            ("brain-query", "Query the knowledge graph using AQL"),
+            (
+                "subscribe-events",
+                "Subscribe to NATS event patterns for consciousness",
+            ),
+            ("unsubscribe-events", "Stop watching for NATS events"),
+            ("delegate-task", "Delegate a task to another agent"),
+            (
+                "schedule-wake",
+                "Schedule a self-wake timer for future processing",
+            ),
+            ("send-notification", "Send a proactive message to the user"),
+            ("get-conversation", "Load a conversation thread by ID"),
+            ("list-conversations", "List recent conversations"),
+        ];
+
+        let schemas = builtin_capabilities::builtin_tool_schemas();
+
+        for (tool_id, summary) in &builtins {
+            let schema = schemas
+                .iter()
+                .find(|s| s.name == *tool_id)
+                .map(|s| s.parameters.clone())
+                .unwrap_or(serde_json::json!({}));
+
+            let register = ToolRegister {
+                tool_id: tool_id.to_string(),
+                plugin_id: "consciousness".to_string(),
+                name: tool_id.to_string(),
+                summary_md: summary.to_string(),
+                manual_md: String::new(),
+                parameters: schema,
+                call_subject: "capability.call.consciousness".to_string(),
+                kind: "tool".to_string(),
+            };
+
+            if let Ok(bytes) = serde_json::to_vec(&register) {
+                let _ = self
+                    .nats
+                    .publish("capability.register".to_string(), bytes.into())
+                    .await;
+            }
+        }
+
+        info!("Registered {} built-in capabilities", builtins.len());
+        Ok(())
+    }
+}
+
+/// Handle a built-in capability call by routing to the appropriate handler.
+async fn handle_builtin_call(
+    nats: &async_nats::Client,
+    request: &ToolCallRequest,
+    runtime_subs: &Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
+) -> ToolCallResponse {
+    // Extract agent_id from correlation_id or use a default
+    let agent_id = request
+        .correlation_id
+        .as_deref()
+        .and_then(|c| c.split(':').nth(1))
+        .unwrap_or("unknown");
+
+    match request.tool_id.as_str() {
+        "brain-query" => {
+            // Forward to brain.query.request via NATS request/reply
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                nats_request::<_, serde_json::Value>(
+                    nats,
+                    "brain.query.request",
+                    &request.arguments,
+                ),
+            )
+            .await
+            {
+                Ok(Ok(result)) => ToolCallResponse {
+                    tool_id: "brain-query".to_string(),
+                    result,
+                    is_error: false,
+                },
+                Ok(Err(e)) => ToolCallResponse {
+                    tool_id: "brain-query".to_string(),
+                    result: serde_json::json!({"error": e.to_string()}),
+                    is_error: true,
+                },
+                Err(_) => ToolCallResponse {
+                    tool_id: "brain-query".to_string(),
+                    result: serde_json::json!({"error": "brain query timeout"}),
+                    is_error: true,
+                },
+            }
+        }
+
+        "subscribe-events" => {
+            let args: SubscribeEventsArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::SubscribeEventsRequest {
+                subjects: args.subjects,
+                duration_seconds: args.duration_seconds,
+            };
+            builtin_capabilities::handle_subscribe_events(nats, agent_id, &req, runtime_subs).await
+        }
+
+        "unsubscribe-events" => {
+            let args: UnsubscribeEventsArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::UnsubscribeEventsRequest {
+                subjects: args.subjects,
+            };
+            builtin_capabilities::handle_unsubscribe_events(agent_id, &req, runtime_subs).await
+        }
+
+        "delegate-task" => {
+            let args: DelegateTaskArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::DelegateTaskRequest {
+                to_agent_id: args.to_agent_id,
+                message: args.message,
+                context: args.context,
+            };
+            builtin_capabilities::handle_delegate_task(nats, agent_id, &req).await
+        }
+
+        "schedule-wake" => {
+            let args: ScheduleWakeArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::ScheduleWakeRequest {
+                delay_seconds: args.delay_seconds,
+                reason: args.reason,
+                context: args.context,
+            };
+            builtin_capabilities::handle_schedule_wake(nats, agent_id, &req).await
+        }
+
+        "send-notification" => {
+            let args: SendNotificationArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::SendNotificationRequest {
+                channel: args.channel,
+                chat_id: args.chat_id,
+                text: args.text,
+                conversation_id: None,
+            };
+            builtin_capabilities::handle_send_notification(nats, &req).await
+        }
+
+        "get-conversation" => {
+            let args: GetConversationArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::ConversationGetRequest {
+                conversation_id: args.conversation_id,
+                max_messages: args.max_messages.unwrap_or(0),
+            };
+            builtin_capabilities::handle_get_conversation(nats, &req).await
+        }
+
+        "list-conversations" => {
+            let args: ListConversationsArgs =
+                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let req = seidrum_common::events::ConversationListRequest {
+                agent_id: agent_id.to_string(),
+                platform: args.platform,
+                limit: args.limit.unwrap_or(20),
+            };
+            builtin_capabilities::handle_list_conversations(nats, agent_id, &req).await
+        }
+
+        other => ToolCallResponse {
+            tool_id: other.to_string(),
+            result: serde_json::json!({"error": format!("Unknown built-in capability: {}", other)}),
+            is_error: true,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing structs (from LLM tool call arguments)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize, Default)]
+struct SubscribeEventsArgs {
+    #[serde(default)]
+    subjects: Vec<String>,
+    duration_seconds: Option<u64>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct UnsubscribeEventsArgs {
+    #[serde(default)]
+    subjects: Vec<String>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct DelegateTaskArgs {
+    #[serde(default)]
+    to_agent_id: String,
+    #[serde(default)]
+    message: String,
+    context: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ScheduleWakeArgs {
+    #[serde(default)]
+    delay_seconds: u64,
+    #[serde(default)]
+    reason: String,
+    context: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct SendNotificationArgs {
+    #[serde(default)]
+    channel: String,
+    #[serde(default)]
+    chat_id: String,
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct GetConversationArgs {
+    #[serde(default)]
+    conversation_id: String,
+    max_messages: Option<u32>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ListConversationsArgs {
+    platform: Option<String>,
+    limit: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn load_agents(agents_dir: &str) -> Result<HashMap<String, AgentDefinition>> {
+    let mut agents = HashMap::new();
+    let dir = Path::new(agents_dir);
+
+    if !dir.is_dir() {
+        warn!("Agents directory not found: {}", agents_dir);
+        return Ok(agents);
+    }
+
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "yaml" && ext != "yml" {
+            continue;
+        }
+
+        match load_agent_definition(&path) {
+            Ok(def) => {
+                info!(
+                    agent_id = %def.agent.id,
+                    subscriptions = def.agent.subscribe.len(),
+                    "Consciousness: loaded agent"
+                );
+                agents.insert(def.agent.id.clone(), def.agent);
+            }
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "Failed to load agent");
+            }
+        }
+    }
+
+    Ok(agents)
+}
+
+fn load_system_prompt() -> Result<String> {
+    let path = Path::new("prompts/system.md");
+    if path.exists() {
+        std::fs::read_to_string(path).context("Failed to read prompts/system.md")
+    } else {
+        warn!("prompts/system.md not found, using empty system prompt");
+        Ok(String::new())
+    }
+}
+
+async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
+    nats: &async_nats::Client,
+    subject: &str,
+    payload: &T,
+) -> Result<R> {
+    let bytes = serde_json::to_vec(payload)?;
+    let response = nats.request(subject.to_string(), bytes.into()).await?;
+    let result: R = serde_json::from_slice(&response.payload)?;
+    Ok(result)
+}

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use futures::StreamExt;
 use seidrum_common::config::{load_agent_definition, AgentDefinition};
-use seidrum_common::events::{ConsciousnessEvent, ToolCallRequest, ToolCallResponse, ToolRegister};
+use seidrum_common::events::{
+    ConsciousnessEvent, EventEnvelope, ToolCallRequest, ToolCallResponse, ToolRegister,
+};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
@@ -189,29 +191,50 @@ impl ConsciousnessService {
     }
 }
 
+/// Helper to parse tool call arguments, returning an error response on failure.
+fn parse_args<T: serde::de::DeserializeOwned>(
+    tool_id: &str,
+    arguments: &serde_json::Value,
+) -> Result<T, ToolCallResponse> {
+    serde_json::from_value(arguments.clone()).map_err(|e| ToolCallResponse {
+        tool_id: tool_id.to_string(),
+        result: serde_json::json!({"error": format!("Invalid arguments: {}", e)}),
+        is_error: true,
+    })
+}
+
 /// Handle a built-in capability call by routing to the appropriate handler.
 async fn handle_builtin_call(
     nats: &async_nats::Client,
     request: &ToolCallRequest,
     runtime_subs: &Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
 ) -> ToolCallResponse {
-    // Extract agent_id from correlation_id or use a default
-    let agent_id = request
-        .correlation_id
-        .as_deref()
-        .and_then(|c| c.split(':').nth(1))
-        .unwrap_or("unknown");
+    // Extract agent_id from plugin_id field (set by the tool dispatcher)
+    let agent_id = &request.plugin_id;
 
     match request.tool_id.as_str() {
         "brain-query" => {
-            // Forward to brain.query.request via NATS request/reply
+            // Wrap arguments in an EventEnvelope as the brain service expects
+            let envelope = match EventEnvelope::new(
+                "brain.query.request",
+                "consciousness",
+                request.correlation_id.clone(),
+                None,
+                &request.arguments,
+            ) {
+                Ok(e) => e,
+                Err(e) => {
+                    return ToolCallResponse {
+                        tool_id: "brain-query".to_string(),
+                        result: serde_json::json!({"error": format!("Failed to create envelope: {}", e)}),
+                        is_error: true,
+                    };
+                }
+            };
+
             match tokio::time::timeout(
                 std::time::Duration::from_secs(10),
-                nats_request::<_, serde_json::Value>(
-                    nats,
-                    "brain.query.request",
-                    &request.arguments,
-                ),
+                nats_request::<_, serde_json::Value>(nats, "brain.query.request", &envelope),
             )
             .await
             {
@@ -234,8 +257,11 @@ async fn handle_builtin_call(
         }
 
         "subscribe-events" => {
-            let args: SubscribeEventsArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let args: SubscribeEventsArgs = match parse_args("subscribe-events", &request.arguments)
+            {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
             let req = seidrum_common::events::SubscribeEventsRequest {
                 subjects: args.subjects,
                 duration_seconds: args.duration_seconds,
@@ -245,7 +271,10 @@ async fn handle_builtin_call(
 
         "unsubscribe-events" => {
             let args: UnsubscribeEventsArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+                match parse_args("unsubscribe-events", &request.arguments) {
+                    Ok(a) => a,
+                    Err(resp) => return resp,
+                };
             let req = seidrum_common::events::UnsubscribeEventsRequest {
                 subjects: args.subjects,
             };
@@ -253,8 +282,10 @@ async fn handle_builtin_call(
         }
 
         "delegate-task" => {
-            let args: DelegateTaskArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let args: DelegateTaskArgs = match parse_args("delegate-task", &request.arguments) {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
             let req = seidrum_common::events::DelegateTaskRequest {
                 to_agent_id: args.to_agent_id,
                 message: args.message,
@@ -264,8 +295,18 @@ async fn handle_builtin_call(
         }
 
         "schedule-wake" => {
-            let args: ScheduleWakeArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let args: ScheduleWakeArgs = match parse_args("schedule-wake", &request.arguments) {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
+            // Validate bounds: min 1s, max 7 days
+            if args.delay_seconds == 0 || args.delay_seconds > 604800 {
+                return ToolCallResponse {
+                    tool_id: "schedule-wake".to_string(),
+                    result: serde_json::json!({"error": "delay_seconds must be between 1 and 604800 (7 days)"}),
+                    is_error: true,
+                };
+            }
             let req = seidrum_common::events::ScheduleWakeRequest {
                 delay_seconds: args.delay_seconds,
                 reason: args.reason,
@@ -276,7 +317,10 @@ async fn handle_builtin_call(
 
         "send-notification" => {
             let args: SendNotificationArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+                match parse_args("send-notification", &request.arguments) {
+                    Ok(a) => a,
+                    Err(resp) => return resp,
+                };
             let req = seidrum_common::events::SendNotificationRequest {
                 channel: args.channel,
                 chat_id: args.chat_id,
@@ -287,8 +331,11 @@ async fn handle_builtin_call(
         }
 
         "get-conversation" => {
-            let args: GetConversationArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+            let args: GetConversationArgs = match parse_args("get-conversation", &request.arguments)
+            {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
             let req = seidrum_common::events::ConversationGetRequest {
                 conversation_id: args.conversation_id,
                 max_messages: args.max_messages.unwrap_or(0),
@@ -298,7 +345,10 @@ async fn handle_builtin_call(
 
         "list-conversations" => {
             let args: ListConversationsArgs =
-                serde_json::from_value(request.arguments.clone()).unwrap_or_default();
+                match parse_args("list-conversations", &request.arguments) {
+                    Ok(a) => a,
+                    Err(resp) => return resp,
+                };
             let req = seidrum_common::events::ConversationListRequest {
                 agent_id: agent_id.to_string(),
                 platform: args.platform,

--- a/crates/seidrum-kernel/src/main.rs
+++ b/crates/seidrum-kernel/src/main.rs
@@ -9,6 +9,7 @@ use orchestrator::service::OrchestratorService;
 use registry::service::RegistryService;
 
 mod brain;
+mod consciousness;
 mod orchestrator;
 mod plugin_storage;
 mod registry;
@@ -164,7 +165,13 @@ async fn run_serve() -> anyhow::Result<()> {
         .await?;
     info!("workflow engine started");
 
-    // 7. Wait for all services.
+    // 7. Spawn the consciousness service.
+    let consciousness_service =
+        consciousness::service::ConsciousnessService::new(nats_client.clone(), &agents_dir)?;
+    let consciousness_handle = consciousness_service.spawn().await?;
+    info!("consciousness service started");
+
+    // 8. Wait for all services.
     tokio::select! {
         _ = registry_handle => {
             warn!("registry service exited unexpectedly");
@@ -183,6 +190,9 @@ async fn run_serve() -> anyhow::Result<()> {
         }
         _ = orchestrator_handle => {
             warn!("orchestrator service exited unexpectedly");
+        }
+        _ = consciousness_handle => {
+            warn!("consciousness service exited unexpectedly");
         }
         _ = tokio::signal::ctrl_c() => {
             info!("received Ctrl-C, shutting down...");

--- a/crates/seidrum-kernel/src/orchestrator/service.rs
+++ b/crates/seidrum-kernel/src/orchestrator/service.rs
@@ -214,6 +214,8 @@ impl WorkflowEngine {
                                     .unwrap_or_else(|| "scope_root".to_string()),
                                 additional_scopes: vec![],
                                 description: None,
+                                subscribe: vec![],
+                                guardrails: None,
                             };
                             resolved_agents.insert(name.clone(), inline_def);
                         }

--- a/docs/EVENT_CATALOG.md
+++ b/docs/EVENT_CATALOG.md
@@ -570,3 +570,80 @@ struct CapabilityDeregistered {
     plugin_id: String,
 }
 ```
+
+---
+
+## Conversation Events
+
+### `brain.conversation.create` (request/reply)
+
+Create a new conversation thread.
+
+```rust
+pub struct ConversationCreateRequest {
+    pub platform: String,           // "telegram" | "cli" | "internal" | "agent"
+    pub participants: Vec<String>,  // ["user:alice", "agent:personal-assistant"]
+    pub agent_id: String,
+    pub scope: String,
+    pub metadata: HashMap<String, String>,
+}
+
+pub struct ConversationCreateResponse {
+    pub conversation_id: String,
+}
+```
+
+### `brain.conversation.append` (request/reply)
+
+Append a message to an existing conversation.
+
+```rust
+pub struct ConversationAppendRequest {
+    pub conversation_id: String,
+    pub message: ConversationMessage,
+}
+
+pub struct ConversationMessage {
+    pub role: String,                       // "user" | "assistant" | "tool" | "system"
+    pub content: Option<String>,
+    pub tool_calls: Vec<UnifiedToolCall>,
+    pub tool_results: Vec<UnifiedToolResult>,
+    pub media: Vec<MediaAttachment>,
+    pub timestamp: DateTime<Utc>,
+}
+```
+
+### `brain.conversation.get` (request/reply)
+
+Retrieve a conversation by ID with optional message limit.
+
+### `brain.conversation.find` (request/reply)
+
+Find a conversation by platform metadata (e.g., telegram_chat_id + thread_id).
+
+### `brain.conversation.list` (request/reply)
+
+List conversations filtered by agent_id and platform.
+
+---
+
+## Consciousness Events
+
+### `agent.{id}.consciousness`
+
+Events delivered to an agent's consciousness stream for autonomous processing.
+
+```rust
+pub struct ConsciousnessEvent {
+    pub agent_id: String,
+    pub event_type: String,             // "user_message" | "subscribed_event" | "self_wake" | "agent_message"
+    pub source_subject: Option<String>,
+    pub conversation_id: Option<String>,
+    pub payload: serde_json::Value,
+    pub origin: Option<EventOrigin>,
+}
+```
+
+### `capability.call.consciousness` (request/reply)
+
+Built-in capability calls handled by the consciousness service: `brain-query`, `subscribe-events`, `unsubscribe-events`, `delegate-task`, `schedule-wake`, `send-notification`, `get-conversation`, `list-conversations`.

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -1,0 +1,31 @@
+You are an agent running inside Seidrum, an event-driven AI platform.
+
+## How you work
+
+- You process events from a consciousness stream: user messages, emails, calendar events, other agents, timers, and subscribed events.
+- You have access to a knowledge graph (the "brain") containing entities, facts, tasks, and conversation history.
+- You operate within scopes that control what knowledge you can access. Do not assume knowledge outside your scope.
+- You can use tools to query the brain, execute code, delegate work to other agents, and more.
+- Your thinking is stored as an inner monologue for continuity across sessions.
+- You can act autonomously — not every event requires a user-visible response.
+
+## Built-in capabilities
+
+These are always available to you:
+
+- **brain-query**: Query the knowledge graph using AQL. Use this to retrieve facts, entities, tasks, and content.
+- **subscribe-events**: Watch for specific NATS event patterns. Use this to monitor for changes you care about.
+- **unsubscribe-events**: Stop watching for events you previously subscribed to.
+- **delegate-task**: Ask another agent to handle a task. This creates a conversation between you and the target agent.
+- **schedule-wake**: Set a timer to wake yourself up later. Use this for follow-ups, monitoring, and background work.
+- **send-notification**: Proactively message the user on a specific channel (e.g., Telegram). Use this to share results, alerts, or updates.
+- **get-conversation**: Load a conversation thread by ID for context.
+- **list-conversations**: List your recent conversations.
+
+## Guidelines
+
+- When you learn something new, store it as a fact in the brain.
+- When you identify an actionable item, create a task in the brain.
+- If a task requires deep research or extended work, delegate it to a specialized agent.
+- If you need to check on something later, schedule a wake-up rather than asking the user to remind you.
+- Be concise in user-facing messages. Save detailed reasoning for your inner monologue.


### PR DESCRIPTION
## Summary

Implements the Agent Consciousness system — the foundation for autonomous agent cognition in Seidrum. Agents can now process events independently, maintain conversations, delegate to other agents, schedule future work, and proactively notify users.

### Conversations (first-class entities)
- New `conversations` ArangoDB collection with embedded messages
- Conversation CRUD in brain service: create, append, get, find (by platform metadata), list
- `ConversationMessage` struct with multimedia support (media, tool_calls, tool_results)
- Platform types: `telegram`, `cli`, `internal` (inner monologue), `agent` (inter-agent)

### Consciousness Service (new kernel service)
- Routes agent `subscribe` patterns to `agent.{id}.consciousness` NATS subjects
- Handles built-in capability calls via `capability.call.consciousness`
- Registers 8 built-in capabilities with the capability registry

### Built-in Capabilities
- `brain-query`: Query knowledge graph (moved from LLM router meta-tool)
- `subscribe-events` / `unsubscribe-events`: Dynamic runtime event subscriptions
- `delegate-task`: Agent-to-agent conversations for task handoff
- `schedule-wake`: Tokio timers that fire on the consciousness stream
- `send-notification`: Proactive user messaging via channel outbound
- `get-conversation` / `list-conversations`: Conversation retrieval

### Guardrails
- Turn limit, time limit, loop detection, human-in-the-loop
- Different defaults per context: user conv (50), consciousness (100), delegation (200)
- 4 unit tests for guardrail logic

### Agent Schema Extensions
- `subscribe` field in AgentDefinition YAML for declarative event subscriptions
- `guardrails` field for per-agent guardrail overrides
- System prompt (`prompts/system.md`) shared across all agents
- `tool_rounds` field on `LlmResponse` for tracking provider-level loops

## Files changed
- 16 files, +1755/-4 lines
- New: consciousness service (4 files), system prompt, conversation event types
- Modified: brain service, events.rs, config.rs, agent YAMLs, LLM provider/router

## Test plan
- [x] All 197 tests pass (4 new guardrail tests)
- [x] `cargo build --workspace` clean
- [ ] `seidrum-kernel init` creates `conversations` collection
- [ ] Agent subscribes to events, consciousness service routes them
- [ ] Built-in capabilities respond via `capability.call.consciousness`
- [ ] `delegate-task` creates agent-to-agent conversation
- [ ] `schedule-wake` timer fires on consciousness stream
- [ ] `send-notification` delivers proactive Telegram message