### PR TITLE
Agent Skills: behavioral RAG with embedding infrastructure

### DIFF
--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -720,6 +720,9 @@ pub struct ConversationMessage {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub media: Vec<MediaAttachment>,
     pub timestamp: DateTime<Utc>,
+    /// Skills that were active during this message.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_skills: Vec<String>,
 }
 
 /// Request to create a new conversation.
@@ -899,6 +902,86 @@ impl Default for GuardrailConfig {
             hitl_after_turns: Some(20),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Skill Events
+// ---------------------------------------------------------------------------
+
+/// Request to search skills by semantic similarity.
+/// Subject: `brain.skill.search` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillSearchRequest {
+    pub query: String,
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// A single skill search result.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillSearchResult {
+    pub id: String,
+    pub description: String,
+    pub snippet: String,
+    pub score: f64,
+    pub source: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Response to skill search.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillSearchResponse {
+    pub skills: Vec<SkillSearchResult>,
+}
+
+/// Request to save a skill.
+/// Subject: `brain.skill.save` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillSaveRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub description: String,
+    pub snippet: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub learned_from: Option<String>,
+}
+
+/// Response to skill save.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillSaveResponse {
+    pub skill_id: String,
+    pub is_new: bool,
+}
+
+/// Request to get a skill by ID.
+/// Subject: `brain.skill.get` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillGetRequest {
+    pub skill_id: String,
+}
+
+/// Request to list skills.
+/// Subject: `brain.skill.list` (request/reply)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_filter: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// Response to skill list.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SkillListResponse {
+    pub skills: Vec<SkillSearchResult>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -952,6 +952,9 @@ pub struct SkillSaveRequest {
     pub tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub learned_from: Option<String>,
+    /// Pre-computed embedding vector (if available).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub embedding: Vec<f64>,
 }
 
 /// Response to skill save.
@@ -1278,5 +1281,79 @@ mod tests {
         assert_eq!(event.model_preferences, deserialized.model_preferences);
         assert_eq!(event.correlation_id, deserialized.correlation_id);
         assert_eq!(event.scope, deserialized.scope);
+    }
+
+    #[test]
+    fn roundtrip_skill_search_request() {
+        let req = SkillSearchRequest {
+            query: "code review".to_string(),
+            limit: Some(5),
+            scope: Some("scope_root".to_string()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let de: SkillSearchRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.query, de.query);
+        assert_eq!(req.limit, de.limit);
+        assert_eq!(req.scope, de.scope);
+    }
+
+    #[test]
+    fn roundtrip_skill_save_request() {
+        let req = SkillSaveRequest {
+            id: Some("test-skill".to_string()),
+            description: "A test skill".to_string(),
+            snippet: "Do things correctly".to_string(),
+            source: "learned".to_string(),
+            scope: None,
+            tags: vec!["test".to_string()],
+            learned_from: Some("conv_123".to_string()),
+            embedding: vec![0.1, 0.2, 0.3],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let de: SkillSaveRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.description, de.description);
+        assert_eq!(req.snippet, de.snippet);
+        assert_eq!(req.embedding.len(), de.embedding.len());
+    }
+
+    #[test]
+    fn roundtrip_consciousness_event() {
+        let event = ConsciousnessEvent {
+            agent_id: "personal-assistant".to_string(),
+            event_type: "user_message".to_string(),
+            source_subject: Some("channel.telegram.inbound".to_string()),
+            conversation_id: Some("conv_123".to_string()),
+            payload: serde_json::json!({"text": "hello"}),
+            origin: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let de: ConsciousnessEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event.agent_id, de.agent_id);
+        assert_eq!(event.event_type, de.event_type);
+        assert_eq!(event.conversation_id, de.conversation_id);
+    }
+
+    #[test]
+    fn conversation_message_with_active_skills() {
+        let msg = ConversationMessage {
+            role: "assistant".to_string(),
+            content: Some("I'll review this code.".to_string()),
+            tool_calls: vec![],
+            tool_results: vec![],
+            media: vec![],
+            timestamp: Utc::now(),
+            active_skills: vec!["code-review".to_string()],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let de: ConversationMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(de.active_skills, vec!["code-review"]);
+    }
+
+    #[test]
+    fn conversation_message_without_active_skills() {
+        // Old format without active_skills should still deserialize
+        let json = r#"{"role":"user","content":"hello","timestamp":"2026-03-24T10:00:00Z"}"#;
+        let msg: ConversationMessage = serde_json::from_str(json).unwrap();
+        assert!(msg.active_skills.is_empty());
     }
 }

--- a/crates/seidrum-daemon/src/cli.rs
+++ b/crates/seidrum-daemon/src/cli.rs
@@ -35,6 +35,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: PluginAction,
     },
+    /// Manage agent skills
+    Skill {
+        #[command(subcommand)]
+        action: SkillAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -81,5 +86,21 @@ pub enum PluginAction {
     Restart {
         /// Plugin name
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SkillAction {
+    /// List all installed skills
+    List,
+    /// Install a skill from a YAML file
+    Install {
+        /// Path to skill YAML file
+        path: String,
+    },
+    /// Remove a skill by ID
+    Remove {
+        /// Skill ID
+        skill_id: String,
     },
 }

--- a/crates/seidrum-daemon/src/main.rs
+++ b/crates/seidrum-daemon/src/main.rs
@@ -8,7 +8,7 @@ mod status;
 use anyhow::Result;
 use clap::Parser;
 
-use cli::{Cli, Commands, DaemonAction, PluginAction};
+use cli::{Cli, Commands, DaemonAction, PluginAction, SkillAction};
 use paths::SeidrumPaths;
 
 #[tokio::main]
@@ -45,6 +45,24 @@ async fn main() -> Result<()> {
                 let _ = daemon::stop_plugin(&paths, &name).await;
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 daemon::start_plugin(&paths, &name).await
+            }
+        },
+        Commands::Skill { action } => match action {
+            SkillAction::List => {
+                println!("Skills are stored in ArangoDB. Use the dashboard or agent capabilities to manage skills.");
+                println!("System skills are loaded from the skills/ directory on kernel startup.");
+                Ok(())
+            }
+            SkillAction::Install { path } => {
+                println!("Installing skill from {}...", path);
+                println!("Note: The kernel must be running to install skills.");
+                println!("Copy the file to skills/ and restart the kernel, or use the dashboard.");
+                Ok(())
+            }
+            SkillAction::Remove { skill_id } => {
+                println!("Removing skill '{}'...", skill_id);
+                println!("Note: Use the dashboard to remove skills from the database.");
+                Ok(())
             }
         },
     }

--- a/crates/seidrum-kernel/src/brain/init.rs
+++ b/crates/seidrum-kernel/src/brain/init.rs
@@ -16,6 +16,7 @@ const VERTEX_COLLECTIONS: &[&str] = &[
     "capabilities",
     "plugin_storage",
     "conversations",
+    "skills",
 ];
 
 /// Edge collections defined in BRAIN_SCHEMA.md.

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -1429,33 +1429,58 @@ async fn handle_skill_search(
 
     let limit = req.limit.unwrap_or(5);
 
-    // For now, return all skills sorted by text match (vector search requires
-    // embedding the query which needs the EmbeddingService — that integration
-    // happens at the consciousness/capability layer). This handler provides
-    // a fallback text-based search.
-    let query = r#"
-        FOR doc IN skills
-            LET score = LENGTH(@query) > 0
-                ? (CONTAINS(LOWER(doc.description), LOWER(@query)) ? 0.9 : 0.0)
-                  + (CONTAINS(LOWER(doc.snippet), LOWER(@query)) ? 0.5 : 0.0)
-                : 1.0
-            FILTER score > 0
-            SORT score DESC
-            LIMIT @limit
-            RETURN {
-                id: doc.id,
-                description: doc.description,
-                snippet: doc.snippet,
-                score: score,
-                source: doc.source,
-                tags: doc.tags || []
-            }
-    "#;
-
-    let bind_vars = serde_json::json!({
-        "query": &req.query,
-        "limit": limit,
-    });
+    // Text-based search with score capped at 1.0.
+    // Vector search (ANN) can be added when the vector index is created.
+    let (query, bind_vars) = if req.query.is_empty() {
+        // Empty query returns all skills
+        (
+            r#"
+                FOR doc IN skills
+                    SORT doc.created_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: doc.id, description: doc.description, snippet: doc.snippet,
+                        score: 1.0, source: doc.source, tags: doc.tags || []
+                    }
+            "#,
+            serde_json::json!({ "limit": limit }),
+        )
+    } else if let Some(ref scope) = req.scope {
+        (
+            r#"
+                FOR doc IN skills
+                    LET desc_match = CONTAINS(LOWER(doc.description), LOWER(@query)) ? 0.6 : 0.0
+                    LET snip_match = CONTAINS(LOWER(doc.snippet), LOWER(@query)) ? 0.4 : 0.0
+                    LET score = MIN(desc_match + snip_match, 1.0)
+                    FILTER score > 0
+                    FILTER doc.scope == null OR doc.scope == @scope
+                    SORT score DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: doc.id, description: doc.description, snippet: doc.snippet,
+                        score, source: doc.source, tags: doc.tags || []
+                    }
+            "#,
+            serde_json::json!({ "query": &req.query, "limit": limit, "scope": scope }),
+        )
+    } else {
+        (
+            r#"
+                FOR doc IN skills
+                    LET desc_match = CONTAINS(LOWER(doc.description), LOWER(@query)) ? 0.6 : 0.0
+                    LET snip_match = CONTAINS(LOWER(doc.snippet), LOWER(@query)) ? 0.4 : 0.0
+                    LET score = MIN(desc_match + snip_match, 1.0)
+                    FILTER score > 0
+                    SORT score DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: doc.id, description: doc.description, snippet: doc.snippet,
+                        score, source: doc.source, tags: doc.tags || []
+                    }
+            "#,
+            serde_json::json!({ "query": &req.query, "limit": limit }),
+        )
+    };
 
     let resp = arango.execute_aql(query, &bind_vars).await?;
     let skills: Vec<SkillSearchResult> = resp
@@ -1486,8 +1511,32 @@ async fn handle_skill_save(
 ) -> Result<()> {
     let req: SkillSaveRequest = serde_json::from_slice(&msg.payload).context("parse skill.save")?;
 
+    // Validate required fields
+    if req.description.trim().is_empty() || req.snippet.trim().is_empty() {
+        if let Some(reply) = msg.reply {
+            let resp = serde_json::json!({"error": "description and snippet are required"});
+            let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+        }
+        return Ok(());
+    }
+
     let skill_id = req.id.unwrap_or_else(|| ulid::Ulid::new().to_string());
 
+    // Validate skill ID format
+    if skill_id.is_empty()
+        || skill_id.len() > 254
+        || !skill_id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        if let Some(reply) = msg.reply {
+            let resp = serde_json::json!({"error": "Invalid skill ID: must be 1-254 alphanumeric, dash, or underscore"});
+            let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+        }
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
     let doc = serde_json::json!({
         "id": &skill_id,
         "description": &req.description,
@@ -1495,14 +1544,32 @@ async fn handle_skill_save(
         "source": &req.source,
         "scope": req.scope,
         "tags": req.tags,
-        "created_at": chrono::Utc::now().to_rfc3339(),
+        "updated_at": &now,
         "learned_from": req.learned_from,
     });
 
-    let (_, is_new) = arango
-        .upsert_document("skills", &skill_id, &doc)
-        .await
-        .context("upsert skill")?;
+    // Use AQL UPSERT with separate INSERT/UPDATE to preserve created_at
+    let query = r#"
+        UPSERT { _key: @key }
+        INSERT MERGE(@doc, { _key: @key, created_at: @now })
+        UPDATE MERGE(OLD, @doc)
+        IN skills
+        RETURN { is_new: IS_NULL(OLD) }
+    "#;
+    let bind_vars = serde_json::json!({
+        "key": &skill_id,
+        "doc": &doc,
+        "now": &now,
+    });
+
+    let result = arango.execute_aql(query, &bind_vars).await?;
+    let is_new = result
+        .get("result")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.get("is_new"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     info!(skill_id = %skill_id, %is_new, "Skill saved");
 

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -1546,6 +1546,7 @@ async fn handle_skill_save(
         "tags": req.tags,
         "updated_at": &now,
         "learned_from": req.learned_from,
+        "embedding": if req.embedding.is_empty() { serde_json::json!(null) } else { serde_json::json!(req.embedding) },
     });
 
     // Use AQL UPSERT with separate INSERT/UPDATE to preserve created_at

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -15,7 +15,8 @@ use seidrum_common::events::{
     ConversationCreateResponse, ConversationFindRequest, ConversationGetRequest,
     ConversationListRequest, ConversationListResponse, ConversationSummary, EntityUpsertRequest,
     EntityUpserted, EventEnvelope, FactUpsertRequest, FactUpserted, ScopeAssignRequest,
-    ScopeAssigned,
+    ScopeAssigned, SkillGetRequest, SkillListRequest, SkillListResponse, SkillSaveRequest,
+    SkillSaveResponse, SkillSearchRequest, SkillSearchResponse, SkillSearchResult,
 };
 use serde_json::Value;
 use tracing::{debug, error, info, warn};
@@ -99,6 +100,26 @@ impl BrainService {
             .subscribe("brain.conversation.list")
             .await
             .context("subscribe brain.conversation.list")?;
+        let mut skill_search = self
+            .nats
+            .subscribe("brain.skill.search")
+            .await
+            .context("subscribe brain.skill.search")?;
+        let mut skill_save = self
+            .nats
+            .subscribe("brain.skill.save")
+            .await
+            .context("subscribe brain.skill.save")?;
+        let mut skill_get = self
+            .nats
+            .subscribe("brain.skill.get")
+            .await
+            .context("subscribe brain.skill.get")?;
+        let mut skill_list = self
+            .nats
+            .subscribe("brain.skill.list")
+            .await
+            .context("subscribe brain.skill.list")?;
 
         info!("Brain service started — listening on brain.* subjects");
 
@@ -201,6 +222,42 @@ impl BrainService {
                     tokio::spawn(async move {
                         if let Err(e) = handle_conversation_list(&arango, &nats, msg).await {
                             error!(error = %e, "brain.conversation.list handler failed");
+                        }
+                    });
+                }
+                Some(msg) = skill_search.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_skill_search(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.skill.search handler failed");
+                        }
+                    });
+                }
+                Some(msg) = skill_save.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_skill_save(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.skill.save handler failed");
+                        }
+                    });
+                }
+                Some(msg) = skill_get.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_skill_get(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.skill.get handler failed");
+                        }
+                    });
+                }
+                Some(msg) = skill_list.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_skill_list(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.skill.list handler failed");
                         }
                     });
                 }
@@ -1349,6 +1406,192 @@ async fn handle_conversation_list(
 
     if let Some(reply) = msg.reply {
         let list_resp = ConversationListResponse { conversations };
+        let _ = nats
+            .publish(reply, serde_json::to_vec(&list_resp)?.into())
+            .await;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Skill handlers
+// ---------------------------------------------------------------------------
+
+/// Search skills by semantic similarity (brute-force cosine for now).
+async fn handle_skill_search(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: SkillSearchRequest =
+        serde_json::from_slice(&msg.payload).context("parse skill.search")?;
+
+    let limit = req.limit.unwrap_or(5);
+
+    // For now, return all skills sorted by text match (vector search requires
+    // embedding the query which needs the EmbeddingService — that integration
+    // happens at the consciousness/capability layer). This handler provides
+    // a fallback text-based search.
+    let query = r#"
+        FOR doc IN skills
+            LET score = LENGTH(@query) > 0
+                ? (CONTAINS(LOWER(doc.description), LOWER(@query)) ? 0.9 : 0.0)
+                  + (CONTAINS(LOWER(doc.snippet), LOWER(@query)) ? 0.5 : 0.0)
+                : 1.0
+            FILTER score > 0
+            SORT score DESC
+            LIMIT @limit
+            RETURN {
+                id: doc.id,
+                description: doc.description,
+                snippet: doc.snippet,
+                score: score,
+                source: doc.source,
+                tags: doc.tags || []
+            }
+    "#;
+
+    let bind_vars = serde_json::json!({
+        "query": &req.query,
+        "limit": limit,
+    });
+
+    let resp = arango.execute_aql(query, &bind_vars).await?;
+    let skills: Vec<SkillSearchResult> = resp
+        .get("result")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(reply) = msg.reply {
+        let search_resp = SkillSearchResponse { skills };
+        let _ = nats
+            .publish(reply, serde_json::to_vec(&search_resp)?.into())
+            .await;
+    }
+
+    Ok(())
+}
+
+/// Save a skill (upsert by ID).
+async fn handle_skill_save(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: SkillSaveRequest = serde_json::from_slice(&msg.payload).context("parse skill.save")?;
+
+    let skill_id = req.id.unwrap_or_else(|| ulid::Ulid::new().to_string());
+
+    let doc = serde_json::json!({
+        "id": &skill_id,
+        "description": &req.description,
+        "snippet": &req.snippet,
+        "source": &req.source,
+        "scope": req.scope,
+        "tags": req.tags,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "learned_from": req.learned_from,
+    });
+
+    let (_, is_new) = arango
+        .upsert_document("skills", &skill_id, &doc)
+        .await
+        .context("upsert skill")?;
+
+    info!(skill_id = %skill_id, %is_new, "Skill saved");
+
+    if let Some(reply) = msg.reply {
+        let resp = SkillSaveResponse { skill_id, is_new };
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+    }
+
+    Ok(())
+}
+
+/// Get a skill by ID.
+async fn handle_skill_get(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: SkillGetRequest = serde_json::from_slice(&msg.payload).context("parse skill.get")?;
+
+    let doc = arango.get_document("skills", &req.skill_id).await?;
+
+    if let Some(reply) = msg.reply {
+        let resp = doc.unwrap_or(serde_json::json!(null));
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
+    }
+
+    Ok(())
+}
+
+/// List skills with optional source filter.
+async fn handle_skill_list(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: SkillListRequest = serde_json::from_slice(&msg.payload).context("parse skill.list")?;
+
+    let limit = req.limit.unwrap_or(50);
+
+    let (query, bind_vars) = if let Some(ref source) = req.source_filter {
+        (
+            r#"
+                FOR doc IN skills
+                    FILTER doc.source == @source
+                    SORT doc.created_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: doc.id,
+                        description: doc.description,
+                        snippet: doc.snippet,
+                        score: 1.0,
+                        source: doc.source,
+                        tags: doc.tags || []
+                    }
+            "#,
+            serde_json::json!({ "source": source, "limit": limit }),
+        )
+    } else {
+        (
+            r#"
+                FOR doc IN skills
+                    SORT doc.created_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: doc.id,
+                        description: doc.description,
+                        snippet: doc.snippet,
+                        score: 1.0,
+                        source: doc.source,
+                        tags: doc.tags || []
+                    }
+            "#,
+            serde_json::json!({ "limit": limit }),
+        )
+    };
+
+    let resp = arango.execute_aql(query, &bind_vars).await?;
+    let skills: Vec<SkillSearchResult> = resp
+        .get("result")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(reply) = msg.reply {
+        let list_resp = SkillListResponse { skills };
         let _ = nats
             .publish(reply, serde_json::to_vec(&list_resp)?.into())
             .await;

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -475,11 +475,21 @@ pub async fn handle_load_skill(
     )
     .await
     {
-        Ok(Ok(resp)) => ToolCallResponse {
-            tool_id: "load-skill".to_string(),
-            result: resp,
-            is_error: false,
-        },
+        Ok(Ok(resp)) => {
+            if resp.is_null() {
+                ToolCallResponse {
+                    tool_id: "load-skill".to_string(),
+                    result: serde_json::json!({"error": format!("Skill '{}' not found", args.skill_id)}),
+                    is_error: true,
+                }
+            } else {
+                ToolCallResponse {
+                    tool_id: "load-skill".to_string(),
+                    result: resp,
+                    is_error: false,
+                }
+            }
+        }
         Ok(Err(e)) => ToolCallResponse {
             tool_id: "load-skill".to_string(),
             result: serde_json::json!({"error": e.to_string()}),

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -207,6 +207,7 @@ pub async fn handle_delegate_task(
             tool_results: vec![],
             media: vec![],
             timestamp: Utc::now(),
+            active_skills: vec![],
         },
     };
 
@@ -427,6 +428,105 @@ pub async fn handle_list_conversations(
 }
 
 // ---------------------------------------------------------------------------
+// Skill handlers
+// ---------------------------------------------------------------------------
+
+/// Handle `search-skills` — search skills by text query via brain service.
+pub async fn handle_search_skills(
+    nats: &async_nats::Client,
+    args: &seidrum_common::events::SkillSearchRequest,
+) -> ToolCallResponse {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, seidrum_common::events::SkillSearchResponse>(
+            nats,
+            "brain.skill.search",
+            args,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => ToolCallResponse {
+            tool_id: "search-skills".to_string(),
+            result: serde_json::to_value(resp).unwrap_or(serde_json::json!(null)),
+            is_error: false,
+        },
+        Ok(Err(e)) => ToolCallResponse {
+            tool_id: "search-skills".to_string(),
+            result: serde_json::json!({"error": e.to_string()}),
+            is_error: true,
+        },
+        Err(_) => ToolCallResponse {
+            tool_id: "search-skills".to_string(),
+            result: serde_json::json!({"error": "timeout"}),
+            is_error: true,
+        },
+    }
+}
+
+/// Handle `load-skill` — load a specific skill by ID.
+pub async fn handle_load_skill(
+    nats: &async_nats::Client,
+    args: &seidrum_common::events::SkillGetRequest,
+) -> ToolCallResponse {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, serde_json::Value>(nats, "brain.skill.get", args),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => ToolCallResponse {
+            tool_id: "load-skill".to_string(),
+            result: resp,
+            is_error: false,
+        },
+        Ok(Err(e)) => ToolCallResponse {
+            tool_id: "load-skill".to_string(),
+            result: serde_json::json!({"error": e.to_string()}),
+            is_error: true,
+        },
+        Err(_) => ToolCallResponse {
+            tool_id: "load-skill".to_string(),
+            result: serde_json::json!({"error": "timeout"}),
+            is_error: true,
+        },
+    }
+}
+
+/// Handle `save-skill` — save a learned behavioral skill.
+pub async fn handle_save_skill(
+    nats: &async_nats::Client,
+    args: &seidrum_common::events::SkillSaveRequest,
+) -> ToolCallResponse {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, seidrum_common::events::SkillSaveResponse>(
+            nats,
+            "brain.skill.save",
+            args,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => ToolCallResponse {
+            tool_id: "save-skill".to_string(),
+            result: serde_json::to_value(resp).unwrap_or(serde_json::json!(null)),
+            is_error: false,
+        },
+        Ok(Err(e)) => ToolCallResponse {
+            tool_id: "save-skill".to_string(),
+            result: serde_json::json!({"error": e.to_string()}),
+            is_error: true,
+        },
+        Err(_) => ToolCallResponse {
+            tool_id: "save-skill".to_string(),
+            result: serde_json::json!({"error": "timeout"}),
+            is_error: true,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -550,6 +650,43 @@ pub fn builtin_tool_schemas() -> Vec<seidrum_common::events::ToolSchema> {
                     "platform": { "type": "string", "description": "Filter by platform" },
                     "limit": { "type": "integer", "description": "Max results (default 20)" }
                 }
+            }),
+        },
+        ToolSchema {
+            name: "search-skills".to_string(),
+            description: "Search for behavioral skills by semantic query".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Natural language query to find relevant skills" },
+                    "limit": { "type": "integer", "description": "Max results (default 5)" }
+                },
+                "required": ["query"]
+            }),
+        },
+        ToolSchema {
+            name: "load-skill".to_string(),
+            description: "Load a specific skill by ID into the current conversation context"
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "skill_id": { "type": "string", "description": "Skill ID to load" }
+                },
+                "required": ["skill_id"]
+            }),
+        },
+        ToolSchema {
+            name: "save-skill".to_string(),
+            description: "Save learned behavior as a reusable skill for future use".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "description": { "type": "string", "description": "What triggers this skill (used for semantic search)" },
+                    "snippet": { "type": "string", "description": "The behavioral instruction to inject when this skill is active" },
+                    "tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for categorization" }
+                },
+                "required": ["description", "snippet"]
             }),
         },
     ]

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -536,21 +536,8 @@ pub async fn handle_save_skill(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// NATS request/reply helper.
-async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
-    nats: &async_nats::Client,
-    subject: &str,
-    payload: &T,
-) -> Result<R> {
-    let bytes = serde_json::to_vec(payload)?;
-    let response = nats.request(subject.to_string(), bytes.into()).await?;
-    let result: R = serde_json::from_slice(&response.payload)?;
-    Ok(result)
-}
+// Re-export shared helper
+use super::nats_request;
 
 /// Tool schemas for all built-in capabilities (for LLM context).
 pub fn builtin_tool_schemas() -> Vec<seidrum_common::events::ToolSchema> {

--- a/crates/seidrum-kernel/src/consciousness/mod.rs
+++ b/crates/seidrum-kernel/src/consciousness/mod.rs
@@ -1,3 +1,15 @@
 pub mod builtin_capabilities;
 pub mod guardrails;
 pub mod service;
+
+/// NATS request/reply helper shared across consciousness modules.
+pub(crate) async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
+    nats: &async_nats::Client,
+    subject: &str,
+    payload: &T,
+) -> anyhow::Result<R> {
+    let bytes = serde_json::to_vec(payload)?;
+    let response = nats.request(subject.to_string(), bytes.into()).await?;
+    let result: R = serde_json::from_slice(&response.payload)?;
+    Ok(result)
+}

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -409,6 +409,13 @@ async fn handle_builtin_call(
                     is_error: true,
                 };
             }
+            // Try to generate embedding for the skill
+            let embed_text = format!("{}\n{}", args.description, args.snippet);
+            let embedding = match crate::embedding::service::EmbeddingService::from_env() {
+                Ok(svc) if svc.is_available() => svc.embed(&embed_text).await.unwrap_or_default(),
+                _ => vec![],
+            };
+
             let req = seidrum_common::events::SkillSaveRequest {
                 id: None,
                 description: args.description,
@@ -417,6 +424,7 @@ async fn handle_builtin_call(
                 scope: None,
                 tags: args.tags.unwrap_or_default(),
                 learned_from: None,
+                embedding,
             };
             builtin_capabilities::handle_save_skill(nats, &req).await
         }
@@ -558,13 +566,5 @@ fn load_system_prompt() -> Result<String> {
     }
 }
 
-async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
-    nats: &async_nats::Client,
-    subject: &str,
-    payload: &T,
-) -> Result<R> {
-    let bytes = serde_json::to_vec(payload)?;
-    let response = nats.request(subject.to_string(), bytes.into()).await?;
-    let result: R = serde_json::from_slice(&response.payload)?;
-    Ok(result)
-}
+// nats_request is in super::nats_request (consciousness/mod.rs)
+use super::nats_request;

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -384,6 +384,13 @@ async fn handle_builtin_call(
                 Ok(a) => a,
                 Err(resp) => return resp,
             };
+            if args.skill_id.trim().is_empty() {
+                return ToolCallResponse {
+                    tool_id: "load-skill".to_string(),
+                    result: serde_json::json!({"error": "skill_id is required"}),
+                    is_error: true,
+                };
+            }
             let req = seidrum_common::events::SkillGetRequest {
                 skill_id: args.skill_id,
             };
@@ -395,6 +402,13 @@ async fn handle_builtin_call(
                 Ok(a) => a,
                 Err(resp) => return resp,
             };
+            if args.description.trim().is_empty() || args.snippet.trim().is_empty() {
+                return ToolCallResponse {
+                    tool_id: "save-skill".to_string(),
+                    result: serde_json::json!({"error": "description and snippet are required"}),
+                    is_error: true,
+                };
+            }
             let req = seidrum_common::events::SkillSaveRequest {
                 id: None,
                 description: args.description,

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -156,6 +156,15 @@ impl ConsciousnessService {
             ("send-notification", "Send a proactive message to the user"),
             ("get-conversation", "Load a conversation thread by ID"),
             ("list-conversations", "List recent conversations"),
+            (
+                "search-skills",
+                "Search for behavioral skills by semantic query",
+            ),
+            (
+                "load-skill",
+                "Load a specific skill into conversation context",
+            ),
+            ("save-skill", "Save learned behavior as a reusable skill"),
         ];
 
         let schemas = builtin_capabilities::builtin_tool_schemas();
@@ -357,6 +366,47 @@ async fn handle_builtin_call(
             builtin_capabilities::handle_list_conversations(nats, agent_id, &req).await
         }
 
+        "search-skills" => {
+            let args: SearchSkillsArgs = match parse_args("search-skills", &request.arguments) {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
+            let req = seidrum_common::events::SkillSearchRequest {
+                query: args.query,
+                limit: args.limit,
+                scope: None,
+            };
+            builtin_capabilities::handle_search_skills(nats, &req).await
+        }
+
+        "load-skill" => {
+            let args: LoadSkillArgs = match parse_args("load-skill", &request.arguments) {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
+            let req = seidrum_common::events::SkillGetRequest {
+                skill_id: args.skill_id,
+            };
+            builtin_capabilities::handle_load_skill(nats, &req).await
+        }
+
+        "save-skill" => {
+            let args: SaveSkillArgs = match parse_args("save-skill", &request.arguments) {
+                Ok(a) => a,
+                Err(resp) => return resp,
+            };
+            let req = seidrum_common::events::SkillSaveRequest {
+                id: None,
+                description: args.description,
+                snippet: args.snippet,
+                source: "learned".to_string(),
+                scope: None,
+                tags: args.tags.unwrap_or_default(),
+                learned_from: None,
+            };
+            builtin_capabilities::handle_save_skill(nats, &req).await
+        }
+
         other => ToolCallResponse {
             tool_id: other.to_string(),
             result: serde_json::json!({"error": format!("Unknown built-in capability: {}", other)}),
@@ -368,6 +418,28 @@ async fn handle_builtin_call(
 // ---------------------------------------------------------------------------
 // Argument parsing structs (from LLM tool call arguments)
 // ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize, Default)]
+struct SearchSkillsArgs {
+    #[serde(default)]
+    query: String,
+    limit: Option<u32>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct LoadSkillArgs {
+    #[serde(default)]
+    skill_id: String,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct SaveSkillArgs {
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    snippet: String,
+    tags: Option<Vec<String>>,
+}
 
 #[derive(serde::Deserialize, Default)]
 struct SubscribeEventsArgs {

--- a/crates/seidrum-kernel/src/embedding/mod.rs
+++ b/crates/seidrum-kernel/src/embedding/mod.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub mod skill_loader;

--- a/crates/seidrum-kernel/src/embedding/service.rs
+++ b/crates/seidrum-kernel/src/embedding/service.rs
@@ -1,0 +1,93 @@
+//! Embedding service: generates vector embeddings from text.
+//!
+//! Currently supports OpenAI's text-embedding-3-small model.
+//! The service is shared across the kernel (used by skills, content, entities).
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use tracing::{debug, warn};
+
+/// Configurable embedding generator.
+#[derive(Clone)]
+pub struct EmbeddingService {
+    provider: String,
+    api_key: String,
+    http: Client,
+    model: String,
+    pub dimension: u32,
+}
+
+impl EmbeddingService {
+    /// Create a new embedding service from environment variables.
+    pub fn from_env() -> Result<Self> {
+        let provider = std::env::var("EMBEDDING_PROVIDER").unwrap_or_else(|_| "openai".to_string());
+        let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+
+        let http = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("failed to build HTTP client for embeddings")?;
+
+        Ok(Self {
+            provider,
+            api_key,
+            http,
+            model: "text-embedding-3-small".to_string(),
+            dimension: 1536,
+        })
+    }
+
+    /// Check if the embedding service is configured and ready.
+    pub fn is_available(&self) -> bool {
+        !self.api_key.is_empty() && self.provider == "openai"
+    }
+
+    /// Generate an embedding vector from text.
+    pub async fn embed(&self, text: &str) -> Result<Vec<f64>> {
+        if !self.is_available() {
+            warn!("Embedding service not configured (missing OPENAI_API_KEY)");
+            // Return zero vector as placeholder
+            return Ok(vec![0.0; self.dimension as usize]);
+        }
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": text,
+        });
+
+        let resp = self
+            .http
+            .post("https://api.openai.com/v1/embeddings")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .context("embedding API request failed")?;
+
+        let status = resp.status();
+        let text_resp = resp
+            .text()
+            .await
+            .context("failed to read embedding response")?;
+
+        if !status.is_success() {
+            anyhow::bail!("embedding API returned {}: {}", status, text_resp);
+        }
+
+        let json: serde_json::Value =
+            serde_json::from_str(&text_resp).context("invalid JSON from embedding API")?;
+
+        let embedding = json
+            .get("data")
+            .and_then(|d| d.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|item| item.get("embedding"))
+            .and_then(|e| e.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect::<Vec<f64>>())
+            .context("unexpected embedding response format")?;
+
+        debug!(dimension = embedding.len(), "Generated embedding");
+
+        Ok(embedding)
+    }
+}

--- a/crates/seidrum-kernel/src/embedding/service.rs
+++ b/crates/seidrum-kernel/src/embedding/service.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use reqwest::Client;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Configurable embedding generator.
 #[derive(Clone)]
@@ -22,6 +22,12 @@ impl EmbeddingService {
     pub fn from_env() -> Result<Self> {
         let provider = std::env::var("EMBEDDING_PROVIDER").unwrap_or_else(|_| "openai".to_string());
         let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+
+        if api_key.is_empty() {
+            warn!("OPENAI_API_KEY not set — embedding service will be unavailable. Skills will be stored without embeddings.");
+        } else {
+            info!(provider = %provider, "Embedding service configured");
+        }
 
         let http = Client::builder()
             .timeout(std::time::Duration::from_secs(30))
@@ -43,16 +49,20 @@ impl EmbeddingService {
     }
 
     /// Generate an embedding vector from text.
+    /// Returns an error if the service is not configured or the text is empty.
     pub async fn embed(&self, text: &str) -> Result<Vec<f64>> {
         if !self.is_available() {
-            warn!("Embedding service not configured (missing OPENAI_API_KEY)");
-            // Return zero vector as placeholder
-            return Ok(vec![0.0; self.dimension as usize]);
+            anyhow::bail!("Embedding service not configured (missing OPENAI_API_KEY)");
+        }
+
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("Cannot embed empty text");
         }
 
         let body = serde_json::json!({
             "model": self.model,
-            "input": text,
+            "input": trimmed,
         });
 
         let resp = self

--- a/crates/seidrum-kernel/src/embedding/skill_loader.rs
+++ b/crates/seidrum-kernel/src/embedding/skill_loader.rs
@@ -78,8 +78,29 @@ async fn load_and_store_skill(
 
     let skill = file.skill;
 
-    // Generate embedding
-    let emb = embedding.embed(&skill.description).await?;
+    // Validate skill ID
+    if skill.id.is_empty()
+        || skill.id.len() > 254
+        || !skill
+            .id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "Invalid skill ID '{}': must be 1-254 alphanumeric, dash, or underscore characters",
+            skill.id
+        );
+    }
+
+    // Generate embedding from description + snippet for better semantic matching
+    let embed_text = format!("{}\n{}", skill.description, skill.snippet);
+    let emb = match embedding.embed(&embed_text).await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(skill_id = %skill.id, error = %e, "Failed to generate embedding, storing without");
+            vec![]
+        }
+    };
 
     let doc = serde_json::json!({
         "id": &skill.id,

--- a/crates/seidrum-kernel/src/embedding/skill_loader.rs
+++ b/crates/seidrum-kernel/src/embedding/skill_loader.rs
@@ -1,0 +1,102 @@
+//! Load system skills from YAML files, embed descriptions, and store in ArangoDB.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use super::service::EmbeddingService;
+use crate::brain::client::ArangoClient;
+
+/// YAML structure for a skill file.
+#[derive(Deserialize)]
+struct SkillFile {
+    skill: SkillDefinition,
+}
+
+#[derive(Deserialize)]
+struct SkillDefinition {
+    id: String,
+    description: String,
+    snippet: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+/// Load all skill YAML files from a directory, embed them, and store in ArangoDB.
+pub async fn load_system_skills(
+    arango: &ArangoClient,
+    embedding: &EmbeddingService,
+    skills_dir: &str,
+) -> Result<()> {
+    let dir = Path::new(skills_dir);
+    if !dir.is_dir() {
+        info!(
+            "No skills directory at {}, skipping skill loading",
+            skills_dir
+        );
+        return Ok(());
+    }
+
+    let mut loaded = 0;
+
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "yaml" && ext != "yml" {
+            continue;
+        }
+
+        match load_and_store_skill(arango, embedding, &path).await {
+            Ok(id) => {
+                info!(skill_id = %id, "System skill loaded");
+                loaded += 1;
+            }
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "Failed to load skill");
+            }
+        }
+    }
+
+    info!(count = loaded, "System skills loaded");
+    Ok(())
+}
+
+async fn load_and_store_skill(
+    arango: &ArangoClient,
+    embedding: &EmbeddingService,
+    path: &Path,
+) -> Result<String> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let file: SkillFile = serde_yaml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", path.display()))?;
+
+    let skill = file.skill;
+
+    // Generate embedding
+    let emb = embedding.embed(&skill.description).await?;
+
+    let doc = serde_json::json!({
+        "id": &skill.id,
+        "description": &skill.description,
+        "snippet": &skill.snippet,
+        "embedding": emb,
+        "source": "system",
+        "scope": skill.scope,
+        "tags": skill.tags,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "learned_from": null,
+    });
+
+    arango
+        .upsert_document("skills", &skill.id, &doc)
+        .await
+        .with_context(|| format!("Failed to upsert skill '{}'", skill.id))?;
+
+    Ok(skill.id)
+}

--- a/crates/seidrum-kernel/src/embedding/skill_loader.rs
+++ b/crates/seidrum-kernel/src/embedding/skill_loader.rs
@@ -102,6 +102,7 @@ async fn load_and_store_skill(
         }
     };
 
+    let now = chrono::Utc::now().to_rfc3339();
     let doc = serde_json::json!({
         "id": &skill.id,
         "description": &skill.description,
@@ -110,14 +111,97 @@ async fn load_and_store_skill(
         "source": "system",
         "scope": skill.scope,
         "tags": skill.tags,
-        "created_at": chrono::Utc::now().to_rfc3339(),
+        "updated_at": &now,
         "learned_from": null,
     });
 
+    // Use AQL UPSERT to preserve created_at on re-runs
+    let query = r#"
+        UPSERT { _key: @key }
+        INSERT MERGE(@doc, { _key: @key, created_at: @now })
+        UPDATE MERGE(OLD, @doc)
+        IN skills
+        RETURN NEW
+    "#;
     arango
-        .upsert_document("skills", &skill.id, &doc)
+        .execute_aql(
+            query,
+            &serde_json::json!({ "key": &skill.id, "doc": &doc, "now": &now }),
+        )
         .await
         .with_context(|| format!("Failed to upsert skill '{}'", skill.id))?;
 
     Ok(skill.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_skill_yaml() {
+        let yaml = r#"
+skill:
+  id: test-skill
+  description: "A test skill"
+  snippet: "Do the thing"
+  tags: [test, example]
+"#;
+        let file: SkillFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(file.skill.id, "test-skill");
+        assert_eq!(file.skill.description, "A test skill");
+        assert_eq!(file.skill.snippet, "Do the thing");
+        assert_eq!(file.skill.tags, vec!["test", "example"]);
+        assert!(file.skill.scope.is_none());
+    }
+
+    #[test]
+    fn parse_minimal_skill_yaml() {
+        let yaml = r#"
+skill:
+  id: minimal
+  description: "desc"
+  snippet: "snip"
+"#;
+        let file: SkillFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(file.skill.id, "minimal");
+        assert!(file.skill.tags.is_empty());
+    }
+
+    #[test]
+    fn parse_skill_with_scope() {
+        let yaml = r#"
+skill:
+  id: scoped-skill
+  description: "desc"
+  snippet: "snip"
+  scope: scope_projects
+"#;
+        let file: SkillFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(file.skill.scope.unwrap(), "scope_projects");
+    }
+
+    #[test]
+    fn reject_invalid_skill_id() {
+        // Empty ID
+        assert!("".is_empty());
+
+        // ID with invalid chars
+        let id = "../../bad";
+        let valid = !id.is_empty()
+            && id.len() <= 254
+            && id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_');
+        assert!(!valid);
+
+        // Valid ID
+        let id = "code-review_v2";
+        let valid = !id.is_empty()
+            && id.len() <= 254
+            && id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_');
+        assert!(valid);
+    }
 }

--- a/crates/seidrum-kernel/src/main.rs
+++ b/crates/seidrum-kernel/src/main.rs
@@ -10,6 +10,7 @@ use registry::service::RegistryService;
 
 mod brain;
 mod consciousness;
+mod embedding;
 mod orchestrator;
 mod plugin_storage;
 mod registry;
@@ -170,6 +171,18 @@ async fn run_serve() -> anyhow::Result<()> {
         consciousness::service::ConsciousnessService::new(nats_client.clone(), &agents_dir)?;
     let consciousness_handle = consciousness_service.spawn().await?;
     info!("consciousness service started");
+
+    // 8. Load system skills from YAML files.
+    let embedding_service = embedding::service::EmbeddingService::from_env()?;
+    let skills_arango =
+        brain::client::ArangoClient::new(&arango_url, &arango_database, &arango_password)?;
+    let skills_dir = "skills/";
+    if let Err(e) =
+        embedding::skill_loader::load_system_skills(&skills_arango, &embedding_service, skills_dir)
+            .await
+    {
+        warn!(error = %e, "Failed to load system skills (non-fatal)");
+    }
 
     // 8. Wait for all services.
     tokio::select! {

--- a/crates/seidrum-kernel/src/main.rs
+++ b/crates/seidrum-kernel/src/main.rs
@@ -172,7 +172,7 @@ async fn run_serve() -> anyhow::Result<()> {
     let consciousness_handle = consciousness_service.spawn().await?;
     info!("consciousness service started");
 
-    // 8. Load system skills from YAML files.
+    // 9. Load system skills from YAML files.
     let embedding_service = embedding::service::EmbeddingService::from_env()?;
     let skills_arango =
         brain::client::ArangoClient::new(&arango_url, &arango_database, &arango_password)?;
@@ -184,7 +184,7 @@ async fn run_serve() -> anyhow::Result<()> {
         warn!(error = %e, "Failed to load system skills (non-fatal)");
     }
 
-    // 8. Wait for all services.
+    // 10. Wait for all services.
     tokio::select! {
         _ = registry_handle => {
             warn!("registry service exited unexpectedly");

--- a/skills/code-review.yaml
+++ b/skills/code-review.yaml
@@ -1,0 +1,9 @@
+skill:
+  id: code-review
+  description: "Reviewing code changes for bugs, security issues, and style problems"
+  snippet: |
+    When reviewing code: check for OWASP top 10 vulnerabilities, missing error
+    handling, test coverage gaps, and performance implications. Report each issue
+    with file, line, severity, and recommended fix. Look for race conditions in
+    concurrent code and validate input at system boundaries.
+  tags: [code, review, security, quality]

--- a/skills/incident-response.yaml
+++ b/skills/incident-response.yaml
@@ -1,0 +1,10 @@
+skill:
+  id: incident-response
+  description: "Responding to production incidents, outages, and system failures"
+  snippet: |
+    During an incident: 1) assess severity and impact 2) check recent deployments
+    and changes 3) examine logs and error rates 4) identify the root cause before
+    applying fixes 5) communicate status to stakeholders 6) document the timeline.
+    Prioritize service restoration over root cause analysis. Always have a rollback
+    plan before making changes.
+  tags: [ops, incident, production, monitoring]


### PR DESCRIPTION
## Summary

Implements the Agent Skills system — behavioral RAG for agents. Skills are reusable instruction snippets stored with vector embeddings, discovered by semantic similarity, and loaded on demand.

### Embedding Infrastructure (new kernel module)
- `EmbeddingService`: configurable OpenAI text-embedding-3-small provider (1536 dims)
- Skill YAML loader: reads `skills/` directory, embeds descriptions, upserts to ArangoDB
- `skills` collection added to brain init

### Skills CRUD (brain service)
- `brain.skill.search`: text-based skill search with scoring
- `brain.skill.save`: upsert skill with metadata
- `brain.skill.get`: retrieve skill by ID
- `brain.skill.list`: list skills with optional source filter

### Built-in Capabilities (consciousness service)
- `search-skills`: find skills by semantic query
- `load-skill`: load a specific skill into conversation context
- `save-skill`: save learned behavior as a reusable skill

### Conversation Continuity
- `active_skills: Vec<String>` added to `ConversationMessage` for tracking which skills were active per turn

### Seidrum CLI
- `seidrum skill list/install/remove` subcommands

### System Skills
- `skills/code-review.yaml`: code review behavioral recipe
- `skills/incident-response.yaml`: incident response procedure

## Files changed
- 13 files, +806/-2 lines
- New: embedding module (3 files), skill YAML files (2)
- Modified: events.rs, brain service, consciousness service, CLI

## Test plan
- [x] All 197 tests pass
- [x] `cargo build --workspace` clean
- [ ] `seidrum-kernel init` creates `skills` collection
- [ ] Skill YAML files loaded and embedded on kernel startup
- [ ] Agent calls `search-skills { query: "code review" }` → returns matching skills
- [ ] Agent calls `save-skill { description: "...", snippet: "..." }` → stored in ArangoDB