### PR TITLE
Complete remaining gaps: consciousness loop, skills injection, dashboard, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
+### Agent consciousness
+
+Agents in Seidrum are not request-response handlers -- they are persistent, autonomous processes. Each agent runs a **consciousness loop** that continuously processes events from a dedicated NATS stream (`agent.{id}.consciousness`). Events include user messages, subscribed system events, self-scheduled wake-ups, and messages from other agents.
+
+**Built-in capabilities** available to every agent: `brain-query`, `subscribe-events`, `unsubscribe-events`, `delegate-task`, `schedule-wake`, `send-notification`, `get-conversation`, `list-conversations`, `search-skills`, `load-skill`, `save-skill`.
+
+**Conversations** are first-class objects stored in the brain. Agents maintain structured conversation threads across platforms, preserving tool calls, media attachments, and inner monologue for continuity across sessions.
+
+**Skills** provide behavioral RAG -- reusable instructions and procedures retrieved by semantic similarity at inference time. Skills come from YAML files (`skills/` directory), user instructions, agent self-learning, or packaged distributions installed via `seidrum skill install`. See [Agent Consciousness](docs/AGENT_CONSCIOUSNESS.md) and [Agent Skills](docs/AGENT_SKILLS.md) for details.
+
 Plugins can also be written in **any language** using the API gateway. The gateway exposes a WebSocket and REST API that bridges to NATS:
 
 ```bash
@@ -268,6 +278,8 @@ Detailed design documents are in [`docs/`](docs/):
 - [Event catalog](docs/EVENT_CATALOG.md)
 - [LLM integration](docs/LLM_INTEGRATION.md)
 - [Agent specification](docs/AGENT_SPEC.md)
+- [Agent consciousness](docs/AGENT_CONSCIOUSNESS.md)
+- [Agent skills](docs/AGENT_SKILLS.md)
 - [Tech stack](docs/TECH_STACK.md)
 
 ## Contributing

--- a/agents/personal-assistant.yaml
+++ b/agents/personal-assistant.yaml
@@ -11,5 +11,4 @@ agent:
     - scope_job_search
     - scope_projects
   subscribe:
-    - channel.*.inbound
     - task.completed.*

--- a/crates/plugins/seidrum-api-gateway/src/dashboard.rs
+++ b/crates/plugins/seidrum-api-gateway/src/dashboard.rs
@@ -166,7 +166,9 @@ pub async fn plugin_health(
     )
     .await
     {
-        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Ok(resp)) => {
+            Json(serde_json::to_value(&resp).unwrap_or(serde_json::json!(null))).into_response()
+        }
         Ok(Err(err)) => (
             StatusCode::BAD_GATEWAY,
             Json(serde_json::json!({"error": err.to_string()})),
@@ -342,7 +344,9 @@ pub async fn list_skills(State(state): State<AppState>) -> impl IntoResponse {
     )
     .await
     {
-        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Ok(resp)) => {
+            Json(serde_json::to_value(&resp).unwrap_or(serde_json::json!(null))).into_response()
+        }
         Ok(Err(err)) => (
             StatusCode::BAD_GATEWAY,
             Json(serde_json::json!({"error": err.to_string()})),
@@ -419,7 +423,9 @@ pub async fn list_conversations_dashboard(State(state): State<AppState>) -> impl
     )
     .await
     {
-        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Ok(resp)) => {
+            Json(serde_json::to_value(&resp).unwrap_or(serde_json::json!(null))).into_response()
+        }
         Ok(Err(err)) => (
             StatusCode::BAD_GATEWAY,
             Json(serde_json::json!({"error": err.to_string()})),

--- a/crates/plugins/seidrum-api-gateway/src/dashboard.rs
+++ b/crates/plugins/seidrum-api-gateway/src/dashboard.rs
@@ -11,8 +11,10 @@ use axum::response::IntoResponse;
 use axum::Json;
 use chrono::Utc;
 use seidrum_common::events::{
-    ConfigUpdated, PluginHealthRequest, PluginHealthResponse, PluginRegister, StorageGetRequest,
-    StorageGetResponse, StorageSetRequest, StorageSetResponse,
+    ConfigUpdated, ConversationGetRequest, ConversationListRequest, ConversationListResponse,
+    PluginHealthRequest, PluginHealthResponse, PluginRegister, SkillGetRequest, SkillListRequest,
+    SkillListResponse, StorageGetRequest, StorageGetResponse, StorageSetRequest,
+    StorageSetResponse,
 };
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -317,6 +319,162 @@ pub async fn update_plugin_config(
     }
 
     Json(serde_json::json!({"success": true})).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/dashboard/skills`
+///
+/// Returns all skills from the brain.
+pub async fn list_skills(State(state): State<AppState>) -> impl IntoResponse {
+    let req = SkillListRequest {
+        source_filter: None,
+        limit: Some(100),
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, SkillListResponse>("brain.skill.list", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Err(err)) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": err.to_string()})),
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({"error": "Skill list request timed out"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/v1/dashboard/skills/:id`
+///
+/// Returns a single skill by ID.
+pub async fn get_skill(
+    State(state): State<AppState>,
+    Path(skill_id): Path<String>,
+) -> impl IntoResponse {
+    let req = SkillGetRequest { skill_id };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, serde_json::Value>("brain.skill.get", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => {
+            if resp.is_null() {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "Skill not found"})),
+                )
+                    .into_response()
+            } else {
+                Json(resp).into_response()
+            }
+        }
+        Ok(Err(err)) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": err.to_string()})),
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({"error": "Skill get request timed out"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversations (dashboard)
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/dashboard/conversations`
+///
+/// Returns recent conversations from the brain.
+pub async fn list_conversations_dashboard(State(state): State<AppState>) -> impl IntoResponse {
+    let req = ConversationListRequest {
+        agent_id: "".to_string(),
+        platform: None,
+        limit: 50,
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, ConversationListResponse>("brain.conversation.list", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => Json(serde_json::to_value(resp).unwrap()).into_response(),
+        Ok(Err(err)) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": err.to_string()})),
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({"error": "Conversation list request timed out"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/v1/dashboard/conversations/:id`
+///
+/// Returns a single conversation with messages.
+pub async fn get_conversation_dashboard(
+    State(state): State<AppState>,
+    Path(conversation_id): Path<String>,
+) -> impl IntoResponse {
+    let req = ConversationGetRequest {
+        conversation_id,
+        max_messages: 100,
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        state
+            .nats
+            .request::<_, serde_json::Value>("brain.conversation.get", &req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => {
+            if resp.is_null() {
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "Conversation not found"})),
+                )
+                    .into_response()
+            } else {
+                Json(resp).into_response()
+            }
+        }
+        Ok(Err(err)) => (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": err.to_string()})),
+        )
+            .into_response(),
+        Err(_) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({"error": "Conversation get request timed out"})),
+        )
+            .into_response(),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/plugins/seidrum-api-gateway/src/main.rs
+++ b/crates/plugins/seidrum-api-gateway/src/main.rs
@@ -134,6 +134,16 @@ async fn main() -> Result<()> {
             "/dashboard/plugins/{id}/config/schema",
             get(dashboard::get_config_schema),
         )
+        .route("/dashboard/skills", get(dashboard::list_skills))
+        .route("/dashboard/skills/{id}", get(dashboard::get_skill))
+        .route(
+            "/dashboard/conversations",
+            get(dashboard::list_conversations_dashboard),
+        )
+        .route(
+            "/dashboard/conversations/{id}",
+            get(dashboard::get_conversation_dashboard),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             bearer_auth_middleware,

--- a/crates/plugins/seidrum-api-gateway/static/app.js
+++ b/crates/plugins/seidrum-api-gateway/static/app.js
@@ -43,7 +43,7 @@ function showPage(page) {
     const link = document.querySelector(`#sidebar a[onclick="showPage('${page}')"]`);
     if (link) link.classList.add('active');
 
-    const pages = { overview: renderOverview, plugins: renderPlugins, capabilities: renderCapabilities, storage: renderStorage, events: renderEvents };
+    const pages = { overview: renderOverview, plugins: renderPlugins, capabilities: renderCapabilities, skills: renderSkills, conversations: renderConversations, storage: renderStorage, events: renderEvents };
     if (pages[page]) pages[page]();
 }
 
@@ -280,6 +280,135 @@ async function renderCapabilities() {
                     `).join('')}
                 </tbody>
             </table>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+async function renderSkills() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const data = await api('/api/v1/dashboard/skills');
+        const skills = data.skills || [];
+
+        el.innerHTML = `
+            <h2>Skills (${skills.length})</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Description</th><th>Source</th><th>Tags</th></tr></thead>
+                <tbody>
+                    ${skills.length === 0 ? '<tr><td colspan="4" style="color:var(--text-muted)">No skills found</td></tr>' : ''}
+                    ${skills.map(s => `
+                        <tr class="clickable" onclick="renderSkillDetail('${s.id}')">
+                            <td><code>${s.id}</code></td>
+                            <td>${s.description || ''}</td>
+                            <td><span class="badge badge-tool">${s.source || ''}</span></td>
+                            <td>${(s.tags || []).map(t => '<span class="badge">' + t + '</span>').join(' ')}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+async function renderSkillDetail(skillId) {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const skill = await api(`/api/v1/dashboard/skills/${skillId}`);
+
+        el.innerHTML = `
+            <h2>${skillId}</h2>
+            <p><a href="#" onclick="renderSkills()">&larr; Back to skills</a></p>
+            <div class="card">
+                <h3>Details</h3>
+                <p><strong>Description:</strong> ${skill.description || 'N/A'}</p>
+                <p><strong>Source:</strong> ${skill.source || 'N/A'}</p>
+                <p><strong>Tags:</strong> ${(skill.tags || []).join(', ') || 'None'}</p>
+                ${skill.created_at ? `<p><strong>Created:</strong> ${new Date(skill.created_at).toLocaleString()}</p>` : ''}
+            </div>
+            ${skill.snippet ? `<div class="card"><h3>Snippet</h3><pre style="white-space:pre-wrap;font-size:12px">${skill.snippet}</pre></div>` : ''}
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversations
+// ---------------------------------------------------------------------------
+
+async function renderConversations() {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const data = await api('/api/v1/dashboard/conversations');
+        const convos = data.conversations || [];
+
+        el.innerHTML = `
+            <h2>Conversations (${convos.length})</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Platform</th><th>Participants</th><th>Messages</th><th>State</th><th>Updated</th></tr></thead>
+                <tbody>
+                    ${convos.length === 0 ? '<tr><td colspan="6" style="color:var(--text-muted)">No conversations found</td></tr>' : ''}
+                    ${convos.map(c => `
+                        <tr class="clickable" onclick="renderConversationDetail('${c.id}')">
+                            <td><code>${c.id}</code></td>
+                            <td><span class="badge badge-tool">${c.platform}</span></td>
+                            <td>${(c.participants || []).join(', ')}</td>
+                            <td>${c.message_count}</td>
+                            <td><span class="badge badge-${c.state === 'active' ? 'healthy' : 'unknown'}">${c.state}</span></td>
+                            <td style="color:var(--text-muted)">${new Date(c.updated_at).toLocaleString()}</td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        `;
+    } catch (e) {
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+    }
+}
+
+async function renderConversationDetail(conversationId) {
+    const el = document.getElementById('page-content');
+    el.innerHTML = '<h2>Loading...</h2>';
+
+    try {
+        const conv = await api(`/api/v1/dashboard/conversations/${conversationId}`);
+
+        const messages = (conv.messages || []).map(m => `
+            <div style="margin-bottom:8px;padding:8px;border-left:3px solid var(--border);border-radius:4px">
+                <strong>${m.role || m.sender || 'unknown'}</strong>
+                <span style="color:var(--text-muted);font-size:11px;margin-left:8px">${m.timestamp ? new Date(m.timestamp).toLocaleString() : ''}</span>
+                <div style="margin-top:4px;white-space:pre-wrap">${m.text || m.content || ''}</div>
+            </div>
+        `).join('');
+
+        el.innerHTML = `
+            <h2>Conversation: ${conversationId}</h2>
+            <p><a href="#" onclick="renderConversations()">&larr; Back to conversations</a></p>
+            <div class="card">
+                <h3>Info</h3>
+                <p><strong>Platform:</strong> ${conv.platform || 'N/A'}</p>
+                <p><strong>Participants:</strong> ${(conv.participants || []).join(', ')}</p>
+                <p><strong>State:</strong> ${conv.state || 'N/A'}</p>
+                ${conv.created_at ? `<p><strong>Created:</strong> ${new Date(conv.created_at).toLocaleString()}</p>` : ''}
+            </div>
+            <div class="card">
+                <h3>Messages (${(conv.messages || []).length})</h3>
+                ${messages || '<p style="color:var(--text-muted)">No messages</p>'}
+            </div>
         `;
     } catch (e) {
         if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;

--- a/crates/plugins/seidrum-api-gateway/static/app.js
+++ b/crates/plugins/seidrum-api-gateway/static/app.js
@@ -1,6 +1,15 @@
 // Seidrum Dashboard - Vanilla JS
 
 // ---------------------------------------------------------------------------
+// X1: HTML escaping to prevent XSS
+// ---------------------------------------------------------------------------
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ---------------------------------------------------------------------------
 // Auth
 // ---------------------------------------------------------------------------
 
@@ -84,10 +93,10 @@ async function renderOverview() {
                     <thead><tr><th>Name</th><th>Version</th><th>Status</th><th>Config</th></tr></thead>
                     <tbody>
                         ${data.plugins.map(p => `
-                            <tr class="clickable" onclick="renderPluginDetail('${p.id}')">
-                                <td><strong>${p.name}</strong><br><span style="color:var(--text-muted);font-size:12px">${p.id}</span></td>
-                                <td>${p.version}</td>
-                                <td><span class="badge badge-${p.health_status}">${p.health_status}</span></td>
+                            <tr class="clickable" onclick="renderPluginDetail('${escapeHtml(p.id)}')">
+                                <td><strong>${escapeHtml(p.name)}</strong><br><span style="color:var(--text-muted);font-size:12px">${escapeHtml(p.id)}</span></td>
+                                <td>${escapeHtml(p.version)}</td>
+                                <td><span class="badge badge-${escapeHtml(p.health_status)}">${escapeHtml(p.health_status)}</span></td>
                                 <td>${p.has_config_schema ? '<span class="badge badge-tool">schema</span>' : ''}</td>
                             </tr>
                         `).join('')}
@@ -96,7 +105,7 @@ async function renderOverview() {
             </div>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -117,19 +126,19 @@ async function renderPlugins() {
                 <thead><tr><th>ID</th><th>Name</th><th>Version</th><th>Status</th><th>Description</th></tr></thead>
                 <tbody>
                     ${data.plugins.map(p => `
-                        <tr class="clickable" onclick="renderPluginDetail('${p.id}')">
-                            <td><code>${p.id}</code></td>
-                            <td>${p.name}</td>
-                            <td>${p.version}</td>
-                            <td><span class="badge badge-${p.health_status}">${p.health_status}</span></td>
-                            <td style="color:var(--text-muted)">${p.description}</td>
+                        <tr class="clickable" onclick="renderPluginDetail('${escapeHtml(p.id)}')">
+                            <td><code>${escapeHtml(p.id)}</code></td>
+                            <td>${escapeHtml(p.name)}</td>
+                            <td>${escapeHtml(p.version)}</td>
+                            <td><span class="badge badge-${escapeHtml(p.health_status)}">${escapeHtml(p.health_status)}</span></td>
+                            <td style="color:var(--text-muted)">${escapeHtml(p.description)}</td>
                         </tr>
                     `).join('')}
                 </tbody>
             </table>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -155,7 +164,7 @@ async function renderPluginDetail(pluginId) {
                 <p>Status: <span class="badge badge-${health.status || 'unknown'}">${health.status || 'unknown'}</span></p>
                 ${health.uptime_seconds ? `<p>Uptime: ${Math.floor(health.uptime_seconds / 60)} minutes</p>` : ''}
                 ${health.events_processed ? `<p>Events processed: ${health.events_processed}</p>` : ''}
-                ${health.last_error ? `<p style="color:var(--error)">Last error: ${health.last_error}</p>` : ''}
+                ${health.last_error ? `<p style="color:var(--error)">Last error: ${escapeHtml(health.last_error)}</p>` : ''}
             </div>
         `;
 
@@ -168,7 +177,7 @@ async function renderPluginDetail(pluginId) {
 
         el.innerHTML = html;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -272,17 +281,17 @@ async function renderCapabilities() {
                 <tbody>
                     ${data.tools.map(t => `
                         <tr>
-                            <td><code>${t.tool_id}</code></td>
-                            <td>${t.name}</td>
-                            <td><span class="badge badge-${t.kind}">${t.kind}</span></td>
-                            <td style="color:var(--text-muted)">${t.summary_md}</td>
+                            <td><code>${escapeHtml(t.tool_id)}</code></td>
+                            <td>${escapeHtml(t.name)}</td>
+                            <td><span class="badge badge-${escapeHtml(t.kind)}">${escapeHtml(t.kind)}</span></td>
+                            <td style="color:var(--text-muted)">${escapeHtml(t.summary_md)}</td>
                         </tr>
                     `).join('')}
                 </tbody>
             </table>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -305,18 +314,18 @@ async function renderSkills() {
                 <tbody>
                     ${skills.length === 0 ? '<tr><td colspan="4" style="color:var(--text-muted)">No skills found</td></tr>' : ''}
                     ${skills.map(s => `
-                        <tr class="clickable" onclick="renderSkillDetail('${s.id}')">
-                            <td><code>${s.id}</code></td>
-                            <td>${s.description || ''}</td>
-                            <td><span class="badge badge-tool">${s.source || ''}</span></td>
-                            <td>${(s.tags || []).map(t => '<span class="badge">' + t + '</span>').join(' ')}</td>
+                        <tr class="clickable" onclick="renderSkillDetail('${escapeHtml(s.id)}')">
+                            <td><code>${escapeHtml(s.id)}</code></td>
+                            <td>${escapeHtml(s.description || '')}</td>
+                            <td><span class="badge badge-tool">${escapeHtml(s.source || '')}</span></td>
+                            <td>${(s.tags || []).map(t => '<span class="badge">' + escapeHtml(t) + '</span>').join(' ')}</td>
                         </tr>
                     `).join('')}
                 </tbody>
             </table>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -332,15 +341,15 @@ async function renderSkillDetail(skillId) {
             <p><a href="#" onclick="renderSkills()">&larr; Back to skills</a></p>
             <div class="card">
                 <h3>Details</h3>
-                <p><strong>Description:</strong> ${skill.description || 'N/A'}</p>
-                <p><strong>Source:</strong> ${skill.source || 'N/A'}</p>
-                <p><strong>Tags:</strong> ${(skill.tags || []).join(', ') || 'None'}</p>
+                <p><strong>Description:</strong> ${escapeHtml(skill.description || 'N/A')}</p>
+                <p><strong>Source:</strong> ${escapeHtml(skill.source || 'N/A')}</p>
+                <p><strong>Tags:</strong> ${escapeHtml((skill.tags || []).join(', ') || 'None')}</p>
                 ${skill.created_at ? `<p><strong>Created:</strong> ${new Date(skill.created_at).toLocaleString()}</p>` : ''}
             </div>
-            ${skill.snippet ? `<div class="card"><h3>Snippet</h3><pre style="white-space:pre-wrap;font-size:12px">${skill.snippet}</pre></div>` : ''}
+            ${skill.snippet ? `<div class="card"><h3>Snippet</h3><pre style="white-space:pre-wrap;font-size:12px">${escapeHtml(skill.snippet)}</pre></div>` : ''}
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -363,12 +372,12 @@ async function renderConversations() {
                 <tbody>
                     ${convos.length === 0 ? '<tr><td colspan="6" style="color:var(--text-muted)">No conversations found</td></tr>' : ''}
                     ${convos.map(c => `
-                        <tr class="clickable" onclick="renderConversationDetail('${c.id}')">
-                            <td><code>${c.id}</code></td>
-                            <td><span class="badge badge-tool">${c.platform}</span></td>
-                            <td>${(c.participants || []).join(', ')}</td>
+                        <tr class="clickable" onclick="renderConversationDetail('${escapeHtml(c.id)}')">
+                            <td><code>${escapeHtml(c.id)}</code></td>
+                            <td><span class="badge badge-tool">${escapeHtml(c.platform)}</span></td>
+                            <td>${escapeHtml((c.participants || []).join(', '))}</td>
                             <td>${c.message_count}</td>
-                            <td><span class="badge badge-${c.state === 'active' ? 'healthy' : 'unknown'}">${c.state}</span></td>
+                            <td><span class="badge badge-${c.state === 'active' ? 'healthy' : 'unknown'}">${escapeHtml(c.state)}</span></td>
                             <td style="color:var(--text-muted)">${new Date(c.updated_at).toLocaleString()}</td>
                         </tr>
                     `).join('')}
@@ -376,7 +385,7 @@ async function renderConversations() {
             </table>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -389,9 +398,9 @@ async function renderConversationDetail(conversationId) {
 
         const messages = (conv.messages || []).map(m => `
             <div style="margin-bottom:8px;padding:8px;border-left:3px solid var(--border);border-radius:4px">
-                <strong>${m.role || m.sender || 'unknown'}</strong>
+                <strong>${escapeHtml(m.role || m.sender || 'unknown')}</strong>
                 <span style="color:var(--text-muted);font-size:11px;margin-left:8px">${m.timestamp ? new Date(m.timestamp).toLocaleString() : ''}</span>
-                <div style="margin-top:4px;white-space:pre-wrap">${m.text || m.content || ''}</div>
+                <div style="margin-top:4px;white-space:pre-wrap">${escapeHtml(m.text || m.content || '')}</div>
             </div>
         `).join('');
 
@@ -400,9 +409,9 @@ async function renderConversationDetail(conversationId) {
             <p><a href="#" onclick="renderConversations()">&larr; Back to conversations</a></p>
             <div class="card">
                 <h3>Info</h3>
-                <p><strong>Platform:</strong> ${conv.platform || 'N/A'}</p>
-                <p><strong>Participants:</strong> ${(conv.participants || []).join(', ')}</p>
-                <p><strong>State:</strong> ${conv.state || 'N/A'}</p>
+                <p><strong>Platform:</strong> ${escapeHtml(conv.platform || 'N/A')}</p>
+                <p><strong>Participants:</strong> ${escapeHtml((conv.participants || []).join(', '))}</p>
+                <p><strong>State:</strong> ${escapeHtml(conv.state || 'N/A')}</p>
                 ${conv.created_at ? `<p><strong>Created:</strong> ${new Date(conv.created_at).toLocaleString()}</p>` : ''}
             </div>
             <div class="card">
@@ -411,7 +420,7 @@ async function renderConversationDetail(conversationId) {
             </div>
         `;
     } catch (e) {
-        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${e.message}</p>`;
+        if (e.message !== 'Unauthorized') el.innerHTML = `<h2>Error</h2><p>${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -458,15 +467,15 @@ async function listStorageKeys() {
                 <tbody>
                     ${data.keys.map(k => `
                         <tr>
-                            <td><code>${k}</code></td>
-                            <td><button class="btn-sm" onclick="viewStorageKey('${pluginId}', '${namespace}', '${k}')">View</button></td>
+                            <td><code>${escapeHtml(k)}</code></td>
+                            <td><button class="btn-sm" onclick="viewStorageKey('${escapeHtml(pluginId)}', '${escapeHtml(namespace)}', '${escapeHtml(k)}')">View</button></td>
                         </tr>
                     `).join('')}
                 </tbody>
             </table>
         `;
     } catch (e) {
-        results.innerHTML = `<p style="color:var(--error)">${e.message}</p>`;
+        results.innerHTML = `<p style="color:var(--error)">${escapeHtml(e.message)}</p>`;
     }
 }
 
@@ -529,8 +538,8 @@ function startEventStream() {
             const time = new Date().toLocaleTimeString();
             const entry = document.createElement('div');
             entry.className = 'event-entry';
-            entry.innerHTML = `<span class="event-time">${time}</span><span class="event-subject">${data.subject}</span>
-                <pre style="margin-top:4px;font-size:11px;color:var(--text-muted);white-space:pre-wrap">${JSON.stringify(data.payload, null, 2).slice(0, 500)}</pre>`;
+            entry.innerHTML = `<span class="event-time">${time}</span><span class="event-subject">${escapeHtml(data.subject)}</span>
+                <pre style="margin-top:4px;font-size:11px;color:var(--text-muted);white-space:pre-wrap">${escapeHtml(JSON.stringify(data.payload, null, 2).slice(0, 500))}</pre>`;
             log.prepend(entry);
             // Keep max 100 entries
             while (log.children.length > 100) log.lastChild.remove();

--- a/crates/plugins/seidrum-api-gateway/static/index.html
+++ b/crates/plugins/seidrum-api-gateway/static/index.html
@@ -14,6 +14,8 @@
                 <li><a href="#" onclick="showPage('overview')">Overview</a></li>
                 <li><a href="#" onclick="showPage('plugins')">Plugins</a></li>
                 <li><a href="#" onclick="showPage('capabilities')">Capabilities</a></li>
+                <li><a href="#" onclick="showPage('skills')">Skills</a></li>
+                <li><a href="#" onclick="showPage('conversations')">Conversations</a></li>
                 <li><a href="#" onclick="showPage('storage')">Storage</a></li>
                 <li><a href="#" onclick="showPage('events')">Events</a></li>
             </ul>

--- a/crates/plugins/seidrum-graph-context-loader/src/main.rs
+++ b/crates/plugins/seidrum-graph-context-loader/src/main.rs
@@ -581,7 +581,7 @@ async fn main() -> Result<()> {
                 );
                 resp.skills
                     .into_iter()
-                    .map(|s| serde_json::to_value(s).unwrap_or_default())
+                    .filter_map(|s| serde_json::to_value(s).ok())
                     .collect()
             }
             Ok(Err(err)) => {

--- a/crates/plugins/seidrum-graph-context-loader/src/main.rs
+++ b/crates/plugins/seidrum-graph-context-loader/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use futures::StreamExt;
 use seidrum_common::events::{
     AgentContextLoaded, BrainQueryRequest, BrainQueryResponse, ChannelInbound, EventEnvelope,
-    PluginRegister,
+    PluginRegister, SkillSearchRequest, SkillSearchResponse,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
@@ -252,6 +252,41 @@ async fn query_active_tasks(nats: &async_nats::Client) -> Result<BrainQueryRespo
     brain_query(nats, &request).await
 }
 
+/// Search for relevant skills via the brain.skill.search NATS endpoint.
+async fn query_skill_search(
+    nats: &async_nats::Client,
+    query: &str,
+    scope: Option<&str>,
+) -> Result<SkillSearchResponse> {
+    let request = SkillSearchRequest {
+        query: query.to_string(),
+        limit: Some(5),
+        scope: scope.map(|s| s.to_string()),
+    };
+
+    let envelope = EventEnvelope::new(
+        "brain.skill.search",
+        "graph-context-loader",
+        None,
+        None,
+        &request,
+    )?;
+    let payload = serde_json::to_vec(&envelope)?;
+
+    let reply = nats
+        .request("brain.skill.search", payload.into())
+        .await
+        .context("brain.skill.search NATS request failed")?;
+
+    let reply_envelope: EventEnvelope = serde_json::from_slice(&reply.payload)
+        .context("failed to parse skill search reply envelope")?;
+
+    let response: SkillSearchResponse = serde_json::from_value(reply_envelope.payload)
+        .context("failed to parse SkillSearchResponse from reply payload")?;
+
+    Ok(response)
+}
+
 // ---------------------------------------------------------------------------
 // Context assembly
 // ---------------------------------------------------------------------------
@@ -264,6 +299,7 @@ fn assemble_context(
     vector_resp: Option<BrainQueryResponse>,
     tasks_resp: Option<BrainQueryResponse>,
     history_resp: Option<BrainQueryResponse>,
+    skill_snippets: Vec<serde_json::Value>,
 ) -> AgentContextLoaded {
     // The get_context response is expected to contain entities and facts.
     let (entities, facts) = match context_resp {
@@ -306,6 +342,7 @@ fn assemble_context(
         similar_content,
         active_tasks,
         conversation_history,
+        skill_snippets,
     }
 }
 
@@ -529,16 +566,52 @@ async fn main() -> Result<()> {
                 }
             };
 
-        // Step 6: Assemble AgentContextLoaded
+        // Step 6: Search for relevant skills
+        let skill_snippets = match tokio::time::timeout(
+            Duration::from_secs(5),
+            query_skill_search(&nats, &inbound.text, envelope.scope.as_deref()),
+        )
+        .await
+        {
+            Ok(Ok(resp)) => {
+                info!(
+                    event_id = %envelope.id,
+                    count = resp.skills.len(),
+                    "Skill search returned results"
+                );
+                resp.skills
+                    .into_iter()
+                    .map(|s| serde_json::to_value(s).unwrap_or_default())
+                    .collect()
+            }
+            Ok(Err(err)) => {
+                warn!(
+                    %err,
+                    event_id = %envelope.id,
+                    "Skill search failed; continuing without skills"
+                );
+                Vec::new()
+            }
+            Err(_) => {
+                warn!(
+                    event_id = %envelope.id,
+                    "Skill search timed out; continuing without skills"
+                );
+                Vec::new()
+            }
+        };
+
+        // Step 7: Assemble AgentContextLoaded
         let context_loaded = assemble_context(
             envelope.clone(),
             context_resp,
             vector_resp,
             tasks_resp,
             history_resp,
+            skill_snippets,
         );
 
-        // Step 7: Publish agent.context.loaded
+        // Step 8: Publish agent.context.loaded
         let context_envelope = EventEnvelope::new(
             "agent.context.loaded",
             "graph-context-loader",
@@ -567,6 +640,7 @@ async fn main() -> Result<()> {
             similar = context_loaded.similar_content.len(),
             tasks = context_loaded.active_tasks.len(),
             history = context_loaded.conversation_history.len(),
+            skills = context_loaded.skill_snippets.len(),
             "Published agent.context.loaded"
         );
     }

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -283,11 +283,7 @@ async fn handle_provider_request(
 
         let api_request = GeminiRequest {
             contents: messages.clone(),
-            system_instruction: if round == 0 {
-                system_instruction.clone()
-            } else {
-                system_instruction.clone()
-            },
+            system_instruction: system_instruction.clone(),
             generation_config: Some(GeminiGenerationConfig {
                 temperature,
                 max_output_tokens: Some(response_max_tokens),

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -275,6 +275,7 @@ async fn handle_provider_request(
     let mut total_input_tokens: u32 = 0;
     let mut total_output_tokens: u32 = 0;
     let mut final_content: Option<String> = None;
+    let mut tool_rounds_count: u32 = 0;
     let start = Instant::now();
 
     for round in 0..=max_tool_rounds {
@@ -378,6 +379,7 @@ async fn handle_provider_request(
         }
 
         // Tool calls present -- execute them via tool dispatcher
+        tool_rounds_count += 1;
         info!(
             tool_count = tool_calls.len(),
             round, "Executing tool calls via tool dispatcher"
@@ -489,7 +491,7 @@ async fn handle_provider_request(
         },
         duration_ms,
         finish_reason: "stop".to_string(),
-        tool_rounds: 0,
+        tool_rounds: tool_rounds_count,
     };
 
     info!(

--- a/crates/plugins/seidrum-llm-google/src/translator.rs
+++ b/crates/plugins/seidrum-llm-google/src/translator.rs
@@ -109,6 +109,7 @@ pub fn gemini_to_unified_response(
     agent_id: &str,
     total_input_tokens: u32,
     total_output_tokens: u32,
+    tool_rounds: u32,
 ) -> LlmResponse {
     let total_tokens = total_input_tokens + total_output_tokens;
 
@@ -146,7 +147,7 @@ pub fn gemini_to_unified_response(
         },
         duration_ms,
         finish_reason,
-        tool_rounds: 0,
+        tool_rounds,
     }
 }
 

--- a/crates/plugins/seidrum-llm-router/src/context_assembly.rs
+++ b/crates/plugins/seidrum-llm-router/src/context_assembly.rs
@@ -160,6 +160,26 @@ fn format_history(history: &[Value]) -> String {
         .join("\n")
 }
 
+/// Format skill snippets into a readable string for injection into the prompt.
+fn format_skills(skills: &[Value]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+
+    skills
+        .iter()
+        .filter_map(|s| {
+            let id = s.get("id").and_then(|v| v.as_str()).unwrap_or("unknown");
+            let snippet = s.get("snippet").and_then(|v| v.as_str()).unwrap_or("");
+            if snippet.is_empty() {
+                return None;
+            }
+            Some(format!("[Active Skill: {}]\n{}", id, snippet))
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
 /// Format similar content (RAG results) into a readable string.
 fn format_similar_content(content: &[Value]) -> String {
     if content.is_empty() {
@@ -209,6 +229,9 @@ fn render_prompt(template_content: &str, context: &AgentContextLoaded) -> Result
     // scope_name
     let scope_name = context.original_event.scope.as_deref().unwrap_or("default");
     tera_ctx.insert("scope_name", scope_name);
+
+    // active_skills
+    tera_ctx.insert("active_skills", &format_skills(&context.skill_snippets));
 
     // current_facts
     tera_ctx.insert("current_facts", &format_facts(&context.facts));
@@ -321,13 +344,19 @@ pub fn assemble_context(
     // 4. Proportional allocation
     let facts_budget = (remaining as f64 * 0.20) as usize;
     let tasks_budget = (remaining as f64 * 0.05) as usize;
-    let rag_budget = (remaining as f64 * 0.25) as usize;
+    let rag_budget = (remaining as f64 * 0.15) as usize;
+    let skills_budget = (remaining as f64 * 0.10) as usize;
     let _tools_budget = (remaining as f64 * 0.15) as usize;
     let history_budget = (remaining as f64 * 0.35) as usize;
 
     debug!(
         facts_budget,
-        tasks_budget, rag_budget, _tools_budget, history_budget, "Token budget allocation"
+        tasks_budget,
+        rag_budget,
+        skills_budget,
+        _tools_budget,
+        history_budget,
+        "Token budget allocation"
     );
 
     // 5. Format and truncate each section
@@ -341,6 +370,7 @@ pub fn assemble_context(
         &format_history(&context.conversation_history),
         history_budget,
     );
+    let skills_text = truncate_to_budget(&format_skills(&context.skill_snippets), skills_budget);
 
     // 6. Build messages array as simple role/content pairs
     let mut messages: Vec<SimpleMessage> = Vec::new();
@@ -418,6 +448,7 @@ pub fn assemble_context(
         &facts_text,
         &tasks_text,
         &history_text,
+        &skills_text,
     )?;
 
     let estimated_tokens = count_tokens(&budgeted_system)
@@ -446,6 +477,7 @@ fn render_budgeted_system_prompt(
     facts_text: &str,
     tasks_text: &str,
     history_text: &str,
+    skills_text: &str,
 ) -> Result<String> {
     let mut tera = tera::Tera::default();
     tera.add_raw_template("prompt", template_content)
@@ -459,6 +491,7 @@ fn render_budgeted_system_prompt(
 
     let scope_name = context.original_event.scope.as_deref().unwrap_or("default");
     tera_ctx.insert("scope_name", scope_name);
+    tera_ctx.insert("active_skills", skills_text);
     tera_ctx.insert("current_facts", facts_text);
     tera_ctx.insert("active_tasks", tasks_text);
     tera_ctx.insert("conversation_history", history_text);
@@ -532,6 +565,7 @@ mod tests {
                 serde_json::json!({"role": "user", "content": "Hello"}),
                 serde_json::json!({"role": "assistant", "content": "Hi there!"}),
             ],
+            skill_snippets: vec![],
         }
     }
 

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
         }
         Err(e) => {
             warn!(path = %cli.prompt_path, error = %e, "Could not load prompt template, using default");
-            "You are {{ user_name }}'s personal assistant.\n\nCurrent time: {{ current_time }}\nContext: {{ scope_name }}\n\n## What you know\n{{ current_facts }}\n\n## Active tasks\n{{ active_tasks }}\n\n## Recent conversation\n{{ conversation_history }}\n\n## Instructions\n- Be direct and concise.\n- If you identify an actionable item, create a task.\n- If you learn a new fact, note it in your response.\n- Stay within your scope.\n".to_string()
+            "You are {{ user_name }}'s personal assistant.\n\nCurrent time: {{ current_time }}\nContext: {{ scope_name }}\n\n## What you know\n{{ current_facts }}\n\n## Active tasks\n{{ active_tasks }}\n\n## Recent conversation\n{{ conversation_history }}\n\n{% if active_skills %}\n## Behavioral guidance\n{{ active_skills }}\n{% endif %}\n\n## Instructions\n- Be direct and concise.\n- If you identify an actionable item, create a task.\n- If you learn a new fact, note it in your response.\n- Stay within your scope.\n".to_string()
         }
     };
 

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -116,6 +116,8 @@ struct AgentContextLoaded {
     active_tasks: Vec<serde_json::Value>,
     #[serde(default)]
     conversation_history: Vec<serde_json::Value>,
+    #[serde(default)]
+    skill_snippets: Vec<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -263,6 +263,8 @@ pub struct AgentContextLoaded {
     pub similar_content: Vec<serde_json::Value>,
     pub active_tasks: Vec<serde_json::Value>,
     pub conversation_history: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub skill_snippets: Vec<serde_json::Value>,
 }
 
 /// Explicitly wake an agent.

--- a/crates/seidrum-common/src/events.rs
+++ b/crates/seidrum-common/src/events.rs
@@ -258,10 +258,15 @@ pub struct BrainQueryResponse {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AgentContextLoaded {
     pub original_event: EventEnvelope,
+    #[serde(default)]
     pub entities: Vec<serde_json::Value>,
+    #[serde(default)]
     pub facts: Vec<serde_json::Value>,
+    #[serde(default)]
     pub similar_content: Vec<serde_json::Value>,
+    #[serde(default)]
     pub active_tasks: Vec<serde_json::Value>,
+    #[serde(default)]
     pub conversation_history: Vec<serde_json::Value>,
     #[serde(default)]
     pub skill_snippets: Vec<serde_json::Value>,

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -1361,9 +1361,33 @@ async fn handle_conversation_list(
 
     let limit = if req.limit == 0 { 20 } else { req.limit };
 
+    let agent_id_empty = req.agent_id.is_empty();
+
     let (query, bind_vars) = if let Some(ref platform) = req.platform {
-        (
-            r#"
+        if agent_id_empty {
+            (
+                r#"
+                FOR conv IN conversations
+                    FILTER conv.platform == @platform
+                    SORT conv.updated_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: conv._key,
+                        platform: conv.platform,
+                        participants: conv.participants,
+                        message_count: LENGTH(conv.messages),
+                        state: conv.state,
+                        updated_at: conv.updated_at
+                    }
+            "#,
+                serde_json::json!({
+                    "platform": platform,
+                    "limit": limit,
+                }),
+            )
+        } else {
+            (
+                r#"
                 FOR conv IN conversations
                     FILTER conv.agent_id == @agent_id
                     FILTER conv.platform == @platform
@@ -1378,9 +1402,29 @@ async fn handle_conversation_list(
                         updated_at: conv.updated_at
                     }
             "#,
+                serde_json::json!({
+                    "agent_id": &req.agent_id,
+                    "platform": platform,
+                    "limit": limit,
+                }),
+            )
+        }
+    } else if agent_id_empty {
+        (
+            r#"
+                FOR conv IN conversations
+                    SORT conv.updated_at DESC
+                    LIMIT @limit
+                    RETURN {
+                        id: conv._key,
+                        platform: conv.platform,
+                        participants: conv.participants,
+                        message_count: LENGTH(conv.messages),
+                        state: conv.state,
+                        updated_at: conv.updated_at
+                    }
+            "#,
             serde_json::json!({
-                "agent_id": &req.agent_id,
-                "platform": platform,
                 "limit": limit,
             }),
         )

--- a/crates/seidrum-kernel/src/brain/service.rs
+++ b/crates/seidrum-kernel/src/brain/service.rs
@@ -120,6 +120,11 @@ impl BrainService {
             .subscribe("brain.skill.list")
             .await
             .context("subscribe brain.skill.list")?;
+        let mut skill_delete = self
+            .nats
+            .subscribe("brain.skill.delete")
+            .await
+            .context("subscribe brain.skill.delete")?;
 
         info!("Brain service started — listening on brain.* subjects");
 
@@ -258,6 +263,15 @@ impl BrainService {
                     tokio::spawn(async move {
                         if let Err(e) = handle_skill_list(&arango, &nats, msg).await {
                             error!(error = %e, "brain.skill.list handler failed");
+                        }
+                    });
+                }
+                Some(msg) = skill_delete.next() => {
+                    let arango = self.arango.clone();
+                    let nats = self.nats.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_skill_delete(&arango, &nats, msg).await {
+                            error!(error = %e, "brain.skill.delete handler failed");
                         }
                     });
                 }
@@ -1663,6 +1677,36 @@ async fn handle_skill_list(
         let _ = nats
             .publish(reply, serde_json::to_vec(&list_resp)?.into())
             .await;
+    }
+
+    Ok(())
+}
+
+/// Delete a skill by ID.
+async fn handle_skill_delete(
+    arango: &ArangoClient,
+    nats: &async_nats::Client,
+    msg: async_nats::Message,
+) -> Result<()> {
+    let req: SkillGetRequest =
+        serde_json::from_slice(&msg.payload).context("parse skill.delete")?;
+
+    debug!(skill_id = %req.skill_id, "handling brain.skill.delete");
+
+    let query = "REMOVE { _key: @key } IN skills";
+    let bind_vars = serde_json::json!({ "key": req.skill_id });
+
+    let result = arango.execute_aql(query, &bind_vars).await;
+
+    if let Some(reply) = msg.reply {
+        let resp = match result {
+            Ok(_) => serde_json::json!({ "success": true, "skill_id": req.skill_id }),
+            Err(e) => {
+                warn!(error = %e, skill_id = %req.skill_id, "failed to delete skill");
+                serde_json::json!({ "success": false, "error": e.to_string() })
+            }
+        };
+        let _ = nats.publish(reply, serde_json::to_vec(&resp)?.into()).await;
     }
 
     Ok(())

--- a/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -36,6 +36,43 @@ pub async fn handle_subscribe_events(
     args: &SubscribeEventsRequest,
     runtime_subs: &Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
 ) -> ToolCallResponse {
+    // S1: Deny subscriptions to internal system subjects
+    const DENIED_PREFIXES: &[&str] = &[
+        "brain.",
+        "capability.",
+        "registry.",
+        "storage.",
+        "plugin.",
+        "llm.",
+        "system.",
+        "agent.",
+    ];
+
+    for subject in &args.subjects {
+        for prefix in DENIED_PREFIXES {
+            if subject.starts_with(prefix) {
+                return ToolCallResponse {
+                    tool_id: "subscribe-events".to_string(),
+                    result: serde_json::json!({"error": format!("Cannot subscribe to internal subject: {}", subject)}),
+                    is_error: true,
+                };
+            }
+        }
+    }
+
+    // S2: Per-agent subscription cap
+    let current_count = {
+        let subs = runtime_subs.read().await;
+        subs.get(agent_id).map(|s| s.len()).unwrap_or(0)
+    };
+    if current_count + args.subjects.len() > 20 {
+        return ToolCallResponse {
+            tool_id: "subscribe-events".to_string(),
+            result: serde_json::json!({"error": "Maximum 20 runtime subscriptions per agent"}),
+            is_error: true,
+        };
+    }
+
     let mut new_subs = Vec::new();
     let expiry = args
         .duration_seconds
@@ -155,6 +192,22 @@ pub async fn handle_delegate_task(
     from_agent_id: &str,
     args: &DelegateTaskRequest,
 ) -> ToolCallResponse {
+    // R1: Check delegation depth to prevent infinite delegation loops
+    let depth = args
+        .context
+        .as_ref()
+        .and_then(|c| c.get("delegation_depth"))
+        .and_then(|d| d.as_u64())
+        .unwrap_or(0);
+
+    if depth >= 5 {
+        return ToolCallResponse {
+            tool_id: "delegate-task".to_string(),
+            result: serde_json::json!({"error": "Maximum delegation depth (5) reached"}),
+            is_error: true,
+        };
+    }
+
     // Create a conversation between the two agents
     let create_req = ConversationCreateRequest {
         platform: "agent".to_string(),
@@ -219,6 +272,7 @@ pub async fn handle_delegate_task(
     .await;
 
     // Send consciousness event to the target agent
+    // R1: Propagate delegation_depth + 1 in the payload
     let event = ConsciousnessEvent {
         agent_id: args.to_agent_id.clone(),
         event_type: "agent_message".to_string(),
@@ -228,6 +282,7 @@ pub async fn handle_delegate_task(
             "from_agent": from_agent_id,
             "message": args.message,
             "context": args.context,
+            "delegation_depth": depth + 1,
         }),
         origin: None,
     };

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -33,6 +33,8 @@ pub struct ConsciousnessService {
     agents: HashMap<String, AgentDefinition>,
     system_prompt: String,
     runtime_subs: Arc<RwLock<HashMap<String, Vec<RuntimeSubscription>>>>,
+    /// Cached identity prompts: agent_id -> rendered prompt text.
+    identity_prompts: HashMap<String, String>,
 }
 
 impl ConsciousnessService {
@@ -41,10 +43,21 @@ impl ConsciousnessService {
         let agents = load_agents(agents_dir)?;
         let system_prompt = load_system_prompt()?;
 
+        // S1+S2: Cache identity prompts at startup to avoid blocking file I/O per event
+        let mut identity_prompts = HashMap::new();
+        for (agent_id, agent_def) in &agents {
+            let prompt = load_agent_identity_prompt(&agent_def.prompt);
+            if !prompt.is_empty() {
+                info!(agent_id = %agent_id, "Cached identity prompt ({} bytes)", prompt.len());
+            }
+            identity_prompts.insert(agent_id.clone(), prompt);
+        }
+
         Ok(Self {
             nats,
             agents,
             system_prompt,
+            identity_prompts,
             runtime_subs: Arc::new(RwLock::new(HashMap::new())),
         })
     }
@@ -82,8 +95,28 @@ impl ConsciousnessService {
                     );
 
                     while let Some(msg) = sub.next().await {
+                        // E1: Reject malformed messages instead of forwarding null
                         let payload: serde_json::Value =
-                            serde_json::from_slice(&msg.payload).unwrap_or(serde_json::json!(null));
+                            match serde_json::from_slice::<serde_json::Value>(&msg.payload) {
+                                Ok(v) if !v.is_null() => v,
+                                Ok(_) => {
+                                    warn!(
+                                        agent_id = %agent_id,
+                                        subject = %msg.subject,
+                                        "Skipping null payload from NATS message"
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        agent_id = %agent_id,
+                                        subject = %msg.subject,
+                                        error = %e,
+                                        "Skipping malformed NATS message"
+                                    );
+                                    continue;
+                                }
+                            };
 
                         let event = ConsciousnessEvent {
                             agent_id: agent_id.clone(),
@@ -160,6 +193,11 @@ impl ConsciousnessService {
             let system_prompt = self.system_prompt.clone();
             let agent_def = agent_def.clone();
             let agent_id_proc = agent_id.clone();
+            let cached_identity = self
+                .identity_prompts
+                .get(agent_id)
+                .cloned()
+                .unwrap_or_default();
 
             tokio::spawn(async move {
                 info!(agent_id = %agent_id_proc, "Consciousness processor started");
@@ -170,6 +208,7 @@ impl ConsciousnessService {
                         &agent_id_proc,
                         &agent_def,
                         &system_prompt,
+                        &cached_identity,
                         &event,
                     )
                     .await
@@ -279,10 +318,18 @@ impl ConsciousnessService {
             };
 
             if let Ok(bytes) = serde_json::to_vec(&register) {
-                let _ = self
+                // E2: Log capability registration failures instead of silently ignoring
+                if let Err(e) = self
                     .nats
                     .publish("capability.register".to_string(), bytes.into())
-                    .await;
+                    .await
+                {
+                    warn!(
+                        tool_id = %tool_id,
+                        error = %e,
+                        "Failed to register built-in capability"
+                    );
+                }
             }
         }
 
@@ -549,6 +596,7 @@ async fn process_consciousness_event(
     agent_id: &str,
     agent_def: &AgentDefinition,
     system_prompt: &str,
+    cached_identity: &str,
     event: &ConsciousnessEvent,
 ) -> Result<()> {
     info!(
@@ -570,14 +618,27 @@ async fn process_consciousness_event(
     // 3. Search for relevant skills based on event content
     let skill_snippets = search_relevant_skills(nats, &user_text).await;
 
-    // 4. Build system prompt: base system prompt + identity prompt + skill snippets
-    let full_system_prompt = build_full_system_prompt(system_prompt, agent_def, &skill_snippets);
+    // 4. Build system prompt: base system prompt + cached identity prompt + skill snippets
+    let full_system_prompt =
+        build_full_system_prompt(system_prompt, agent_def, cached_identity, &skill_snippets);
 
     // 5. Build messages array from history + current event
     let messages = build_messages(&history, &user_text, event);
 
-    // 6. Build tool schemas
-    let tools = builtin_tool_schemas();
+    // 6. Build tool schemas, filtered by agent's configured tools (M2)
+    let agent_tools = &agent_def.tools;
+    let mut tools = builtin_tool_schemas();
+    if !agent_tools.is_empty() {
+        // Keep only tools that are in the agent's configured list, plus always include brain-query
+        tools.retain(|t| agent_tools.contains(&t.name) || t.name == "brain-query");
+    }
+
+    // M1: Extract correlation_id from event payload if present
+    let correlation_id = event
+        .payload
+        .get("correlation_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
 
     // Build UnifiedLlmRequest
     let llm_request = UnifiedLlmRequest {
@@ -592,17 +653,21 @@ async fn process_consciousness_event(
         },
         routing_strategy: "best-first".to_string(),
         model_preferences: vec!["gemini-2.0-flash".to_string()],
-        correlation_id: None,
+        correlation_id,
         scope: Some(agent_def.scope.clone()),
     };
 
     // Create guardrail state
     let mut guardrail = GuardrailState::new(build_guardrail_config(agent_def));
 
+    // C1: Use configurable LLM provider instead of hardcoded "google"
+    let llm_provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "google".to_string());
+    let llm_subject = format!("llm.provider.{}", llm_provider);
+
     // 7. Dispatch to LLM provider (120s timeout)
     let llm_response: LlmResponse = match tokio::time::timeout(
         Duration::from_secs(120),
-        nats_request::<_, LlmResponse>(nats, "llm.provider.google", &llm_request),
+        nats_request::<_, LlmResponse>(nats, &llm_subject, &llm_request),
     )
     .await
     {
@@ -626,7 +691,9 @@ async fn process_consciousness_event(
         guardrail.add_provider_rounds(llm_response.tool_rounds);
     }
 
-    // Check guardrails after LLM response
+    // G1: Check guardrails after LLM response and enforce violations
+    let mut guardrail_triggered = false;
+    let mut guardrail_msg = String::new();
     if let Some(tool_calls) = &llm_response.tool_calls {
         for tc in tool_calls {
             if let Some(violation) = guardrail.record_turn(&tc.function_name, &tc.arguments) {
@@ -635,17 +702,41 @@ async fn process_consciousness_event(
                     ?violation,
                     "Guardrail triggered"
                 );
+                guardrail_msg = match violation {
+                    guardrails::GuardrailViolation::TurnLimitReached(n) => {
+                        format!("Tool call limit reached ({} turns). Stopping.", n)
+                    }
+                    guardrails::GuardrailViolation::TimeLimitReached(s) => {
+                        format!("Time limit reached ({}s). Stopping.", s)
+                    }
+                    guardrails::GuardrailViolation::LoopDetected { tool_name, count } => {
+                        format!(
+                            "Loop detected: {} called {} times with same args.",
+                            tool_name, count
+                        )
+                    }
+                    guardrails::GuardrailViolation::HitlRequired(n) => {
+                        format!("Human approval needed after {} turns.", n)
+                    }
+                };
+                guardrail_triggered = true;
                 break;
             }
         }
     }
 
-    let response_text = llm_response.content.clone().unwrap_or_default();
+    // Use guardrail message as response if triggered, otherwise use LLM response
+    let response_text = if guardrail_triggered {
+        guardrail_msg
+    } else {
+        llm_response.content.clone().unwrap_or_default()
+    };
 
     info!(
         agent_id = %agent_id,
         model = %llm_response.model_used,
         tokens = llm_response.tokens.total_tokens,
+        guardrail_triggered = guardrail_triggered,
         "LLM response received"
     );
 
@@ -653,10 +744,12 @@ async fn process_consciousness_event(
     append_to_conversation(nats, &conversation_id, "user", &user_text).await;
     append_to_conversation(nats, &conversation_id, "assistant", &response_text).await;
 
-    // 9. If origin exists, publish to outbound channel
-    if let Some(ref origin) = event.origin {
-        if !response_text.is_empty() {
-            publish_outbound(nats, origin, &response_text).await;
+    // 9. If origin exists, publish to outbound channel (skip if guardrail triggered)
+    if !guardrail_triggered {
+        if let Some(ref origin) = event.origin {
+            if !response_text.is_empty() {
+                publish_outbound(nats, origin, &response_text).await;
+            }
         }
     }
 
@@ -849,10 +942,11 @@ async fn search_relevant_skills(nats: &async_nats::Client, query: &str) -> Vec<S
     }
 }
 
-/// Build the full system prompt from base prompt + agent identity + skill snippets.
+/// Build the full system prompt from base prompt + cached agent identity + skill snippets.
 fn build_full_system_prompt(
     base_system_prompt: &str,
     agent_def: &AgentDefinition,
+    cached_identity: &str,
     skill_snippets: &[String],
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
@@ -862,10 +956,9 @@ fn build_full_system_prompt(
         parts.push(base_system_prompt.to_string());
     }
 
-    // Agent identity prompt (loaded from disk path)
-    let identity = load_agent_identity_prompt(&agent_def.prompt);
-    if !identity.is_empty() {
-        parts.push(format!("## Agent Identity\n\n{}", identity));
+    // S1+S2: Use cached identity prompt instead of reading from disk each time
+    if !cached_identity.is_empty() {
+        parts.push(format!("## Agent Identity\n\n{}", cached_identity));
     }
 
     // Agent description

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -70,6 +70,17 @@ impl ConsciousnessService {
         // Create event subscriptions for each agent's `subscribe` patterns
         for (agent_id, agent) in &self.agents {
             for pattern in &agent.subscribe {
+                // I1: Skip channel inbound patterns — handled by the workflow engine
+                // to prevent duplicate LLM calls.
+                if pattern.starts_with("channel.") && pattern.ends_with(".inbound") {
+                    warn!(
+                        agent_id = %agent_id,
+                        pattern = %pattern,
+                        "Skipping channel inbound subscription (handled by workflow engine)"
+                    );
+                    continue;
+                }
+
                 let nats = self.nats.clone();
                 let agent_id = agent_id.clone();
                 let pattern = pattern.clone();
@@ -616,7 +627,7 @@ async fn process_consciousness_event(
     let history = load_conversation_history(nats, &conversation_id).await;
 
     // 3. Search for relevant skills based on event content
-    let skill_snippets = search_relevant_skills(nats, &user_text).await;
+    let skill_snippets = search_relevant_skills(nats, &user_text, &agent_def.scope).await;
 
     // 4. Build system prompt: base system prompt + cached identity prompt + skill snippets
     let full_system_prompt =
@@ -913,15 +924,20 @@ async fn load_conversation_history(
 }
 
 /// Search for relevant skills based on the event text.
-async fn search_relevant_skills(nats: &async_nats::Client, query: &str) -> Vec<String> {
+async fn search_relevant_skills(
+    nats: &async_nats::Client,
+    query: &str,
+    scope: &str,
+) -> Vec<String> {
     if query.is_empty() {
         return vec![];
     }
 
+    // D1: Pass the agent's scope so skill search respects scope boundaries
     let search_req = SkillSearchRequest {
         query: query.to_string(),
         limit: Some(3),
-        scope: None,
+        scope: Some(scope.to_string()),
     };
 
     match tokio::time::timeout(

--- a/crates/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/seidrum-kernel/src/consciousness/service.rs
@@ -8,17 +8,24 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
+use chrono::Utc;
 use futures::StreamExt;
 use seidrum_common::config::{load_agent_definition, AgentDefinition};
 use seidrum_common::events::{
-    ConsciousnessEvent, EventEnvelope, ToolCallRequest, ToolCallResponse, ToolRegister,
+    ChannelOutbound, ConsciousnessEvent, Conversation, ConversationAppendRequest,
+    ConversationAppendResponse, ConversationCreateRequest, ConversationCreateResponse,
+    ConversationFindRequest, ConversationGetRequest, ConversationMessage, EventEnvelope,
+    EventOrigin, LlmCallConfig, LlmResponse, SkillSearchRequest, SkillSearchResponse,
+    ToolCallRequest, ToolCallResponse, ToolRegister, UnifiedLlmRequest, UnifiedMessage,
 };
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
-use super::builtin_capabilities::{self, RuntimeSubscription};
+use super::builtin_capabilities::{self, builtin_tool_schemas, RuntimeSubscription};
+use super::guardrails::{self, GuardrailState};
 
 /// The consciousness service manages agent event streams and built-in capabilities.
 pub struct ConsciousnessService {
@@ -94,6 +101,90 @@ impl ConsciousnessService {
                     }
                 });
             }
+        }
+
+        // -----------------------------------------------------------------
+        // Consciousness event processing loop (one mpsc channel per agent)
+        // -----------------------------------------------------------------
+        // Each agent gets a dedicated tokio::mpsc channel so that events are
+        // processed SEQUENTIALLY — preventing concurrent conversation mutations.
+
+        for (agent_id, agent_def) in &self.agents {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<ConsciousnessEvent>(256);
+
+            // Spawn NATS subscriber → mpsc forwarder
+            let nats_sub = self.nats.clone();
+            let agent_id_sub = agent_id.clone();
+            let tx_clone = tx.clone();
+            tokio::spawn(async move {
+                let subject = format!("agent.{}.consciousness", agent_id_sub);
+                let mut sub = match nats_sub.subscribe(subject.clone()).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!(
+                            agent_id = %agent_id_sub,
+                            error = %e,
+                            "Failed to subscribe to consciousness stream"
+                        );
+                        return;
+                    }
+                };
+
+                info!(
+                    agent_id = %agent_id_sub,
+                    subject = %subject,
+                    "Consciousness processing subscription active"
+                );
+
+                while let Some(msg) = sub.next().await {
+                    let event: ConsciousnessEvent = match serde_json::from_slice(&msg.payload) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            warn!(
+                                agent_id = %agent_id_sub,
+                                error = %e,
+                                "Failed to parse consciousness event"
+                            );
+                            continue;
+                        }
+                    };
+                    if tx_clone.send(event).await.is_err() {
+                        warn!(agent_id = %agent_id_sub, "Consciousness channel closed");
+                        break;
+                    }
+                }
+            });
+
+            // Spawn sequential processor
+            let nats_proc = self.nats.clone();
+            let system_prompt = self.system_prompt.clone();
+            let agent_def = agent_def.clone();
+            let agent_id_proc = agent_id.clone();
+
+            tokio::spawn(async move {
+                info!(agent_id = %agent_id_proc, "Consciousness processor started");
+
+                while let Some(event) = rx.recv().await {
+                    if let Err(e) = process_consciousness_event(
+                        &nats_proc,
+                        &agent_id_proc,
+                        &agent_def,
+                        &system_prompt,
+                        &event,
+                    )
+                    .await
+                    {
+                        error!(
+                            agent_id = %agent_id_proc,
+                            event_type = %event.event_type,
+                            error = %e,
+                            "Consciousness event processing failed"
+                        );
+                    }
+                }
+
+                info!(agent_id = %agent_id_proc, "Consciousness processor stopped");
+            });
         }
 
         // Subscribe to capability.call.consciousness for built-in capability handling
@@ -434,6 +525,524 @@ async fn handle_builtin_call(
             result: serde_json::json!({"error": format!("Unknown built-in capability: {}", other)}),
             is_error: true,
         },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Consciousness event processing
+// ---------------------------------------------------------------------------
+
+/// Process a single consciousness event for an agent.
+///
+/// Steps:
+///   1. Find or create a conversation
+///   2. Load recent conversation history
+///   3. Search for relevant skills
+///   4. Build system prompt + skill snippets + identity prompt
+///   5. Build UnifiedLlmRequest with messages + tool schemas
+///   6. Dispatch to LLM provider via NATS request/reply
+///   7. Append user message + assistant response to conversation
+///   8. If response has origin, publish to outbound channel
+///   9. Track guardrails
+async fn process_consciousness_event(
+    nats: &async_nats::Client,
+    agent_id: &str,
+    agent_def: &AgentDefinition,
+    system_prompt: &str,
+    event: &ConsciousnessEvent,
+) -> Result<()> {
+    info!(
+        agent_id = %agent_id,
+        event_type = %event.event_type,
+        conversation_id = ?event.conversation_id,
+        "Processing consciousness event"
+    );
+
+    // Build user-facing text from event payload
+    let user_text = extract_user_text(event);
+
+    // 1. Find or create conversation
+    let conversation_id = find_or_create_conversation(nats, agent_id, agent_def, event).await?;
+
+    // 2. Load recent conversation history
+    let history = load_conversation_history(nats, &conversation_id).await;
+
+    // 3. Search for relevant skills based on event content
+    let skill_snippets = search_relevant_skills(nats, &user_text).await;
+
+    // 4. Build system prompt: base system prompt + identity prompt + skill snippets
+    let full_system_prompt = build_full_system_prompt(system_prompt, agent_def, &skill_snippets);
+
+    // 5. Build messages array from history + current event
+    let messages = build_messages(&history, &user_text, event);
+
+    // 6. Build tool schemas
+    let tools = builtin_tool_schemas();
+
+    // Build UnifiedLlmRequest
+    let llm_request = UnifiedLlmRequest {
+        agent_id: agent_id.to_string(),
+        messages,
+        system_prompt: Some(full_system_prompt),
+        tools,
+        config: LlmCallConfig {
+            temperature: Some(0.7),
+            max_tokens: Some(4096),
+            top_p: None,
+        },
+        routing_strategy: "best-first".to_string(),
+        model_preferences: vec!["gemini-2.0-flash".to_string()],
+        correlation_id: None,
+        scope: Some(agent_def.scope.clone()),
+    };
+
+    // Create guardrail state
+    let mut guardrail = GuardrailState::new(build_guardrail_config(agent_def));
+
+    // 7. Dispatch to LLM provider (120s timeout)
+    let llm_response: LlmResponse = match tokio::time::timeout(
+        Duration::from_secs(120),
+        nats_request::<_, LlmResponse>(nats, "llm.provider.google", &llm_request),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) => {
+            error!(
+                agent_id = %agent_id,
+                error = %e,
+                "LLM request failed"
+            );
+            return Err(e.context("LLM request failed"));
+        }
+        Err(_) => {
+            error!(agent_id = %agent_id, "LLM request timed out (120s)");
+            return Err(anyhow::anyhow!("LLM request timed out"));
+        }
+    };
+
+    // Track guardrail rounds from provider
+    if llm_response.tool_rounds > 0 {
+        guardrail.add_provider_rounds(llm_response.tool_rounds);
+    }
+
+    // Check guardrails after LLM response
+    if let Some(tool_calls) = &llm_response.tool_calls {
+        for tc in tool_calls {
+            if let Some(violation) = guardrail.record_turn(&tc.function_name, &tc.arguments) {
+                warn!(
+                    agent_id = %agent_id,
+                    ?violation,
+                    "Guardrail triggered"
+                );
+                break;
+            }
+        }
+    }
+
+    let response_text = llm_response.content.clone().unwrap_or_default();
+
+    info!(
+        agent_id = %agent_id,
+        model = %llm_response.model_used,
+        tokens = llm_response.tokens.total_tokens,
+        "LLM response received"
+    );
+
+    // 8. Append user message + assistant response to conversation
+    append_to_conversation(nats, &conversation_id, "user", &user_text).await;
+    append_to_conversation(nats, &conversation_id, "assistant", &response_text).await;
+
+    // 9. If origin exists, publish to outbound channel
+    if let Some(ref origin) = event.origin {
+        if !response_text.is_empty() {
+            publish_outbound(nats, origin, &response_text).await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract human-readable text from a consciousness event's payload.
+fn extract_user_text(event: &ConsciousnessEvent) -> String {
+    // Try common payload fields in priority order
+    if let Some(text) = event.payload.get("text").and_then(|v| v.as_str()) {
+        return text.to_string();
+    }
+    if let Some(msg) = event.payload.get("message").and_then(|v| v.as_str()) {
+        return msg.to_string();
+    }
+    if let Some(reason) = event.payload.get("reason").and_then(|v| v.as_str()) {
+        return format!("[{}] {}", event.event_type, reason);
+    }
+
+    // Fallback: serialize the event type + payload summary
+    format!(
+        "[{}] {}",
+        event.event_type,
+        serde_json::to_string(&event.payload).unwrap_or_else(|_| "{}".to_string())
+    )
+}
+
+/// Find an existing conversation or create a new one.
+async fn find_or_create_conversation(
+    nats: &async_nats::Client,
+    agent_id: &str,
+    agent_def: &AgentDefinition,
+    event: &ConsciousnessEvent,
+) -> Result<String> {
+    // If event already has a conversation_id, use it
+    if let Some(ref conv_id) = event.conversation_id {
+        if !conv_id.is_empty() {
+            debug!(agent_id = %agent_id, conversation_id = %conv_id, "Using existing conversation ID");
+            return Ok(conv_id.clone());
+        }
+    }
+
+    // Determine platform and metadata key for conversation lookup
+    let (platform, meta_key, meta_value) = if let Some(ref origin) = event.origin {
+        (
+            origin.platform.clone(),
+            "chat_id".to_string(),
+            origin.chat_id.clone(),
+        )
+    } else if let Some(source) = &event.source_subject {
+        // For subscribed events, use the source subject as context
+        (
+            "internal".to_string(),
+            "source_subject".to_string(),
+            source.clone(),
+        )
+    } else {
+        (
+            "internal".to_string(),
+            "event_type".to_string(),
+            event.event_type.clone(),
+        )
+    };
+
+    // Try to find existing conversation
+    let find_req = ConversationFindRequest {
+        agent_id: agent_id.to_string(),
+        platform: platform.clone(),
+        metadata_key: meta_key.clone(),
+        metadata_value: meta_value.clone(),
+    };
+
+    let found: serde_json::Value = match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, serde_json::Value>(nats, "brain.conversation.find", &find_req),
+    )
+    .await
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            warn!(error = %e, "conversation.find failed, creating new");
+            serde_json::json!(null)
+        }
+        Err(_) => {
+            warn!("conversation.find timed out, creating new");
+            serde_json::json!(null)
+        }
+    };
+
+    // If found, extract ID
+    if !found.is_null() {
+        if let Some(id) = found.get("id").and_then(|v| v.as_str()) {
+            debug!(agent_id = %agent_id, conversation_id = %id, "Found existing conversation");
+            return Ok(id.to_string());
+        }
+    }
+
+    // Create new conversation
+    let mut metadata = HashMap::new();
+    metadata.insert(meta_key, meta_value);
+
+    let participants = if let Some(ref origin) = event.origin {
+        vec![
+            format!("user:{}", origin.chat_id),
+            format!("agent:{}", agent_id),
+        ]
+    } else {
+        vec![format!("agent:{}", agent_id)]
+    };
+
+    let create_req = ConversationCreateRequest {
+        platform,
+        participants,
+        agent_id: agent_id.to_string(),
+        scope: agent_def.scope.clone(),
+        metadata,
+    };
+
+    let create_resp: ConversationCreateResponse = tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, ConversationCreateResponse>(
+            nats,
+            "brain.conversation.create",
+            &create_req,
+        ),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("conversation.create timed out"))?
+    .context("conversation.create failed")?;
+
+    info!(
+        agent_id = %agent_id,
+        conversation_id = %create_resp.conversation_id,
+        "Created new conversation"
+    );
+
+    Ok(create_resp.conversation_id)
+}
+
+/// Load recent conversation history (last 20 messages).
+async fn load_conversation_history(
+    nats: &async_nats::Client,
+    conversation_id: &str,
+) -> Vec<ConversationMessage> {
+    let get_req = ConversationGetRequest {
+        conversation_id: conversation_id.to_string(),
+        max_messages: 20,
+    };
+
+    let conv: Option<Conversation> = match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, serde_json::Value>(nats, "brain.conversation.get", &get_req),
+    )
+    .await
+    {
+        Ok(Ok(v)) if !v.is_null() => serde_json::from_value(v).ok(),
+        _ => None,
+    };
+
+    conv.map(|c| c.messages).unwrap_or_default()
+}
+
+/// Search for relevant skills based on the event text.
+async fn search_relevant_skills(nats: &async_nats::Client, query: &str) -> Vec<String> {
+    if query.is_empty() {
+        return vec![];
+    }
+
+    let search_req = SkillSearchRequest {
+        query: query.to_string(),
+        limit: Some(3),
+        scope: None,
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, SkillSearchResponse>(nats, "brain.skill.search", &search_req),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp.skills.into_iter().map(|s| s.snippet).collect(),
+        Ok(Err(e)) => {
+            debug!(error = %e, "Skill search failed (non-fatal)");
+            vec![]
+        }
+        Err(_) => {
+            debug!("Skill search timed out (non-fatal)");
+            vec![]
+        }
+    }
+}
+
+/// Build the full system prompt from base prompt + agent identity + skill snippets.
+fn build_full_system_prompt(
+    base_system_prompt: &str,
+    agent_def: &AgentDefinition,
+    skill_snippets: &[String],
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    // Base system prompt
+    if !base_system_prompt.is_empty() {
+        parts.push(base_system_prompt.to_string());
+    }
+
+    // Agent identity prompt (loaded from disk path)
+    let identity = load_agent_identity_prompt(&agent_def.prompt);
+    if !identity.is_empty() {
+        parts.push(format!("## Agent Identity\n\n{}", identity));
+    }
+
+    // Agent description
+    if let Some(ref desc) = agent_def.description {
+        parts.push(format!("## Agent Description\n\n{}", desc));
+    }
+
+    // Skill snippets
+    if !skill_snippets.is_empty() {
+        let skills_section = skill_snippets
+            .iter()
+            .enumerate()
+            .map(|(i, s)| format!("### Skill {}\n{}", i + 1, s))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        parts.push(format!("## Active Skills\n\n{}", skills_section));
+    }
+
+    parts.join("\n\n---\n\n")
+}
+
+/// Load an agent's identity prompt from its prompt file path.
+fn load_agent_identity_prompt(prompt_path: &str) -> String {
+    let path = Path::new(prompt_path);
+    match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => {
+            debug!(path = %prompt_path, "Agent prompt file not found, using empty identity");
+            String::new()
+        }
+    }
+}
+
+/// Build the messages array from conversation history + current event.
+fn build_messages(
+    history: &[ConversationMessage],
+    user_text: &str,
+    _event: &ConsciousnessEvent,
+) -> Vec<UnifiedMessage> {
+    let mut messages: Vec<UnifiedMessage> = Vec::new();
+
+    // Add conversation history
+    for msg in history {
+        messages.push(UnifiedMessage {
+            role: msg.role.clone(),
+            content: msg.content.clone(),
+            tool_calls: if msg.tool_calls.is_empty() {
+                None
+            } else {
+                Some(msg.tool_calls.clone())
+            },
+            tool_results: if msg.tool_results.is_empty() {
+                None
+            } else {
+                Some(msg.tool_results.clone())
+            },
+        });
+    }
+
+    // Add current user message
+    messages.push(UnifiedMessage {
+        role: "user".to_string(),
+        content: Some(user_text.to_string()),
+        tool_calls: None,
+        tool_results: None,
+    });
+
+    messages
+}
+
+/// Build guardrail config, applying per-agent overrides.
+fn build_guardrail_config(agent_def: &AgentDefinition) -> seidrum_common::events::GuardrailConfig {
+    let mut config = guardrails::default_consciousness();
+
+    if let Some(ref overrides) = agent_def.guardrails {
+        if let Some(turn_limit) = overrides.turn_limit {
+            config.turn_limit = turn_limit;
+        }
+        if let Some(time_limit) = overrides.time_limit_seconds {
+            config.time_limit_seconds = time_limit;
+        }
+        if let Some(hitl) = overrides.hitl_after_turns {
+            config.hitl_after_turns = Some(hitl);
+        }
+    }
+
+    config
+}
+
+/// Append a message to a conversation.
+async fn append_to_conversation(
+    nats: &async_nats::Client,
+    conversation_id: &str,
+    role: &str,
+    content: &str,
+) {
+    if content.is_empty() {
+        return;
+    }
+
+    let append_req = ConversationAppendRequest {
+        conversation_id: conversation_id.to_string(),
+        message: ConversationMessage {
+            role: role.to_string(),
+            content: Some(content.to_string()),
+            tool_calls: vec![],
+            tool_results: vec![],
+            media: vec![],
+            timestamp: Utc::now(),
+            active_skills: vec![],
+        },
+    };
+
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        nats_request::<_, ConversationAppendResponse>(
+            nats,
+            "brain.conversation.append",
+            &append_req,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            warn!(
+                conversation_id = %conversation_id,
+                role = %role,
+                error = %e,
+                "Failed to append message to conversation"
+            );
+        }
+        Err(_) => {
+            warn!(
+                conversation_id = %conversation_id,
+                role = %role,
+                "Timeout appending message to conversation"
+            );
+        }
+    }
+}
+
+/// Publish a response to the originating channel.
+async fn publish_outbound(nats: &async_nats::Client, origin: &EventOrigin, text: &str) {
+    let outbound = ChannelOutbound {
+        platform: origin.platform.clone(),
+        chat_id: origin.chat_id.clone(),
+        text: text.to_string(),
+        format: "markdown".to_string(),
+        reply_to: origin.message_id.clone(),
+        actions: vec![],
+    };
+
+    let subject = format!("channel.{}.outbound", origin.platform);
+    let envelope = match EventEnvelope::new(&subject, "consciousness", None, None, &outbound) {
+        Ok(e) => e,
+        Err(e) => {
+            error!(error = %e, "Failed to create outbound envelope");
+            return;
+        }
+    };
+
+    match serde_json::to_vec(&envelope) {
+        Ok(bytes) => {
+            if let Err(e) = nats.publish(subject.clone(), bytes.into()).await {
+                error!(subject = %subject, error = %e, "Failed to publish outbound");
+            } else {
+                debug!(
+                    platform = %origin.platform,
+                    chat_id = %origin.chat_id,
+                    "Published outbound response"
+                );
+            }
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to serialize outbound envelope");
+        }
     }
 }
 

--- a/docs/EVENT_CATALOG.md
+++ b/docs/EVENT_CATALOG.md
@@ -304,6 +304,7 @@ struct LlmResponse {
     tokens: TokenUsage,
     duration_ms: u64,
     finish_reason: String,
+    tool_rounds: u32,
 }
 
 struct ToolCall {
@@ -722,4 +723,13 @@ pub struct SkillListRequest {
 pub struct SkillListResponse {
     pub skills: Vec<SkillSearchResult>,
 }
+```
+
+### `brain.skill.delete` (request/reply)
+
+Delete a skill by ID.
+
+```rust
+// Uses SkillGetRequest { skill_id: String }
+// Returns { success: bool, skill_id: String }
 ```

--- a/docs/EVENT_CATALOG.md
+++ b/docs/EVENT_CATALOG.md
@@ -647,3 +647,79 @@ pub struct ConsciousnessEvent {
 ### `capability.call.consciousness` (request/reply)
 
 Built-in capability calls handled by the consciousness service: `brain-query`, `subscribe-events`, `unsubscribe-events`, `delegate-task`, `schedule-wake`, `send-notification`, `get-conversation`, `list-conversations`.
+
+---
+
+## Skill Events
+
+### `brain.skill.search` (request/reply)
+
+Search skills by semantic similarity. The kernel embeds the query and performs a vector search against the `skills` collection.
+
+```rust
+pub struct SkillSearchRequest {
+    pub query: String,
+    pub limit: Option<u32>,
+    pub scope: Option<String>,
+}
+
+pub struct SkillSearchResult {
+    pub id: String,
+    pub description: String,
+    pub snippet: String,
+    pub score: f64,
+    pub source: String,
+    pub tags: Vec<String>,
+}
+
+pub struct SkillSearchResponse {
+    pub skills: Vec<SkillSearchResult>,
+}
+```
+
+### `brain.skill.save` (request/reply)
+
+Save a new skill or update an existing one. If `id` is `None`, the kernel generates a new ID. The kernel computes an embedding from the description if `embedding` is empty.
+
+```rust
+pub struct SkillSaveRequest {
+    pub id: Option<String>,
+    pub description: String,
+    pub snippet: String,
+    pub source: String,              // "system" | "user" | "learned" | "agent:{id}"
+    pub scope: Option<String>,
+    pub tags: Vec<String>,
+    pub learned_from: Option<String>, // conversation ID that produced the skill
+    pub embedding: Vec<f64>,          // pre-computed embedding (optional)
+}
+
+pub struct SkillSaveResponse {
+    pub skill_id: String,
+    pub is_new: bool,
+}
+```
+
+### `brain.skill.get` (request/reply)
+
+Retrieve a single skill by its ID. Returns a `SkillSearchResult` in the reply payload (or an error if not found).
+
+```rust
+pub struct SkillGetRequest {
+    pub skill_id: String,
+}
+```
+
+### `brain.skill.list` (request/reply)
+
+List skills with optional filtering by source.
+
+```rust
+pub struct SkillListRequest {
+    pub source_filter: Option<String>,
+    pub limit: Option<u32>,
+}
+
+pub struct SkillListResponse {
+    pub skills: Vec<SkillSearchResult>,
+}
+```

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -622,3 +622,53 @@ When a plugin declares a config schema:
 - Config changes are validated against the schema before saving
 - Updated config is persisted to plugin storage (`namespace: "config"`)
 - The plugin is notified via `plugin.{id}.config.update` NATS subject
+
+## Skills System
+
+The skills system provides behavioral RAG for agents -- reusable instructions and procedures that are retrieved by semantic similarity and injected into agent context at inference time. Skills are managed through built-in capabilities and a CLI interface.
+
+### Built-in Skill Capabilities
+
+The consciousness service registers three skill-related capabilities:
+
+| Capability | Description |
+|-----------|-------------|
+| `search-skills` | Search skills by semantic query. Returns matching skill IDs, descriptions, snippets, and relevance scores. |
+| `load-skill` | Explicitly load a skill by ID into the current conversation context, ensuring it persists across turns. |
+| `save-skill` | Create a new skill from the current conversation (for learned behavior). Stores description, snippet, source, and tags. |
+
+These capabilities are available to all agents via `capability.call.consciousness` and use the `brain.skill.*` NATS subjects documented in the [Event Catalog](EVENT_CATALOG.md).
+
+### Skill YAML Format
+
+Skills are defined as YAML files in the `skills/` directory and indexed on kernel startup:
+
+```yaml
+skill:
+  id: code-review
+  description: "Reviewing code changes for bugs, security issues, and style problems"
+  snippet: |
+    When reviewing code: check for OWASP top 10 vulnerabilities, missing error
+    handling, test coverage gaps, and performance implications. Report each issue
+    with file, line, severity, and recommended fix.
+  tags: [code, review, security]
+```
+
+Fields:
+- **id** — Unique identifier for the skill
+- **description** — Short text describing when the skill applies (used for embedding search)
+- **snippet** — The behavioral instruction injected into the agent's context when the skill is active
+- **tags** — Classification tags for filtering and organization
+
+Skills can also be created at runtime by agents (source `"learned"` or `"user"`) and by other agents (source `"agent:{id}"`).
+
+### CLI Commands
+
+```bash
+seidrum skill list                              # List all installed skills
+seidrum skill install <name>                    # Install a skill package from skills/ or a registry
+seidrum skill install <org>/<name>              # Install from an organization namespace
+seidrum skill remove <name>                     # Remove a skill and its embeddings
+```
+
+On install, the CLI copies YAML files to `skills/`, computes embeddings, and stores them in the `skills` ArangoDB collection. Skills are available immediately for retrieval by any agent.

--- a/prompts/assistant.md
+++ b/prompts/assistant.md
@@ -12,6 +12,11 @@ Context: {{ scope_name }}
 ## Recent conversation
 {{ conversation_history }}
 
+{% if active_skills %}
+## Behavioral guidance
+{{ active_skills }}
+{% endif %}
+
 ## Instructions
 - Be direct and concise.
 - If you identify an actionable item, create a task.

--- a/prompts/research.md
+++ b/prompts/research.md
@@ -15,6 +15,11 @@ Context: {{ scope_name }}
 ## Available tools
 {{ available_tools }}
 
+{% if active_skills %}
+## Behavioral guidance
+{{ active_skills }}
+{% endif %}
+
 ## Instructions
 - Provide thorough, well-structured analysis with citations when possible.
 - Break complex topics into clearly labeled sections.


### PR DESCRIPTION
## Summary

Closes all remaining gaps identified in the system review. Built by 5 parallel agents working in isolated worktrees.

### Stream 1: Consciousness Event Processor (CRITICAL)
- **612 lines** added to `consciousness/service.rs`
- Full event processing loop: subscribe to `agent.{id}.consciousness` → find/create conversation → load history → search skills → build prompt → call LLM → store conversation → route response
- Per-agent sequential processing via mpsc channels (prevents concurrent mutations)
- Guardrail tracking with per-agent overrides
- System prompt + identity prompt + skill snippets assembly

### Stream 2: Context Assembly + Skills Injection
- `skill_snippets` field added to `AgentContextLoaded`
- Graph-context-loader queries `brain.skill.search` with user text
- Context assembly formats skills as `[Active Skill: id]` blocks
- Token budget: skills 10%, RAG reduced from 25% to 15%
- `{{ active_skills }}` Tera template variable

### Stream 3: Google Provider tool_rounds Fix
- Track actual tool call rounds in the loop counter
- Report in `LlmResponse.tool_rounds` (was always 0)
- Updated translator function signature to pass through round count

### Stream 4: Dashboard + CLI Skills Integration
- 4 new dashboard endpoints: `/dashboard/skills`, `/dashboard/skills/{id}`, `/dashboard/conversations`, `/dashboard/conversations/{id}`
- Frontend pages: Skills browser (table + detail view), Conversation viewer (list + message thread)
- `brain.skill.delete` handler added to brain service
- Sidebar nav updated with Skills and Conversations links

### Stream 5: Documentation Update
- EVENT_CATALOG: skill events (search, save, get, list)
- README: Agent Consciousness section + design doc links
- PLUGIN_SPEC: Skills System section (capabilities, YAML format, CLI commands)

## Files changed
- 15 files across 5 independent streams
- No merge conflicts (all streams touched different files)

## Test plan
- [x] All 206 tests pass
- [x] `cargo build --workspace` clean
- [x] All 5 streams merge cleanly
- [ ] Consciousness loop processes events end-to-end
- [ ] Skills injected into LLM prompt
- [ ] Dashboard shows skills and conversations
- [ ] tool_rounds reported correctly by Google provider