### PR TITLE
feat(eventbus): Phase 5 — durable retry & dead-lettering

### DIFF
--- a/crates/core/seidrum-eventbus/src/builder.rs
+++ b/crates/core/seidrum-eventbus/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::bus::{EventBus, EventBusImpl, SubscribeOpts, Subscription};
-use crate::delivery::{ChannelRegistry, RetryConfig, RetryTask};
+use crate::delivery::{ChannelRegistry, DeliveryChannel, RetryConfig, RetryTask, WebhookChannel};
 use crate::dispatch::{EventFilter, Interceptor, SubscriptionInfo};
 use crate::request_reply::RequestSubscription;
 use crate::storage::compaction::CompactionTask;
@@ -77,7 +77,16 @@ pub struct EventBusBuilder {
     retention: Duration,
     ws_addr: Option<SocketAddr>,
     http_addr: Option<SocketAddr>,
-    retry: Option<RetryTaskConfig>,
+    retry: Option<RetryConfig>,
+    /// Set independently of `with_retry` so order doesn't matter.
+    retry_poll_interval: Option<Duration>,
+    /// Set independently of `with_retry` so order doesn't matter.
+    retry_query_limit: Option<usize>,
+    /// Optional user-supplied registry. If `None`, a fresh empty one is built.
+    registry: Option<Arc<ChannelRegistry>>,
+    /// Pending channel registrations queued via `register_channel`. Drained
+    /// during `build_with_handles` against the resolved registry.
+    pending_channels: Vec<(String, Arc<dyn DeliveryChannel>)>,
 }
 
 /// Default compaction interval: 1 hour.
@@ -86,19 +95,16 @@ const DEFAULT_COMPACTION_INTERVAL: Duration = Duration::from_secs(3600);
 const DEFAULT_RETENTION: Duration = Duration::from_secs(86400);
 /// Default poll interval for the retry task: 1 second.
 const DEFAULT_RETRY_POLL_INTERVAL: Duration = Duration::from_secs(1);
-
-/// Internal config for the retry task — combines retry parameters with poll interval.
-#[derive(Debug, Clone)]
-struct RetryTaskConfig {
-    retry: RetryConfig,
-    poll_interval: Duration,
-}
+/// Default query limit per retry poll cycle: 256 deliveries.
+const DEFAULT_RETRY_QUERY_LIMIT: usize = 256;
 
 /// Handles to background tasks spawned by the builder.
 ///
 /// Callers can use these handles to detect if a server task panicked or exited
-/// unexpectedly. Call [`BusHandles::shutdown`] to gracefully stop transport
-/// servers. Dropping the handles does **not** cancel the tasks.
+/// unexpectedly. Call [`BusHandles::shutdown`] to non-blockingly signal
+/// shutdown, or [`BusHandles::shutdown_and_join`] (consuming `self`) to
+/// signal **and** await all background tasks. Dropping the handles does
+/// **not** cancel the tasks.
 pub struct BusHandles {
     /// The constructed event bus.
     pub bus: Arc<dyn EventBus>,
@@ -115,9 +121,35 @@ pub struct BusHandles {
 }
 
 impl BusHandles {
-    /// Signal all transport servers to shut down gracefully.
+    /// Signal all background tasks to shut down. Non-blocking — does not
+    /// wait for tasks to actually exit. Use [`Self::shutdown_and_join`] when
+    /// you need ordered shutdown.
     pub fn shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
+    }
+
+    /// Signal shutdown and `await` every background task to actually exit.
+    /// Consumes `self` because the joined `JoinHandle`s cannot be reused.
+    ///
+    /// Errors from individual `JoinHandle`s (e.g., a task panicked) are
+    /// logged at warn level but do not propagate.
+    pub async fn shutdown_and_join(self) {
+        let _ = self.shutdown_tx.send(true);
+        let mut tasks: Vec<(&'static str, JoinHandle<()>)> = vec![("compaction", self.compaction)];
+        if let Some(h) = self.ws_server {
+            tasks.push(("websocket", h));
+        }
+        if let Some(h) = self.http_server {
+            tasks.push(("http", h));
+        }
+        if let Some(h) = self.retry_task {
+            tasks.push(("retry", h));
+        }
+        for (name, handle) in tasks {
+            if let Err(e) = handle.await {
+                tracing::warn!(task = name, error = %e, "background task did not exit cleanly");
+            }
+        }
     }
 }
 
@@ -130,6 +162,10 @@ impl EventBusBuilder {
             ws_addr: None,
             http_addr: None,
             retry: None,
+            retry_poll_interval: None,
+            retry_query_limit: None,
+            registry: None,
+            pending_channels: Vec::new(),
         }
     }
 
@@ -165,25 +201,56 @@ impl EventBusBuilder {
 
     /// Enable the background retry task with the given config.
     ///
-    /// Polls the store every second by default; use [`Self::with_retry_poll_interval`]
-    /// to change the interval. Failed deliveries are retried via the dispatch
-    /// engine, which looks up the live subscription and routes through the
-    /// configured channel. Deliveries whose attempt count reaches
-    /// `retry.max_attempts` (or hit a permanent error) are dead-lettered.
+    /// `retry.initial_backoff_ms` and `retry.max_backoff_ms` flow through
+    /// to the dispatch engine and retry task — both use them when computing
+    /// `next_retry` timestamps via [`crate::delivery::calculate_backoff`].
+    /// `retry.max_attempts` is the cap before deliveries are dead-lettered.
+    ///
+    /// Use [`Self::with_retry_poll_interval`] (in any order) to override the
+    /// default 1s poll interval, and [`Self::with_retry_query_limit`] to
+    /// override the default 256 deliveries-per-cycle batch size.
     pub fn with_retry(mut self, retry: RetryConfig) -> Self {
-        self.retry = Some(RetryTaskConfig {
-            retry,
-            poll_interval: DEFAULT_RETRY_POLL_INTERVAL,
-        });
+        self.retry = Some(retry);
         self
     }
 
-    /// Override the retry task's polling interval. Has no effect unless
-    /// [`Self::with_retry`] was also called.
+    /// Override the retry task's polling interval. Order-independent —
+    /// works whether called before or after [`Self::with_retry`].
     pub fn with_retry_poll_interval(mut self, interval: Duration) -> Self {
-        if let Some(cfg) = self.retry.as_mut() {
-            cfg.poll_interval = interval;
-        }
+        self.retry_poll_interval = Some(interval);
+        self
+    }
+
+    /// Override the per-cycle query limit (max deliveries fetched per poll).
+    /// Order-independent.
+    pub fn with_retry_query_limit(mut self, limit: usize) -> Self {
+        self.retry_query_limit = Some(limit);
+        self
+    }
+
+    /// Use a user-supplied [`ChannelRegistry`].
+    ///
+    /// The same registry is shared with the dispatch engine (for retry-time
+    /// `Custom` channel lookups) and the HTTP transport (for webhook
+    /// subscriptions). If not called, the builder constructs a fresh empty
+    /// registry.
+    pub fn with_channel_registry(mut self, registry: Arc<ChannelRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Register a custom delivery channel under the given type name.
+    ///
+    /// Channels registered here are looked up at retry time when a
+    /// subscription uses `ChannelConfig::Custom { channel_type, .. }`.
+    /// Registrations are deferred until `build_with_handles` so the order
+    /// relative to `with_channel_registry` doesn't matter.
+    pub fn register_channel(
+        mut self,
+        type_name: impl Into<String>,
+        channel: Arc<dyn DeliveryChannel>,
+    ) -> Self {
+        self.pending_channels.push((type_name.into(), channel));
         self
     }
 
@@ -214,12 +281,40 @@ impl EventBusBuilder {
             .store
             .ok_or_else(|| EventBusError::Config("storage backend is required".to_string()))?;
 
-        // Shared registry between the dispatch engine (for retry channel
-        // lookups) and the HTTP transport (for webhook subscriptions).
-        let registry = Arc::new(ChannelRegistry::new());
+        // Resolve registry: use the user-supplied one or create a fresh
+        // empty registry. Either way, the same Arc is shared between the
+        // dispatch engine (retry path) and the HTTP transport (webhook
+        // subscriptions) and any user-registered Custom channels.
+        let registry = self
+            .registry
+            .unwrap_or_else(|| Arc::new(ChannelRegistry::new()));
 
-        let bus_impl = EventBusImpl::with_registry(Arc::clone(&store), Arc::clone(&registry));
-        let engine = bus_impl.engine();
+        // Drain pending channel registrations against the resolved registry.
+        for (type_name, channel) in self.pending_channels {
+            registry.register(&type_name, channel).await;
+        }
+
+        // Single shared WebhookChannel — used by both the dispatch engine
+        // (for retry-time delivery) and the HTTP transport (for live
+        // delivery from webhook subscriptions).
+        let webhook_channel = WebhookChannel::new();
+
+        // Resolve retry config: defaults applied if `with_retry` was not
+        // called. Always Some so the engine can use it for first-failure
+        // backoff regardless of whether the retry task is enabled.
+        let retry_config = Arc::new(self.retry.clone().unwrap_or_default());
+
+        let engine = Arc::new(crate::dispatch::DispatchEngine::with_components(
+            Arc::clone(&store),
+            Arc::clone(&registry),
+            Arc::clone(&webhook_channel),
+            Arc::clone(&retry_config),
+        ));
+
+        // Wrap the engine in EventBusImpl. The bus_impl uses the same engine
+        // we'll hand to RetryTask, so retry-time subscription lookups see
+        // exactly the same trie state as live publish/subscribe.
+        let bus_impl = EventBusImpl::from_engine(Arc::clone(&engine));
         let bus: Arc<dyn EventBus> = Arc::new(bus_impl);
 
         // Shared shutdown signal for all background tasks
@@ -237,15 +332,17 @@ impl EventBusBuilder {
         });
 
         // Start retry task if configured.
-        // Backoff parameters in `cfg.retry` (initial_backoff_ms, max_backoff_ms)
-        // are currently informational; the store hardcodes 100ms × 2^attempts
-        // capped at 30s. Future work: thread these into the store layer.
-        let retry_handle = if let Some(cfg) = self.retry {
+        let retry_handle = if self.retry.is_some() {
+            let poll_interval = self
+                .retry_poll_interval
+                .unwrap_or(DEFAULT_RETRY_POLL_INTERVAL);
+            let query_limit = self.retry_query_limit.unwrap_or(DEFAULT_RETRY_QUERY_LIMIT);
             let task = RetryTask::new(
                 Arc::clone(&store),
                 Arc::clone(&engine),
-                cfg.retry.max_attempts,
-                cfg.poll_interval,
+                Arc::clone(&retry_config),
+                poll_interval,
+                query_limit,
                 shutdown_rx.clone(),
             );
             Some(tokio::spawn(async move {
@@ -273,9 +370,11 @@ impl EventBusBuilder {
         let http_handle = if let Some(addr) = self.http_addr {
             let bus_clone = Arc::clone(&bus);
             let registry_clone = Arc::clone(&registry);
+            let webhook_clone = Arc::clone(&webhook_channel);
             let rx = shutdown_rx.clone();
             Some(tokio::spawn(async move {
-                let http_server = HttpServer::new(bus_clone, registry_clone, rx);
+                let http_server =
+                    HttpServer::with_webhook_channel(bus_clone, registry_clone, webhook_clone, rx);
                 if let Err(e) = http_server.start(addr).await {
                     tracing::error!("HTTP server error: {}", e);
                 }

--- a/crates/core/seidrum-eventbus/src/builder.rs
+++ b/crates/core/seidrum-eventbus/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::bus::{EventBus, EventBusImpl, SubscribeOpts, Subscription};
-use crate::delivery::ChannelRegistry;
+use crate::delivery::{ChannelRegistry, RetryConfig, RetryTask};
 use crate::dispatch::{EventFilter, Interceptor, SubscriptionInfo};
 use crate::request_reply::RequestSubscription;
 use crate::storage::compaction::CompactionTask;
@@ -77,12 +77,22 @@ pub struct EventBusBuilder {
     retention: Duration,
     ws_addr: Option<SocketAddr>,
     http_addr: Option<SocketAddr>,
+    retry: Option<RetryTaskConfig>,
 }
 
 /// Default compaction interval: 1 hour.
 const DEFAULT_COMPACTION_INTERVAL: Duration = Duration::from_secs(3600);
 /// Default retention period for delivered events: 24 hours.
 const DEFAULT_RETENTION: Duration = Duration::from_secs(86400);
+/// Default poll interval for the retry task: 1 second.
+const DEFAULT_RETRY_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Internal config for the retry task — combines retry parameters with poll interval.
+#[derive(Debug, Clone)]
+struct RetryTaskConfig {
+    retry: RetryConfig,
+    poll_interval: Duration,
+}
 
 /// Handles to background tasks spawned by the builder.
 ///
@@ -98,6 +108,8 @@ pub struct BusHandles {
     pub ws_server: Option<JoinHandle<()>>,
     /// Handle to the HTTP server task, if configured.
     pub http_server: Option<JoinHandle<()>>,
+    /// Handle to the retry task, if `with_retry()` was called.
+    pub retry_task: Option<JoinHandle<()>>,
     /// Send `true` to gracefully shut down all transport servers.
     shutdown_tx: watch::Sender<bool>,
 }
@@ -117,6 +129,7 @@ impl EventBusBuilder {
             retention: DEFAULT_RETENTION,
             ws_addr: None,
             http_addr: None,
+            retry: None,
         }
     }
 
@@ -150,6 +163,30 @@ impl EventBusBuilder {
         self
     }
 
+    /// Enable the background retry task with the given config.
+    ///
+    /// Polls the store every second by default; use [`Self::with_retry_poll_interval`]
+    /// to change the interval. Failed deliveries are retried via the dispatch
+    /// engine, which looks up the live subscription and routes through the
+    /// configured channel. Deliveries whose attempt count reaches
+    /// `retry.max_attempts` (or hit a permanent error) are dead-lettered.
+    pub fn with_retry(mut self, retry: RetryConfig) -> Self {
+        self.retry = Some(RetryTaskConfig {
+            retry,
+            poll_interval: DEFAULT_RETRY_POLL_INTERVAL,
+        });
+        self
+    }
+
+    /// Override the retry task's polling interval. Has no effect unless
+    /// [`Self::with_retry`] was also called.
+    pub fn with_retry_poll_interval(mut self, interval: Duration) -> Self {
+        if let Some(cfg) = self.retry.as_mut() {
+            cfg.poll_interval = interval;
+        }
+        self
+    }
+
     /// Build the EventBus, returning only the bus (dropping task handles).
     ///
     /// Background tasks (compaction, transport servers) are spawned and will run
@@ -177,9 +214,15 @@ impl EventBusBuilder {
             .store
             .ok_or_else(|| EventBusError::Config("storage backend is required".to_string()))?;
 
-        let bus = Arc::new(EventBusImpl::new(Arc::clone(&store)));
+        // Shared registry between the dispatch engine (for retry channel
+        // lookups) and the HTTP transport (for webhook subscriptions).
+        let registry = Arc::new(ChannelRegistry::new());
 
-        // Shared shutdown signal for all transport servers
+        let bus_impl = EventBusImpl::with_registry(Arc::clone(&store), Arc::clone(&registry));
+        let engine = bus_impl.engine();
+        let bus: Arc<dyn EventBus> = Arc::new(bus_impl);
+
+        // Shared shutdown signal for all background tasks
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
         // Start compaction task
@@ -192,6 +235,25 @@ impl EventBusBuilder {
         let compaction_handle = tokio::spawn(async move {
             compaction_task.run().await;
         });
+
+        // Start retry task if configured.
+        // Backoff parameters in `cfg.retry` (initial_backoff_ms, max_backoff_ms)
+        // are currently informational; the store hardcodes 100ms × 2^attempts
+        // capped at 30s. Future work: thread these into the store layer.
+        let retry_handle = if let Some(cfg) = self.retry {
+            let task = RetryTask::new(
+                Arc::clone(&store),
+                Arc::clone(&engine),
+                cfg.retry.max_attempts,
+                cfg.poll_interval,
+                shutdown_rx.clone(),
+            );
+            Some(tokio::spawn(async move {
+                task.run().await;
+            }))
+        } else {
+            None
+        };
 
         // Start WebSocket server if configured
         let ws_handle = if let Some(addr) = self.ws_addr {
@@ -210,10 +272,10 @@ impl EventBusBuilder {
         // Start HTTP server if configured
         let http_handle = if let Some(addr) = self.http_addr {
             let bus_clone = Arc::clone(&bus);
-            let registry = Arc::new(ChannelRegistry::new());
+            let registry_clone = Arc::clone(&registry);
             let rx = shutdown_rx.clone();
             Some(tokio::spawn(async move {
-                let http_server = HttpServer::new(bus_clone, registry, rx);
+                let http_server = HttpServer::new(bus_clone, registry_clone, rx);
                 if let Err(e) = http_server.start(addr).await {
                     tracing::error!("HTTP server error: {}", e);
                 }
@@ -227,6 +289,7 @@ impl EventBusBuilder {
             compaction: compaction_handle,
             ws_server: ws_handle,
             http_server: http_handle,
+            retry_task: retry_handle,
             shutdown_tx,
         })
     }

--- a/crates/core/seidrum-eventbus/src/builder.rs
+++ b/crates/core/seidrum-eventbus/src/builder.rs
@@ -302,14 +302,17 @@ impl EventBusBuilder {
         // Resolve retry config: defaults applied if `with_retry` was not
         // called. Always Some so the engine can use it for first-failure
         // backoff regardless of whether the retry task is enabled.
+        let retry_enabled = self.retry.is_some();
         let retry_config = Arc::new(self.retry.clone().unwrap_or_default());
 
-        let engine = Arc::new(crate::dispatch::DispatchEngine::with_components(
+        let mut engine = crate::dispatch::DispatchEngine::with_components(
             Arc::clone(&store),
             Arc::clone(&registry),
             Arc::clone(&webhook_channel),
             Arc::clone(&retry_config),
-        ));
+        );
+        engine.set_retry_enabled(retry_enabled);
+        let engine = Arc::new(engine);
 
         // Wrap the engine in EventBusImpl. The bus_impl uses the same engine
         // we'll hand to RetryTask, so retry-time subscription lookups see

--- a/crates/core/seidrum-eventbus/src/bus.rs
+++ b/crates/core/seidrum-eventbus/src/bus.rs
@@ -255,21 +255,25 @@ impl EventBus for EventBusImpl {
 
     async fn metrics(&self) -> crate::Result<BusMetrics> {
         use std::sync::atomic::Ordering;
-        // Use the dedicated count_retryable method (O(failed events) for
-        // ReDB, O(events) for in-memory) instead of fetching full delivery
-        // records just to count them. Errors are logged so operators see
-        // a signal rather than a silent zero.
-        let pending_retry = match self
-            .engine
-            .store
-            .count_retryable(self.engine.retry_config.max_attempts)
-            .await
-        {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(error = %e, "metrics: count_retryable failed");
-                0
+        // Only report `events_pending_retry` if a retry task is actually
+        // running. Otherwise the count is meaningless — there's no worker
+        // to drain it. A bus without `with_retry()` reports 0 here so
+        // dashboards don't surface a permanent backlog.
+        let pending_retry = if self.engine.retry_enabled {
+            match self
+                .engine
+                .store
+                .count_retryable(self.engine.retry_config.max_attempts)
+                .await
+            {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::warn!(error = %e, "metrics: count_retryable failed");
+                    0
+                }
             }
+        } else {
+            0
         };
 
         Ok(BusMetrics {

--- a/crates/core/seidrum-eventbus/src/bus.rs
+++ b/crates/core/seidrum-eventbus/src/bus.rs
@@ -146,13 +146,22 @@ pub struct EventBusImpl {
 }
 
 impl EventBusImpl {
+    /// Construct an `EventBusImpl` from an event store with default
+    /// retry configuration and an empty channel registry.
+    ///
+    /// **Note:** the engine wired up by this constructor cannot share its
+    /// `ChannelRegistry` with anything else (e.g., the HTTP transport's
+    /// webhook subscriptions or the retry task's `Custom` channel lookups).
+    /// For production use, prefer constructing via [`crate::EventBusBuilder`]
+    /// which wires up a single shared registry across the engine, transports,
+    /// and retry task.
     pub fn new(store: Arc<dyn EventStore>) -> Self {
         Self {
             engine: Arc::new(DispatchEngine::new(store)),
         }
     }
 
-    /// Construct an EventBusImpl that shares a [`crate::delivery::ChannelRegistry`]
+    /// Construct an `EventBusImpl` that shares a [`crate::delivery::ChannelRegistry`]
     /// with the dispatch engine. The registry is used by the retry task for
     /// looking up `ChannelConfig::Custom` delivery channels.
     pub fn with_registry(
@@ -164,9 +173,11 @@ impl EventBusImpl {
         }
     }
 
-    /// Internal accessor used by the builder to spawn the retry task.
-    pub(crate) fn engine(&self) -> Arc<DispatchEngine> {
-        Arc::clone(&self.engine)
+    /// Wrap an already-constructed [`DispatchEngine`] in an `EventBusImpl`.
+    /// Used by [`crate::EventBusBuilder`] so the engine, retry task, and
+    /// transports all share the same instance.
+    pub fn from_engine(engine: Arc<DispatchEngine>) -> Self {
+        Self { engine }
     }
 }
 
@@ -244,16 +255,22 @@ impl EventBus for EventBusImpl {
 
     async fn metrics(&self) -> crate::Result<BusMetrics> {
         use std::sync::atomic::Ordering;
-        // events_pending_retry: query the store. We use u32::MAX as the
-        // "give me everything that could ever retry" upper bound and a large
-        // limit so the count is approximate but useful.
-        let pending_retry = self
+        // Use the dedicated count_retryable method (O(failed events) for
+        // ReDB, O(events) for in-memory) instead of fetching full delivery
+        // records just to count them. Errors are logged so operators see
+        // a signal rather than a silent zero.
+        let pending_retry = match self
             .engine
             .store
-            .query_retryable(u32::MAX, 10_000)
+            .count_retryable(self.engine.retry_config.max_attempts)
             .await
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
+        {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, "metrics: count_retryable failed");
+                0
+            }
+        };
 
         Ok(BusMetrics {
             events_published: self.engine.events_published.load(Ordering::Relaxed),

--- a/crates/core/seidrum-eventbus/src/bus.rs
+++ b/crates/core/seidrum-eventbus/src/bus.rs
@@ -151,6 +151,23 @@ impl EventBusImpl {
             engine: Arc::new(DispatchEngine::new(store)),
         }
     }
+
+    /// Construct an EventBusImpl that shares a [`crate::delivery::ChannelRegistry`]
+    /// with the dispatch engine. The registry is used by the retry task for
+    /// looking up `ChannelConfig::Custom` delivery channels.
+    pub fn with_registry(
+        store: Arc<dyn EventStore>,
+        registry: Arc<crate::delivery::ChannelRegistry>,
+    ) -> Self {
+        Self {
+            engine: Arc::new(DispatchEngine::with_registry(store, registry)),
+        }
+    }
+
+    /// Internal accessor used by the builder to spawn the retry task.
+    pub(crate) fn engine(&self) -> Arc<DispatchEngine> {
+        Arc::clone(&self.engine)
+    }
 }
 
 #[async_trait]

--- a/crates/core/seidrum-eventbus/src/delivery/mod.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/mod.rs
@@ -28,14 +28,20 @@ use thiserror::Error;
 
 pub use in_process::InProcessChannel;
 pub use registry::ChannelRegistry;
-pub use retry::{calculate_backoff, RetryConfig, RetryTask};
+pub use retry::{calculate_backoff, next_retry_after, RetryConfig, RetryTask};
 pub use webhook::WebhookChannel;
 pub use websocket::{WebSocketChannel, WebSocketMessage};
 
 #[derive(Debug, Error)]
 pub enum DeliveryError {
+    /// Transient delivery failure — the delivery should be retried.
     #[error("delivery failed: {0}")]
     Failed(String),
+    /// Permanent delivery failure — retrying will not help. The retry task
+    /// dead-letters deliveries that return this variant.
+    #[error("delivery permanently failed: {0}")]
+    Permanent(String),
+    /// The channel is not ready to deliver (e.g., closed connection).
     #[error("channel not ready")]
     NotReady,
 }

--- a/crates/core/seidrum-eventbus/src/delivery/registry.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/registry.rs
@@ -26,8 +26,18 @@ impl ChannelRegistry {
     }
 
     /// Register a delivery channel by type name.
+    ///
+    /// If a channel was already registered under the same type name it is
+    /// silently replaced; a warning is logged so accidental shadowing is
+    /// visible in operator logs.
     pub async fn register(&self, type_name: &str, channel: Arc<dyn DeliveryChannel>) {
         let mut channels = self.channels.write().await;
+        if channels.contains_key(type_name) {
+            tracing::warn!(
+                channel_type = type_name,
+                "ChannelRegistry: replacing existing registration"
+            );
+        }
         channels.insert(type_name.to_string(), channel);
     }
 

--- a/crates/core/seidrum-eventbus/src/delivery/retry.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/retry.rs
@@ -1,13 +1,15 @@
 //! Background retry task for failed deliveries.
 //!
-//! Periodically polls the event store for retryable deliveries,
-//! re-attempts delivery, and handles backoff logic.
-//!
-//! **Status: Phase 5 stub.** The polling and backoff infrastructure is in
-//! place, but `retry_delivery` does not yet re-invoke delivery channels.
-//! Do not rely on this task for automatic retries until Phase 5 is complete.
+//! Periodically polls the event store for retryable deliveries and re-attempts
+//! them via the [`crate::dispatch::DispatchEngine`]. The engine looks up the
+//! live subscription, routes to the correct delivery channel, and reports
+//! the outcome. Successful retries are recorded as `Delivered`; transient
+//! failures are recorded as `Failed` (retried after exponential backoff);
+//! permanent failures and exhausted attempts are recorded as `DeadLettered`.
 
-use crate::storage::{EventStore, RetryableDelivery};
+use crate::dispatch::engine::RetryOutcome;
+use crate::dispatch::DispatchEngine;
+use crate::storage::{DeliveryStatus, EventStatus, EventStore, RetryableDelivery};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -47,15 +49,17 @@ pub fn calculate_backoff(attempt: u32, initial_ms: u64, max_ms: u64) -> Duration
 
 /// Background task for retrying failed deliveries.
 ///
-/// **Phase 5 stub:** The task polls the store and computes backoff, but
-/// `retry_delivery` currently logs a warning and skips actual re-delivery.
-/// Wire up delivery channel lookup + re-invocation in Phase 5.
+/// Polls the store on a fixed interval, calls
+/// [`DispatchEngine::retry_to_subscriber`] for each retryable delivery,
+/// and updates the store with the outcome.
+///
+/// Backoff timing is computed by the store implementation in
+/// `record_delivery` (currently 100ms × 2^attempts capped at 30s).
 pub struct RetryTask {
     store: Arc<dyn EventStore>,
+    engine: Arc<DispatchEngine>,
     max_attempts: u32,
     poll_interval: Duration,
-    initial_backoff_ms: u64,
-    max_backoff_ms: u64,
     shutdown_rx: watch::Receiver<bool>,
 }
 
@@ -63,18 +67,16 @@ impl RetryTask {
     /// Create a new retry task.
     pub fn new(
         store: Arc<dyn EventStore>,
+        engine: Arc<DispatchEngine>,
         max_attempts: u32,
         poll_interval: Duration,
-        initial_backoff_ms: u64,
-        max_backoff_ms: u64,
         shutdown_rx: watch::Receiver<bool>,
     ) -> Self {
         Self {
             store,
+            engine,
             max_attempts,
             poll_interval,
-            initial_backoff_ms,
-            max_backoff_ms,
             shutdown_rx,
         }
     }
@@ -129,27 +131,164 @@ impl RetryTask {
     }
 
     async fn retry_delivery(&self, delivery: &RetryableDelivery) {
-        // TODO(phase5): Implement actual retry delivery logic.
-        // This requires:
-        //   1. Looking up the delivery channel for this subscriber
-        //   2. Calling deliver() on it with the original payload
-        //   3. Recording success/failure in the store
-        //   4. Applying backoff on failure
-        // For now, log a warning so operators know retries are not yet active.
-        warn!(
-            "Retry delivery is a stub — skipping seq={} subscriber={} attempt={}",
-            delivery.seq, delivery.subscriber_id, delivery.attempts
+        debug!(
+            seq = delivery.seq,
+            subscriber = delivery.subscriber_id,
+            attempt = delivery.attempts,
+            "retrying delivery"
         );
 
-        let backoff = calculate_backoff(
-            delivery.attempts,
-            self.initial_backoff_ms,
-            self.max_backoff_ms,
-        );
-        debug!(
-            "Next retry would be scheduled in {:?} for seq={}",
-            backoff, delivery.seq
-        );
+        // If we've already exhausted attempts, dead-letter immediately.
+        // (query_retryable filters by attempts < max_attempts, so this is
+        // a defensive check.)
+        if delivery.attempts >= self.max_attempts {
+            self.dead_letter(delivery, "max attempts exceeded").await;
+            return;
+        }
+
+        // Attempt the retry via the engine
+        let result = self
+            .engine
+            .retry_to_subscriber(
+                &delivery.subscriber_id,
+                &delivery.subject,
+                &delivery.payload,
+            )
+            .await;
+
+        match result {
+            Ok(()) => {
+                debug!(
+                    seq = delivery.seq,
+                    subscriber = delivery.subscriber_id,
+                    "retry succeeded"
+                );
+                if let Err(e) = self
+                    .store
+                    .record_delivery(
+                        delivery.seq,
+                        &delivery.subscriber_id,
+                        DeliveryStatus::Delivered,
+                        None,
+                    )
+                    .await
+                {
+                    warn!(seq = delivery.seq, error = %e, "failed to record retry success");
+                }
+                // Re-evaluate the parent event's status now that one more
+                // subscriber is delivered.
+                self.maybe_finalize_event(delivery.seq).await;
+            }
+            Err(RetryOutcome::Transient(msg)) => {
+                let new_attempts = delivery.attempts + 1;
+                debug!(
+                    seq = delivery.seq,
+                    subscriber = delivery.subscriber_id,
+                    attempt = new_attempts,
+                    error = %msg,
+                    "retry failed (transient)"
+                );
+                // record_delivery increments attempts and computes next_retry
+                // backoff via the store implementation.
+                if let Err(e) = self
+                    .store
+                    .record_delivery(
+                        delivery.seq,
+                        &delivery.subscriber_id,
+                        DeliveryStatus::Failed,
+                        Some(msg.clone()),
+                    )
+                    .await
+                {
+                    warn!(seq = delivery.seq, error = %e, "failed to record retry failure");
+                }
+                // If this attempt was the last allowed one, dead-letter
+                // immediately. Otherwise the entry would stop being returned
+                // by query_retryable (which filters attempts < max_attempts)
+                // and would be stuck in Failed state forever.
+                if new_attempts >= self.max_attempts {
+                    self.dead_letter(
+                        delivery,
+                        &format!("max attempts ({}) exhausted: {}", self.max_attempts, msg),
+                    )
+                    .await;
+                }
+            }
+            Err(RetryOutcome::Permanent(msg)) => {
+                debug!(
+                    seq = delivery.seq,
+                    subscriber = delivery.subscriber_id,
+                    error = %msg,
+                    "retry failed (permanent), dead-lettering"
+                );
+                self.dead_letter(delivery, &msg).await;
+            }
+        }
+    }
+
+    /// Mark a delivery as dead-lettered and update the parent event status
+    /// if all subscribers are now in a terminal state.
+    async fn dead_letter(&self, delivery: &RetryableDelivery, reason: &str) {
+        if let Err(e) = self
+            .store
+            .record_delivery(
+                delivery.seq,
+                &delivery.subscriber_id,
+                DeliveryStatus::DeadLettered,
+                Some(format!("dead-lettered: {}", reason)),
+            )
+            .await
+        {
+            warn!(seq = delivery.seq, error = %e, "failed to record dead-letter");
+        }
+        self.maybe_finalize_event(delivery.seq).await;
+    }
+
+    /// If every delivery for an event is in a terminal state (Delivered or
+    /// DeadLettered), update the event status accordingly. Sets the event
+    /// to `DeadLettered` if any delivery is dead-lettered, otherwise
+    /// `Delivered`.
+    async fn maybe_finalize_event(&self, seq: u64) {
+        // Read the event back from the store to inspect its delivery records.
+        let events = match self
+            .store
+            .query_by_status(EventStatus::PartiallyDelivered, 10_000)
+            .await
+        {
+            Ok(events) => events,
+            Err(e) => {
+                warn!(seq = seq, error = %e, "failed to query events for finalization");
+                return;
+            }
+        };
+        let event = match events.into_iter().find(|e| e.seq == seq) {
+            Some(e) => e,
+            None => return, // Already finalized or not found
+        };
+
+        // Check if every delivery is terminal (Delivered or DeadLettered).
+        let all_terminal = event.deliveries.iter().all(|d| {
+            matches!(
+                d.status,
+                DeliveryStatus::Delivered | DeliveryStatus::DeadLettered
+            )
+        });
+        if !all_terminal {
+            return;
+        }
+
+        let any_dead = event
+            .deliveries
+            .iter()
+            .any(|d| d.status == DeliveryStatus::DeadLettered);
+        let final_status = if any_dead {
+            EventStatus::DeadLettered
+        } else {
+            EventStatus::Delivered
+        };
+        if let Err(e) = self.store.update_status(seq, final_status).await {
+            warn!(seq = seq, error = %e, "failed to finalize event status");
+        }
     }
 }
 

--- a/crates/core/seidrum-eventbus/src/delivery/retry.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/retry.rs
@@ -217,27 +217,12 @@ impl RetryTask {
                     error = %msg,
                     "retry failed (transient)"
                 );
-                // Compute next_retry from the new attempt count using the
-                // canonical backoff helper.
-                let next_retry = next_retry_after(new_attempts, &self.config);
-                if let Err(e) = self
-                    .store
-                    .record_delivery(
-                        delivery.seq,
-                        &delivery.subscriber_id,
-                        DeliveryStatus::Failed,
-                        Some(msg.clone()),
-                        Some(next_retry),
-                    )
-                    .await
-                {
-                    warn!(seq = delivery.seq, error = %e, "failed to record retry failure");
-                }
-                // If this attempt was the last allowed one, dead-letter
-                // immediately. Otherwise the entry would stop being returned
-                // by query_retryable (which filters attempts < max_attempts)
-                // and would be stuck in Failed state forever.
                 if new_attempts >= self.config.max_attempts {
+                    // Last allowed attempt has just been used up. Skip the
+                    // intermediate Failed write and dead-letter directly
+                    // (was: record Failed then immediately overwrite with
+                    // DeadLettered, which produced two write transactions
+                    // and a brief window where the delivery looked retryable).
                     self.dead_letter(
                         delivery,
                         &format!(
@@ -246,6 +231,23 @@ impl RetryTask {
                         ),
                     )
                     .await;
+                } else {
+                    // Compute next_retry from the new attempt count using
+                    // the canonical backoff helper, then record the failure.
+                    let next_retry = next_retry_after(new_attempts, &self.config);
+                    if let Err(e) = self
+                        .store
+                        .record_delivery(
+                            delivery.seq,
+                            &delivery.subscriber_id,
+                            DeliveryStatus::Failed,
+                            Some(msg.clone()),
+                            Some(next_retry),
+                        )
+                        .await
+                    {
+                        warn!(seq = delivery.seq, error = %e, "failed to record retry failure");
+                    }
                 }
             }
             Err(RetryOutcome::Permanent(msg)) => {

--- a/crates/core/seidrum-eventbus/src/delivery/retry.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/retry.rs
@@ -37,14 +37,35 @@ impl Default for RetryConfig {
     }
 }
 
-/// Exponential backoff with jitter for retries.
+/// Canonical exponential backoff with subtractive jitter.
+///
+/// `attempt` is the *next* attempt number (1-indexed). Returns
+/// `initial_ms × 2^(attempt-1)` capped at `max_ms`, with up to 25%
+/// subtractive jitter.
+///
+/// Used by both the dispatch engine (when recording an initial failure)
+/// and the retry task (when recording a retry failure) so all backoff
+/// timing flows through one source of truth.
 pub fn calculate_backoff(attempt: u32, initial_ms: u64, max_ms: u64) -> Duration {
-    let base_ms = initial_ms.saturating_mul(2_u64.saturating_pow(attempt));
+    // Subtract 1 so the first attempt waits initial_ms, not 2*initial_ms.
+    let exp = attempt.saturating_sub(1);
+    let base_ms = initial_ms.saturating_mul(2_u64.saturating_pow(exp));
     let capped_ms = base_ms.min(max_ms);
-    // Jitter is subtracted (not added) so the result never exceeds capped_ms.
     let jitter_range = (capped_ms / 4).max(1);
     let jitter_ms = rand::random_range(0..jitter_range);
     Duration::from_millis(capped_ms - jitter_ms)
+}
+
+/// Compute the next retry timestamp (unix-millis) for a delivery that just
+/// failed and now has `attempts` total failures recorded. Convenience wrapper
+/// over [`calculate_backoff`] that adds the backoff to the current time.
+pub fn next_retry_after(attempts: u32, config: &RetryConfig) -> u64 {
+    let backoff = calculate_backoff(attempts, config.initial_backoff_ms, config.max_backoff_ms);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    now + backoff.as_millis() as u64
 }
 
 /// Background task for retrying failed deliveries.
@@ -53,13 +74,14 @@ pub fn calculate_backoff(attempt: u32, initial_ms: u64, max_ms: u64) -> Duration
 /// [`DispatchEngine::retry_to_subscriber`] for each retryable delivery,
 /// and updates the store with the outcome.
 ///
-/// Backoff timing is computed by the store implementation in
-/// `record_delivery` (currently 100ms × 2^attempts capped at 30s).
+/// All backoff timing flows through [`calculate_backoff`] / [`next_retry_after`]
+/// using the [`RetryConfig`] supplied at construction.
 pub struct RetryTask {
     store: Arc<dyn EventStore>,
     engine: Arc<DispatchEngine>,
-    max_attempts: u32,
+    config: Arc<RetryConfig>,
     poll_interval: Duration,
+    query_limit: usize,
     shutdown_rx: watch::Receiver<bool>,
 }
 
@@ -68,30 +90,37 @@ impl RetryTask {
     pub fn new(
         store: Arc<dyn EventStore>,
         engine: Arc<DispatchEngine>,
-        max_attempts: u32,
+        config: Arc<RetryConfig>,
         poll_interval: Duration,
+        query_limit: usize,
         shutdown_rx: watch::Receiver<bool>,
     ) -> Self {
         Self {
             store,
             engine,
-            max_attempts,
+            config,
             poll_interval,
+            query_limit,
             shutdown_rx,
         }
     }
 
     /// Run the retry task continuously until a shutdown signal is received.
     /// This task polls the store periodically and retries failed deliveries.
-    pub async fn run(mut self) {
+    pub async fn run(self) {
         info!("Retry task starting");
 
-        // If shutdown was already signaled before we started, exit immediately
-        // rather than waiting a full poll interval to detect it.
+        // Check pre-signaled shutdown to avoid waiting a full poll interval.
         if *self.shutdown_rx.borrow() {
             info!("Retry task shutting down (pre-signaled)");
             return;
         }
+
+        // Move shutdown_rx out so the select! arm can take a mutable
+        // borrow without conflicting with the &self borrow used by
+        // poll_and_retry(). Use changed() (which returns a Send result)
+        // rather than wait_for (which returns a non-Send watch::Ref).
+        let mut shutdown_rx = self.shutdown_rx.clone();
 
         loop {
             tokio::select! {
@@ -100,8 +129,8 @@ impl RetryTask {
                         error!("Error during retry poll: {}", e);
                     }
                 }
-                result = self.shutdown_rx.changed() => {
-                    if result.is_err() || *self.shutdown_rx.borrow() {
+                result = shutdown_rx.changed() => {
+                    if result.is_err() || *shutdown_rx.borrow() {
                         info!("Retry task shutting down");
                         break;
                     }
@@ -113,7 +142,7 @@ impl RetryTask {
     async fn poll_and_retry(&self) -> crate::Result<()> {
         let retryables = self
             .store
-            .query_retryable(self.max_attempts, 100)
+            .query_retryable(self.config.max_attempts, self.query_limit)
             .await
             .map_err(crate::EventBusError::Storage)?;
 
@@ -138,21 +167,22 @@ impl RetryTask {
             "retrying delivery"
         );
 
-        // If we've already exhausted attempts, dead-letter immediately.
-        // (query_retryable filters by attempts < max_attempts, so this is
-        // a defensive check.)
-        if delivery.attempts >= self.max_attempts {
+        // Defensive: query_retryable filters attempts < max_attempts.
+        if delivery.attempts >= self.config.max_attempts {
             self.dead_letter(delivery, "max attempts exceeded").await;
             return;
         }
 
-        // Attempt the retry via the engine
+        // Attempt the retry via the engine, propagating reply_subject so
+        // request/reply handlers see a working Replier.
         let result = self
             .engine
             .retry_to_subscriber(
                 &delivery.subscriber_id,
                 &delivery.subject,
                 &delivery.payload,
+                delivery.reply_subject.clone(),
+                delivery.seq,
             )
             .await;
 
@@ -170,13 +200,12 @@ impl RetryTask {
                         &delivery.subscriber_id,
                         DeliveryStatus::Delivered,
                         None,
+                        None,
                     )
                     .await
                 {
                     warn!(seq = delivery.seq, error = %e, "failed to record retry success");
                 }
-                // Re-evaluate the parent event's status now that one more
-                // subscriber is delivered.
                 self.maybe_finalize_event(delivery.seq).await;
             }
             Err(RetryOutcome::Transient(msg)) => {
@@ -188,8 +217,9 @@ impl RetryTask {
                     error = %msg,
                     "retry failed (transient)"
                 );
-                // record_delivery increments attempts and computes next_retry
-                // backoff via the store implementation.
+                // Compute next_retry from the new attempt count using the
+                // canonical backoff helper.
+                let next_retry = next_retry_after(new_attempts, &self.config);
                 if let Err(e) = self
                     .store
                     .record_delivery(
@@ -197,6 +227,7 @@ impl RetryTask {
                         &delivery.subscriber_id,
                         DeliveryStatus::Failed,
                         Some(msg.clone()),
+                        Some(next_retry),
                     )
                     .await
                 {
@@ -206,10 +237,13 @@ impl RetryTask {
                 // immediately. Otherwise the entry would stop being returned
                 // by query_retryable (which filters attempts < max_attempts)
                 // and would be stuck in Failed state forever.
-                if new_attempts >= self.max_attempts {
+                if new_attempts >= self.config.max_attempts {
                     self.dead_letter(
                         delivery,
-                        &format!("max attempts ({}) exhausted: {}", self.max_attempts, msg),
+                        &format!(
+                            "max attempts ({}) exhausted: {}",
+                            self.config.max_attempts, msg
+                        ),
                     )
                     .await;
                 }
@@ -229,13 +263,17 @@ impl RetryTask {
     /// Mark a delivery as dead-lettered and update the parent event status
     /// if all subscribers are now in a terminal state.
     async fn dead_letter(&self, delivery: &RetryableDelivery, reason: &str) {
+        // Use a single canonical reason format so log/error parsing is
+        // consistent across all dead-letter sources.
+        let formatted = format!("dead-lettered: {}", reason);
         if let Err(e) = self
             .store
             .record_delivery(
                 delivery.seq,
                 &delivery.subscriber_id,
                 DeliveryStatus::DeadLettered,
-                Some(format!("dead-lettered: {}", reason)),
+                Some(formatted),
+                None,
             )
             .await
         {
@@ -245,25 +283,19 @@ impl RetryTask {
     }
 
     /// If every delivery for an event is in a terminal state (Delivered or
-    /// DeadLettered), update the event status accordingly. Sets the event
-    /// to `DeadLettered` if any delivery is dead-lettered, otherwise
-    /// `Delivered`.
+    /// DeadLettered), update the event status accordingly.
+    ///
+    /// Uses [`EventStore::get`] to load the specific event, avoiding the
+    /// status-based scan + bounded-window failure modes of the previous
+    /// implementation.
     async fn maybe_finalize_event(&self, seq: u64) {
-        // Read the event back from the store to inspect its delivery records.
-        let events = match self
-            .store
-            .query_by_status(EventStatus::PartiallyDelivered, 10_000)
-            .await
-        {
-            Ok(events) => events,
+        let event = match self.store.get(seq).await {
+            Ok(Some(e)) => e,
+            Ok(None) => return, // Compacted away
             Err(e) => {
-                warn!(seq = seq, error = %e, "failed to query events for finalization");
+                warn!(seq = seq, error = %e, "failed to load event for finalization");
                 return;
             }
-        };
-        let event = match events.into_iter().find(|e| e.seq == seq) {
-            Some(e) => e,
-            None => return, // Already finalized or not found
         };
 
         // Check if every delivery is terminal (Delivered or DeadLettered).
@@ -306,27 +338,27 @@ mod tests {
 
     #[test]
     fn test_calculate_backoff() {
-        let d1 = calculate_backoff(0, 100, 30000);
-        // attempt 0: base=100, jitter subtracts up to 25 → 75..100
+        // attempt 1 (first retry): base=100, jitter subtracts up to 25 → 75..100
+        let d1 = calculate_backoff(1, 100, 30000);
         assert!(d1 >= Duration::from_millis(75));
         assert!(d1 <= Duration::from_millis(100));
 
-        let d2 = calculate_backoff(1, 100, 30000);
-        // attempt 1: base=200, jitter subtracts up to 50 → 150..200
+        // attempt 2: base=200, jitter subtracts up to 50 → 150..200
+        let d2 = calculate_backoff(2, 100, 30000);
         assert!(d2 >= Duration::from_millis(150));
         assert!(d2 <= Duration::from_millis(200));
 
-        let d3 = calculate_backoff(10, 100, 30000);
-        // attempt 10: base capped at 30000, jitter subtracts up to 7500 → 22500..30000
-        assert!(d3 <= Duration::from_millis(30000));
-        assert!(d3 >= Duration::from_millis(22500));
+        // attempt 11: 100 * 2^10 = 102400, capped at 30000
+        let d11 = calculate_backoff(11, 100, 30000);
+        assert!(d11 <= Duration::from_millis(30000));
+        assert!(d11 >= Duration::from_millis(22500));
     }
 
     #[test]
     fn test_calculate_backoff_jitter() {
         let mut durations = Vec::new();
         for _ in 0..10 {
-            durations.push(calculate_backoff(1, 100, 30000));
+            durations.push(calculate_backoff(2, 100, 30000));
         }
 
         // All should be different due to jitter

--- a/crates/core/seidrum-eventbus/src/delivery/webhook.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/webhook.rs
@@ -80,13 +80,21 @@ impl DeliveryChannel for WebhookChannel {
             .await
             .map_err(|e| DeliveryError::Failed(format!("HTTP request failed: {}", e)))?;
 
-        // Check status code
-        if !response.status().is_success() {
-            return Err(DeliveryError::Failed(format!(
+        // Classify status code: 4xx is permanent (auth errors, not-found,
+        // method-not-allowed don't get better with retries); 5xx and other
+        // failures are transient.
+        let status = response.status();
+        if !status.is_success() {
+            let msg = format!(
                 "HTTP {}: {}",
-                response.status().as_u16(),
-                response.status().canonical_reason().unwrap_or("unknown")
-            )));
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("unknown")
+            );
+            // Treat 408 Request Timeout and 429 Too Many Requests as transient.
+            if status.is_client_error() && status.as_u16() != 408 && status.as_u16() != 429 {
+                return Err(DeliveryError::Permanent(msg));
+            }
+            return Err(DeliveryError::Failed(msg));
         }
 
         let elapsed = SystemTime::now()

--- a/crates/core/seidrum-eventbus/src/delivery/webhook.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/webhook.rs
@@ -90,8 +90,11 @@ impl DeliveryChannel for WebhookChannel {
                 status.as_u16(),
                 status.canonical_reason().unwrap_or("unknown")
             );
-            // Treat 408 Request Timeout and 429 Too Many Requests as transient.
-            if status.is_client_error() && status.as_u16() != 408 && status.as_u16() != 429 {
+            // Treat 408 (Request Timeout), 425 (Too Early — RFC 8470:
+            // "try again later"), and 429 (Too Many Requests) as transient.
+            // All other 4xx are permanent.
+            let code = status.as_u16();
+            if status.is_client_error() && code != 408 && code != 425 && code != 429 {
                 return Err(DeliveryError::Permanent(msg));
             }
             return Err(DeliveryError::Failed(msg));

--- a/crates/core/seidrum-eventbus/src/dispatch/engine.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/engine.rs
@@ -79,6 +79,10 @@ pub struct DispatchEngine {
     pub(crate) events_published: AtomicU64,
     /// Counter incremented for every successful subscriber delivery.
     pub(crate) events_delivered: AtomicU64,
+    /// Registry of custom delivery channels for retry execution.
+    pub(crate) channel_registry: Arc<crate::delivery::ChannelRegistry>,
+    /// Built-in webhook delivery channel used by the retry task.
+    pub(crate) webhook_channel: Arc<crate::delivery::WebhookChannel>,
 }
 
 pub(crate) struct DispatchState {
@@ -90,6 +94,13 @@ pub(crate) struct DispatchState {
 
 impl DispatchEngine {
     pub fn new(store: Arc<dyn EventStore>) -> Self {
+        Self::with_registry(store, Arc::new(crate::delivery::ChannelRegistry::new()))
+    }
+
+    pub fn with_registry(
+        store: Arc<dyn EventStore>,
+        channel_registry: Arc<crate::delivery::ChannelRegistry>,
+    ) -> Self {
         Self {
             store,
             state: Arc::new(RwLock::new(DispatchState {
@@ -99,6 +110,8 @@ impl DispatchEngine {
             })),
             events_published: AtomicU64::new(0),
             events_delivered: AtomicU64::new(0),
+            channel_registry,
+            webhook_channel: crate::delivery::WebhookChannel::new(),
         }
     }
 
@@ -595,6 +608,115 @@ impl DispatchEngine {
                 mode: format!("{:?}", e.mode),
             })
             .collect())
+    }
+
+    /// Retry delivery to a specific subscriber. Used by [`crate::delivery::RetryTask`].
+    ///
+    /// Looks up the live subscription by `subscriber_id`, then dispatches the
+    /// payload through the channel configured on that subscription. Returns
+    /// `Ok(())` on successful delivery, `Err(RetryOutcome::Permanent)` if the
+    /// subscriber is gone or the channel cannot be retried (e.g., closed
+    /// WebSocket), or `Err(RetryOutcome::Transient)` if delivery failed and
+    /// can be retried again.
+    pub async fn retry_to_subscriber(
+        &self,
+        subscriber_id: &str,
+        subject: &str,
+        payload: &[u8],
+    ) -> Result<(), RetryOutcome> {
+        // Look up the live subscription
+        let entry = {
+            let state = self.state.read().await;
+            state.index.find_by_id(subscriber_id)
+        };
+        let entry = match entry {
+            Some(e) => e,
+            None => {
+                // Subscription is gone — cannot retry
+                return Err(RetryOutcome::Permanent(format!(
+                    "subscriber {} no longer exists",
+                    subscriber_id
+                )));
+            }
+        };
+
+        match &entry.channel {
+            ChannelConfig::Webhook { .. } => {
+                use crate::delivery::DeliveryChannel;
+                self.webhook_channel
+                    .deliver(payload, subject, &entry.channel)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+            }
+            ChannelConfig::Custom { channel_type, .. } => {
+                let channel_opt = self.channel_registry.get(channel_type).await;
+                let channel = match channel_opt {
+                    Some(c) => c,
+                    None => {
+                        return Err(RetryOutcome::Permanent(format!(
+                            "no channel registered for type '{}'",
+                            channel_type
+                        )));
+                    }
+                };
+                channel
+                    .deliver(payload, subject, &entry.channel)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+            }
+            ChannelConfig::InProcess => {
+                // Try to push through the live mpsc sender. If the consumer
+                // is still draining, this may now succeed even if the original
+                // try_send failed.
+                let state = self.state.read().await;
+                let tx = match state.senders.get(subscriber_id) {
+                    Some(tx) => tx.clone(),
+                    None => {
+                        return Err(RetryOutcome::Permanent(
+                            "in-process sender no longer registered".to_string(),
+                        ));
+                    }
+                };
+                drop(state);
+                let event = crate::request_reply::DispatchedEvent {
+                    payload: payload.to_vec(),
+                    reply_subject: None,
+                    subject: subject.to_string(),
+                    seq: 0, // unknown at retry time
+                };
+                tx.try_send(event)
+                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+            }
+            ChannelConfig::WebSocket => {
+                // WebSocket connections are per-session and cannot survive
+                // a retry — the original connection is gone by the time we
+                // get here. Mark as permanent.
+                Err(RetryOutcome::Permanent(
+                    "WebSocket subscriptions are not retryable".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// Outcome of a retry attempt.
+#[derive(Debug, Clone)]
+pub enum RetryOutcome {
+    /// The retry failed but is eligible for further attempts.
+    Transient(String),
+    /// The retry cannot succeed (subscriber gone, channel type not retryable).
+    /// The caller should dead-letter this delivery.
+    Permanent(String),
+}
+
+impl std::fmt::Display for RetryOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RetryOutcome::Transient(msg) => write!(f, "transient: {}", msg),
+            RetryOutcome::Permanent(msg) => write!(f, "permanent: {}", msg),
+        }
     }
 }
 

--- a/crates/core/seidrum-eventbus/src/dispatch/engine.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/engine.rs
@@ -81,8 +81,10 @@ pub struct DispatchEngine {
     pub(crate) events_delivered: AtomicU64,
     /// Registry of custom delivery channels for retry execution.
     pub(crate) channel_registry: Arc<crate::delivery::ChannelRegistry>,
-    /// Built-in webhook delivery channel used by the retry task.
+    /// Shared webhook delivery channel used for both initial delivery and retries.
     pub(crate) webhook_channel: Arc<crate::delivery::WebhookChannel>,
+    /// Retry backoff configuration applied when recording delivery failures.
+    pub(crate) retry_config: Arc<crate::delivery::RetryConfig>,
 }
 
 pub(crate) struct DispatchState {
@@ -94,12 +96,35 @@ pub(crate) struct DispatchState {
 
 impl DispatchEngine {
     pub fn new(store: Arc<dyn EventStore>) -> Self {
-        Self::with_registry(store, Arc::new(crate::delivery::ChannelRegistry::new()))
+        Self::with_components(
+            store,
+            Arc::new(crate::delivery::ChannelRegistry::new()),
+            crate::delivery::WebhookChannel::new(),
+            Arc::new(crate::delivery::RetryConfig::default()),
+        )
     }
 
     pub fn with_registry(
         store: Arc<dyn EventStore>,
         channel_registry: Arc<crate::delivery::ChannelRegistry>,
+    ) -> Self {
+        Self::with_components(
+            store,
+            channel_registry,
+            crate::delivery::WebhookChannel::new(),
+            Arc::new(crate::delivery::RetryConfig::default()),
+        )
+    }
+
+    /// Construct a `DispatchEngine` with all components explicitly supplied.
+    /// Used by [`crate::EventBusBuilder`] so the same channel registry,
+    /// webhook channel, and retry config are shared with the HTTP transport
+    /// and retry task.
+    pub fn with_components(
+        store: Arc<dyn EventStore>,
+        channel_registry: Arc<crate::delivery::ChannelRegistry>,
+        webhook_channel: Arc<crate::delivery::WebhookChannel>,
+        retry_config: Arc<crate::delivery::RetryConfig>,
     ) -> Self {
         Self {
             store,
@@ -111,7 +136,8 @@ impl DispatchEngine {
             events_published: AtomicU64::new(0),
             events_delivered: AtomicU64::new(0),
             channel_registry,
-            webhook_channel: crate::delivery::WebhookChannel::new(),
+            webhook_channel,
+            retry_config,
         }
     }
 
@@ -218,17 +244,33 @@ impl DispatchEngine {
         let event_reply_subject = reply_subject;
 
         // Helper: record delivery only for persisted (non-reply) events.
+        // For Failed transitions, computes next_retry from the engine's
+        // RetryConfig (this is the *first* failure on this subscriber, so
+        // the post-store attempt count will be 1).
         let store = &self.store;
         let delivered_counter = &self.events_delivered;
-        let try_record = |seq: u64, sub_id: &str, status: DeliveryStatus, error: Option<String>| {
+        let retry_config = Arc::clone(&self.retry_config);
+        let try_record = move |seq: u64,
+                               sub_id: &str,
+                               status: DeliveryStatus,
+                               error: Option<String>| {
             let sub_id = sub_id.to_string();
             let store = Arc::clone(store);
+            let retry_config = Arc::clone(&retry_config);
             async move {
                 if status == DeliveryStatus::Delivered {
                     delivered_counter.fetch_add(1, Ordering::Relaxed);
                 }
+                let next_retry = if status == DeliveryStatus::Failed {
+                    Some(crate::delivery::next_retry_after(1, &retry_config))
+                } else {
+                    None
+                };
                 if !is_reply {
-                    if let Err(e) = store.record_delivery(seq, &sub_id, status, error).await {
+                    if let Err(e) = store
+                        .record_delivery(seq, &sub_id, status, error, next_retry)
+                        .await
+                    {
                         warn!(seq = seq, subscriber = sub_id, error = %e, "failed to record delivery");
                     }
                 }
@@ -612,27 +654,36 @@ impl DispatchEngine {
 
     /// Retry delivery to a specific subscriber. Used by [`crate::delivery::RetryTask`].
     ///
-    /// Looks up the live subscription by `subscriber_id`, then dispatches the
-    /// payload through the channel configured on that subscription. Returns
-    /// `Ok(())` on successful delivery, `Err(RetryOutcome::Permanent)` if the
-    /// subscriber is gone or the channel cannot be retried (e.g., closed
-    /// WebSocket), or `Err(RetryOutcome::Transient)` if delivery failed and
-    /// can be retried again.
+    /// Looks up the live subscription by `subscriber_id` (in a single read
+    /// lock acquisition that also captures the in-process sender if applicable)
+    /// and dispatches the payload through the configured channel.
+    ///
+    /// Returns:
+    /// - `Ok(())` on successful delivery
+    /// - `Err(RetryOutcome::Permanent)` if the subscriber is gone, the
+    ///   channel type isn't retryable (WebSocket), or no `Custom` handler
+    ///   is registered
+    /// - `Err(RetryOutcome::Transient)` if delivery failed and is eligible
+    ///   for further retry attempts
     pub async fn retry_to_subscriber(
         &self,
         subscriber_id: &str,
         subject: &str,
         payload: &[u8],
+        reply_subject: Option<String>,
+        seq: u64,
     ) -> Result<(), RetryOutcome> {
-        // Look up the live subscription
-        let entry = {
+        // Single lock acquisition: look up the entry AND the in-process
+        // sender, so we don't need to re-acquire later.
+        let (entry, sender) = {
             let state = self.state.read().await;
-            state.index.find_by_id(subscriber_id)
+            let entry = state.index.find_by_id(subscriber_id);
+            let sender = state.senders.get(subscriber_id).cloned();
+            (entry, sender)
         };
         let entry = match entry {
             Some(e) => e,
             None => {
-                // Subscription is gone — cannot retry
                 return Err(RetryOutcome::Permanent(format!(
                     "subscriber {} no longer exists",
                     subscriber_id
@@ -642,14 +693,19 @@ impl DispatchEngine {
 
         match &entry.channel {
             ChannelConfig::Webhook { .. } => {
-                use crate::delivery::DeliveryChannel;
-                self.webhook_channel
+                use crate::delivery::{DeliveryChannel, DeliveryError};
+                match self
+                    .webhook_channel
                     .deliver(payload, subject, &entry.channel)
                     .await
-                    .map(|_| ())
-                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+                {
+                    Ok(_) => Ok(()),
+                    Err(DeliveryError::Permanent(msg)) => Err(RetryOutcome::Permanent(msg)),
+                    Err(e) => Err(RetryOutcome::Transient(format!("{}", e))),
+                }
             }
             ChannelConfig::Custom { channel_type, .. } => {
+                use crate::delivery::DeliveryError;
                 let channel_opt = self.channel_registry.get(channel_type).await;
                 let channel = match channel_opt {
                     Some(c) => c,
@@ -660,31 +716,27 @@ impl DispatchEngine {
                         )));
                     }
                 };
-                channel
-                    .deliver(payload, subject, &entry.channel)
-                    .await
-                    .map(|_| ())
-                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+                match channel.deliver(payload, subject, &entry.channel).await {
+                    Ok(_) => Ok(()),
+                    Err(DeliveryError::Permanent(msg)) => Err(RetryOutcome::Permanent(msg)),
+                    Err(e) => Err(RetryOutcome::Transient(format!("{}", e))),
+                }
             }
             ChannelConfig::InProcess => {
-                // Try to push through the live mpsc sender. If the consumer
-                // is still draining, this may now succeed even if the original
-                // try_send failed.
-                let state = self.state.read().await;
-                let tx = match state.senders.get(subscriber_id) {
-                    Some(tx) => tx.clone(),
+                // Push through the live mpsc sender we captured above.
+                let tx = match sender {
+                    Some(tx) => tx,
                     None => {
                         return Err(RetryOutcome::Permanent(
                             "in-process sender no longer registered".to_string(),
                         ));
                     }
                 };
-                drop(state);
                 let event = crate::request_reply::DispatchedEvent {
                     payload: payload.to_vec(),
-                    reply_subject: None,
+                    reply_subject,
                     subject: subject.to_string(),
-                    seq: 0, // unknown at retry time
+                    seq,
                 };
                 tx.try_send(event)
                     .map_err(|e| RetryOutcome::Transient(format!("{}", e)))

--- a/crates/core/seidrum-eventbus/src/dispatch/engine.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/engine.rs
@@ -85,6 +85,10 @@ pub struct DispatchEngine {
     pub(crate) webhook_channel: Arc<crate::delivery::WebhookChannel>,
     /// Retry backoff configuration applied when recording delivery failures.
     pub(crate) retry_config: Arc<crate::delivery::RetryConfig>,
+    /// Whether a retry task is actually running. Reported via `bus.metrics()`
+    /// so operators can distinguish between "no failed deliveries" and
+    /// "no retry task to drain failed deliveries".
+    pub(crate) retry_enabled: bool,
 }
 
 pub(crate) struct DispatchState {
@@ -95,6 +99,13 @@ pub(crate) struct DispatchState {
 }
 
 impl DispatchEngine {
+    /// Construct a `DispatchEngine` from an event store with default
+    /// retry configuration (`RetryConfig::default()`), an empty channel
+    /// registry, and a fresh `WebhookChannel`.
+    ///
+    /// `retry_enabled` is `false` because no retry task is wired up. Use
+    /// [`crate::EventBusBuilder::with_retry`] to enable durable retries
+    /// in production.
     pub fn new(store: Arc<dyn EventStore>) -> Self {
         Self::with_components(
             store,
@@ -104,6 +115,9 @@ impl DispatchEngine {
         )
     }
 
+    /// Construct a `DispatchEngine` with a user-supplied channel registry.
+    /// Other components default as in [`Self::new`]. `retry_enabled` is
+    /// `false`.
     pub fn with_registry(
         store: Arc<dyn EventStore>,
         channel_registry: Arc<crate::delivery::ChannelRegistry>,
@@ -119,7 +133,8 @@ impl DispatchEngine {
     /// Construct a `DispatchEngine` with all components explicitly supplied.
     /// Used by [`crate::EventBusBuilder`] so the same channel registry,
     /// webhook channel, and retry config are shared with the HTTP transport
-    /// and retry task.
+    /// and retry task. `retry_enabled` defaults to `false`; the builder
+    /// flips it via an internal accessor when `with_retry` is configured.
     pub fn with_components(
         store: Arc<dyn EventStore>,
         channel_registry: Arc<crate::delivery::ChannelRegistry>,
@@ -138,7 +153,14 @@ impl DispatchEngine {
             channel_registry,
             webhook_channel,
             retry_config,
+            retry_enabled: false,
         }
+    }
+
+    /// Mark this engine as having an active retry task. Called by the
+    /// builder when `with_retry` is configured.
+    pub(crate) fn set_retry_enabled(&mut self, enabled: bool) {
+        self.retry_enabled = enabled;
     }
 
     /// Validate a subject string.
@@ -392,12 +414,19 @@ impl DispatchEngine {
                                 "sync interceptor timed out, skipping"
                             );
                             any_failed = true;
+                            // Interceptors are not retryable — they're sync,
+                            // in-process, and have no sender for the retry
+                            // task to dispatch through. Record as
+                            // DeadLettered directly so the retry task
+                            // doesn't pick this up only to discover the
+                            // entry is an interceptor and dead-letter it
+                            // anyway.
                             try_record(
                                 seq,
                                 entry_id,
-                                DeliveryStatus::Failed,
+                                DeliveryStatus::DeadLettered,
                                 Some(format!(
-                                    "interceptor timed out after {}ms",
+                                    "dead-lettered: interceptor timed out after {}ms",
                                     timeout.as_millis()
                                 )),
                             )
@@ -761,15 +790,6 @@ pub enum RetryOutcome {
     /// The retry cannot succeed (subscriber gone, channel type not retryable).
     /// The caller should dead-letter this delivery.
     Permanent(String),
-}
-
-impl std::fmt::Display for RetryOutcome {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RetryOutcome::Transient(msg) => write!(f, "transient: {}", msg),
-            RetryOutcome::Permanent(msg) => write!(f, "permanent: {}", msg),
-        }
-    }
 }
 
 /// Public information about a subscription.

--- a/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
@@ -227,6 +227,41 @@ impl SubjectIndex {
         all
     }
 
+    /// Find a subscription by its ID. O(n) walk over the trie.
+    /// Returns `None` if no subscription with the given ID exists.
+    pub fn find_by_id(&self, id: &str) -> Option<SubscriptionEntry> {
+        let mut found = None;
+        Self::find_by_id_inner(&self.root, id, &mut found);
+        found
+    }
+
+    fn find_by_id_inner(node: &TrieNode, id: &str, out: &mut Option<SubscriptionEntry>) {
+        if out.is_some() {
+            return;
+        }
+        for entry in &node.subscriptions {
+            if entry.id == id {
+                *out = Some(entry.clone());
+                return;
+            }
+        }
+        for entry in &node.terminal_wildcard {
+            if entry.id == id {
+                *out = Some(entry.clone());
+                return;
+            }
+        }
+        for child in node.children.values() {
+            Self::find_by_id_inner(child, id, out);
+            if out.is_some() {
+                return;
+            }
+        }
+        if let Some(ref wildcard) = node.wildcard {
+            Self::find_by_id_inner(wildcard, id, out);
+        }
+    }
+
     fn collect_all(node: &TrieNode, filter: Option<&str>, results: &mut Vec<SubscriptionEntry>) {
         let matches = |entry: &SubscriptionEntry| filter.is_none_or(|f| entry.subject_pattern == f);
         for entry in &node.subscriptions {

--- a/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
@@ -465,6 +465,51 @@ mod tests {
     }
 
     #[test]
+    fn test_find_by_id_exact() {
+        let mut index = SubjectIndex::new();
+        index.subscribe(make_entry("a", "test.exact", 10)).unwrap();
+        let found = index.find_by_id("a");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().subject_pattern, "test.exact");
+    }
+
+    #[test]
+    fn test_find_by_id_star_wildcard() {
+        let mut index = SubjectIndex::new();
+        index
+            .subscribe(make_entry("star", "channel.*.inbound", 10))
+            .unwrap();
+        let found = index.find_by_id("star");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().subject_pattern, "channel.*.inbound");
+    }
+
+    #[test]
+    fn test_find_by_id_gt_wildcard() {
+        let mut index = SubjectIndex::new();
+        index.subscribe(make_entry("gt", "brain.>", 10)).unwrap();
+        let found = index.find_by_id("gt");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().subject_pattern, "brain.>");
+    }
+
+    #[test]
+    fn test_find_by_id_not_found() {
+        let mut index = SubjectIndex::new();
+        index.subscribe(make_entry("a", "test", 10)).unwrap();
+        assert!(index.find_by_id("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_find_by_id_after_unsubscribe() {
+        let mut index = SubjectIndex::new();
+        index.subscribe(make_entry("a", "test", 10)).unwrap();
+        assert!(index.find_by_id("a").is_some());
+        index.unsubscribe("a");
+        assert!(index.find_by_id("a").is_none());
+    }
+
+    #[test]
     fn test_subject_depth_limit() {
         let mut index = SubjectIndex::new();
         let deep_pattern = (0..257)

--- a/crates/core/seidrum-eventbus/src/storage/memory_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/memory_store.rs
@@ -51,6 +51,11 @@ impl EventStore for InMemoryEventStore {
         Ok(seq)
     }
 
+    async fn get(&self, seq: u64) -> StorageResult<Option<StoredEvent>> {
+        let events = self.events.read().await;
+        Ok(events.iter().find(|e| e.seq == seq).cloned())
+    }
+
     async fn update_status(&self, seq: u64, status: EventStatus) -> StorageResult<()> {
         let mut events = self.events.write().await;
         if let Some(event) = events.iter_mut().find(|e| e.seq == seq) {
@@ -67,6 +72,7 @@ impl EventStore for InMemoryEventStore {
         subscriber_id: &str,
         status: DeliveryStatus,
         error: Option<String>,
+        next_retry: Option<u64>,
     ) -> StorageResult<()> {
         let mut events = self.events.write().await;
         if let Some(event) = events.iter_mut().find(|e| e.seq == seq) {
@@ -77,28 +83,29 @@ impl EventStore for InMemoryEventStore {
                 .find(|d| d.subscriber_id == subscriber_id)
             {
                 delivery.status = status;
-                delivery.attempts += 1;
+                // Only count failed retries against attempts; success and
+                // dead-letter transitions preserve the existing count for
+                // accurate observability.
+                if status == DeliveryStatus::Failed {
+                    delivery.attempts += 1;
+                }
                 delivery.last_attempt = Some(Self::current_time_ms());
-                delivery.error = error;
-                delivery.next_retry = if status == DeliveryStatus::Failed {
-                    // Exponential backoff: 100ms * 2^attempts, capped at 30s
-                    let backoff_ms =
-                        100_u64.saturating_mul(2_u64.saturating_pow(delivery.attempts));
-                    Some(Self::current_time_ms() + backoff_ms.min(30_000))
-                } else {
-                    None
-                };
+                // Preserve the previous error on success transitions so the
+                // diagnostic context isn't wiped; replace on failures.
+                if error.is_some() {
+                    delivery.error = error;
+                }
+                delivery.next_retry = next_retry;
             } else {
                 let now = Self::current_time_ms();
-                let next_retry = if status == DeliveryStatus::Failed {
-                    Some(now + 100) // first retry after 100ms
-                } else {
-                    None
-                };
                 event.deliveries.push(DeliveryRecord {
                     subscriber_id: subscriber_id.to_string(),
                     status,
-                    attempts: 1,
+                    attempts: if status == DeliveryStatus::Failed {
+                        1
+                    } else {
+                        0
+                    },
                     last_attempt: Some(now),
                     next_retry,
                     error,
@@ -160,12 +167,34 @@ impl EventStore for InMemoryEventStore {
                         subscriber_id: delivery.subscriber_id.clone(),
                         attempts: delivery.attempts,
                         payload: event.payload.clone(),
+                        reply_subject: event.reply_subject.clone(),
+                        next_retry: delivery.next_retry,
                     });
                 }
             }
         }
 
+        // Sort by next_retry ascending so the earliest-due deliveries come
+        // first. None (no retry scheduled) sorts first.
+        retryable.sort_by_key(|r| r.next_retry.unwrap_or(0));
         Ok(retryable.into_iter().take(limit).collect())
+    }
+
+    async fn count_retryable(&self, max_attempts: u32) -> StorageResult<u64> {
+        let events = self.events.read().await;
+        let now = Self::current_time_ms();
+        let mut count = 0u64;
+        for event in events.iter() {
+            for delivery in &event.deliveries {
+                if delivery.status == DeliveryStatus::Failed
+                    && delivery.attempts < max_attempts
+                    && delivery.next_retry.is_none_or(|t| t <= now)
+                {
+                    count += 1;
+                }
+            }
+        }
+        Ok(count)
     }
 
     async fn compact(&self, older_than: Duration) -> StorageResult<u64> {

--- a/crates/core/seidrum-eventbus/src/storage/memory_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/memory_store.rs
@@ -83,16 +83,23 @@ impl EventStore for InMemoryEventStore {
                 .find(|d| d.subscriber_id == subscriber_id)
             {
                 delivery.status = status;
-                // Only count failed retries against attempts; success and
-                // dead-letter transitions preserve the existing count for
-                // accurate observability.
-                if status == DeliveryStatus::Failed {
+                // Count attempts that represent a real delivery attempt
+                // (Failed and DeadLettered) but not Delivered (which would
+                // produce off-by-one observability).
+                if matches!(
+                    status,
+                    DeliveryStatus::Failed | DeliveryStatus::DeadLettered
+                ) {
                     delivery.attempts += 1;
                 }
                 delivery.last_attempt = Some(Self::current_time_ms());
-                // Preserve the previous error on success transitions so the
-                // diagnostic context isn't wiped; replace on failures.
-                if error.is_some() {
+                // Only overwrite the error on Failed/DeadLettered transitions.
+                // Successful retries preserve the prior failure context for
+                // diagnostics, regardless of what the caller passed.
+                if matches!(
+                    status,
+                    DeliveryStatus::Failed | DeliveryStatus::DeadLettered
+                ) {
                     delivery.error = error;
                 }
                 delivery.next_retry = next_retry;
@@ -157,10 +164,7 @@ impl EventStore for InMemoryEventStore {
         let now = Self::current_time_ms();
         for event in events.iter() {
             for delivery in &event.deliveries {
-                if delivery.status == DeliveryStatus::Failed
-                    && delivery.attempts < max_attempts
-                    && delivery.next_retry.is_none_or(|t| t <= now)
-                {
+                if delivery.is_retryable(max_attempts, now) {
                     retryable.push(RetryableDelivery {
                         seq: event.seq,
                         subject: event.subject.clone(),
@@ -186,10 +190,7 @@ impl EventStore for InMemoryEventStore {
         let mut count = 0u64;
         for event in events.iter() {
             for delivery in &event.deliveries {
-                if delivery.status == DeliveryStatus::Failed
-                    && delivery.attempts < max_attempts
-                    && delivery.next_retry.is_none_or(|t| t <= now)
-                {
+                if delivery.is_retryable(max_attempts, now) {
                     count += 1;
                 }
             }

--- a/crates/core/seidrum-eventbus/src/storage/mod.rs
+++ b/crates/core/seidrum-eventbus/src/storage/mod.rs
@@ -84,6 +84,13 @@ pub trait EventStore: Send + Sync + 'static {
     /// Compact: remove fully-delivered events older than the retention threshold.
     /// Returns the number of events removed.
     async fn compact(&self, older_than: Duration) -> StorageResult<u64>;
+
+    /// Query dead-lettered events for inspection or replay.
+    ///
+    /// Convenience wrapper around `query_by_status(EventStatus::DeadLettered, limit)`.
+    async fn query_dead_lettered(&self, limit: usize) -> StorageResult<Vec<StoredEvent>> {
+        self.query_by_status(EventStatus::DeadLettered, limit).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/seidrum-eventbus/src/storage/mod.rs
+++ b/crates/core/seidrum-eventbus/src/storage/mod.rs
@@ -45,17 +45,36 @@ pub trait EventStore: Send + Sync + 'static {
     /// This is the write-ahead step — the event is durable after this call returns.
     async fn append(&self, event: &StoredEvent) -> StorageResult<u64>;
 
+    /// Fetch a single event by its sequence number.
+    /// Returns `Ok(None)` if no event with that seq exists.
+    async fn get(&self, seq: u64) -> StorageResult<Option<StoredEvent>>;
+
     /// Update the dispatch status of an event.
+    ///
+    /// Implementations should defensively clean any stale per-subscriber
+    /// retry-tracking metadata when transitioning to a terminal state
+    /// (`Delivered` or `DeadLettered`).
     async fn update_status(&self, seq: u64, status: EventStatus) -> StorageResult<()>;
 
     /// Record delivery outcome for one subscriber.
-    /// `error` carries an optional human-readable error message for failed deliveries.
+    ///
+    /// - `error`: optional human-readable error message. Preserved on success
+    ///   transitions so the last failure context isn't wiped.
+    /// - `next_retry`: optional unix-millis timestamp indicating when the
+    ///   delivery is eligible for the next retry attempt. Callers compute
+    ///   this using the canonical [`crate::delivery::calculate_backoff`]
+    ///   helper. Stored verbatim by the implementation.
+    ///
+    /// `attempts` is incremented only on `Failed` transitions; success and
+    /// dead-letter transitions preserve the existing count for accurate
+    /// observability.
     async fn record_delivery(
         &self,
         seq: u64,
         subscriber_id: &str,
         status: DeliveryStatus,
         error: Option<String>,
+        next_retry: Option<u64>,
     ) -> StorageResult<()>;
 
     /// Query events by status (for crash recovery and retry).
@@ -75,11 +94,27 @@ pub trait EventStore: Send + Sync + 'static {
     ) -> StorageResult<Vec<StoredEvent>>;
 
     /// Query failed deliveries that are due for retry.
+    ///
+    /// Returns deliveries whose `next_retry` is `<= now` (or unset),
+    /// ordered ascending by `next_retry` so the earliest-due deliveries
+    /// are processed first. This prevents older deliveries from starving
+    /// newer urgent ones.
     async fn query_retryable(
         &self,
         max_attempts: u32,
         limit: usize,
     ) -> StorageResult<Vec<RetryableDelivery>>;
+
+    /// Count failed deliveries eligible for retry (cheap version of
+    /// [`Self::query_retryable`] for metrics scraping).
+    ///
+    /// Default implementation calls `query_retryable` with `usize::MAX`
+    /// and counts. Implementations should override with an O(1) or
+    /// O(failed events) version where possible.
+    async fn count_retryable(&self, max_attempts: u32) -> StorageResult<u64> {
+        let v = self.query_retryable(max_attempts, usize::MAX).await?;
+        Ok(v.len() as u64)
+    }
 
     /// Compact: remove fully-delivered events older than the retention threshold.
     /// Returns the number of events removed.
@@ -191,7 +226,7 @@ mod tests {
 
         let seq = store.append(&event).await.unwrap();
         store
-            .record_delivery(seq, "sub1", DeliveryStatus::Delivered, None)
+            .record_delivery(seq, "sub1", DeliveryStatus::Delivered, None, None)
             .await
             .unwrap();
 

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -230,22 +230,18 @@ impl EventStore for RedbEventStore {
                 })?;
             }
 
-            // Defensively clean the failed-deliveries index when transitioning
-            // to a terminal state. The invariant is "seq is in the index iff
-            // any delivery is Failed", and a terminal event status implies no
-            // outstanding failures.
-            if matches!(status, EventStatus::Delivered | EventStatus::DeadLettered) {
-                let mut failed_idx =
-                    write_txn
-                        .open_table(FAILED_DELIVERIES_IDX_TABLE)
-                        .map_err(|e| {
-                            StorageError::DatabaseError(format!(
-                                "failed to open failed_deliveries_idx: {}",
-                                e
-                            ))
-                        })?;
-                let _ = failed_idx.remove(seq);
-            }
+            // NOTE: We deliberately do NOT touch failed_deliveries_idx here.
+            // The invariant "seq in index iff any delivery is Failed" is
+            // maintained exclusively by record_delivery, which has full
+            // visibility into the deliveries Vec.
+            //
+            // An earlier version "defensively" purged the index entry on
+            // transitions to terminal status, but update_status does not
+            // mutate the deliveries Vec — so callers like the dispatch
+            // engine's interceptor-Drop path (which records Failed
+            // deliveries before flipping status to Delivered) would silently
+            // strand failed deliveries that the retry task could no longer
+            // see.
 
             write_txn
                 .commit()
@@ -295,14 +291,24 @@ impl EventStore for RedbEventStore {
                     .find(|d| d.subscriber_id == subscriber_id)
                 {
                     delivery.status = status;
-                    // Only count failed retries against attempts; success and
-                    // dead-letter transitions preserve the existing count.
-                    if status == DeliveryStatus::Failed {
+                    // Count attempts that represent a real delivery attempt
+                    // (Failed and DeadLettered) but not Delivered (off-by-one
+                    // observability).
+                    if matches!(
+                        status,
+                        DeliveryStatus::Failed | DeliveryStatus::DeadLettered
+                    ) {
                         delivery.attempts += 1;
                     }
                     delivery.last_attempt = Some(RedbEventStore::current_time_ms());
-                    // Preserve previous error on success transitions.
-                    if error.is_some() {
+                    // Only overwrite the error on Failed/DeadLettered
+                    // transitions. Successful retries preserve the prior
+                    // failure context for diagnostics, regardless of what
+                    // the caller passed.
+                    if matches!(
+                        status,
+                        DeliveryStatus::Failed | DeliveryStatus::DeadLettered
+                    ) {
                         delivery.error = error;
                     }
                     delivery.next_retry = next_retry;
@@ -544,10 +550,7 @@ impl EventStore for RedbEventStore {
                 })?;
 
                 for delivery in &event.deliveries {
-                    if delivery.status == DeliveryStatus::Failed
-                        && delivery.attempts < max_attempts
-                        && delivery.next_retry.is_none_or(|t| t <= now)
-                    {
+                    if delivery.is_retryable(max_attempts, now) {
                         results.push(RetryableDelivery {
                             seq: event.seq,
                             subject: event.subject.clone(),
@@ -563,6 +566,11 @@ impl EventStore for RedbEventStore {
 
             // Sort by next_retry ascending so the earliest-due deliveries
             // come first. None (no retry scheduled) sorts to the front.
+            //
+            // PERF: For very large failed-deliveries backlogs (10k+) this
+            // is O(n log n) where n is the backlog size, then truncated
+            // to `limit`. A bounded min-heap would be O(n log limit) but
+            // is not worth the code complexity at current scale.
             results.sort_by_key(|r| r.next_retry.unwrap_or(0));
             results.truncate(limit);
             Ok(results)
@@ -603,17 +611,20 @@ impl EventStore for RedbEventStore {
                     StorageError::DatabaseError(format!("failed to get event: {}", e))
                 })? {
                     Some(d) => d,
-                    None => continue,
+                    None => {
+                        tracing::warn!(
+                            seq = seq,
+                            "stale failed_deliveries_idx entry: event not found"
+                        );
+                        continue;
+                    }
                 };
                 let bytes = data.value().to_vec();
                 let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
                     StorageError::OperationFailed(format!("failed to deserialize: {}", e))
                 })?;
                 for delivery in &event.deliveries {
-                    if delivery.status == DeliveryStatus::Failed
-                        && delivery.attempts < max_attempts
-                        && delivery.next_retry.is_none_or(|t| t <= now)
-                    {
+                    if delivery.is_retryable(max_attempts, now) {
                         count += 1;
                     }
                 }
@@ -857,5 +868,60 @@ mod tests {
         let results = store.query_by_subject("test", None, 10).await.unwrap();
         assert_eq!(results[0].deliveries.len(), 1);
         assert_eq!(results[0].deliveries[0].subscriber_id, "sub1");
+    }
+
+    /// Regression test: a Failed delivery must remain queryable via
+    /// `query_retryable` even if the parent event's status was bumped to
+    /// `Delivered` by an unrelated path (e.g., the dispatch engine's
+    /// interceptor-Drop branch). The original Phase 5 implementation had
+    /// `update_status` defensively purge `failed_deliveries_idx`, which
+    /// silently dropped failed deliveries.
+    #[tokio::test]
+    async fn test_redb_update_status_preserves_failed_index() {
+        let temp = TempDir::new().unwrap();
+        let store = RedbEventStore::open(temp.path().join("events.db")).unwrap();
+
+        // Append an event and record a Failed delivery against it.
+        let event = StoredEvent {
+            seq: 0,
+            subject: "test".to_string(),
+            payload: b"data".to_vec(),
+            stored_at: 1000,
+            status: EventStatus::Dispatching,
+            deliveries: vec![],
+            reply_subject: None,
+        };
+        let seq = store.append(&event).await.unwrap();
+        store
+            .record_delivery(
+                seq,
+                "sub1",
+                DeliveryStatus::Failed,
+                Some("boom".to_string()),
+                Some(0), // due immediately
+            )
+            .await
+            .unwrap();
+
+        // Sanity: the failed delivery is visible.
+        let pending = store.query_retryable(10, 100).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].subscriber_id, "sub1");
+
+        // Bump the event status to Delivered (simulating the dispatch
+        // engine's interceptor-Drop branch).
+        store
+            .update_status(seq, EventStatus::Delivered)
+            .await
+            .unwrap();
+
+        // The failed delivery MUST still be retryable.
+        let still_pending = store.query_retryable(10, 100).await.unwrap();
+        assert_eq!(
+            still_pending.len(),
+            1,
+            "Failed delivery should survive update_status -> Delivered"
+        );
+        assert_eq!(still_pending[0].subscriber_id, "sub1");
     }
 }

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -149,6 +149,33 @@ impl EventStore for RedbEventStore {
         .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
     }
 
+    async fn get(&self, seq: u64) -> StorageResult<Option<StoredEvent>> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || {
+            let read_txn = db
+                .begin_read()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+            let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+            })?;
+            match events_table
+                .get(seq)
+                .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {}", e)))?
+            {
+                Some(data) => {
+                    let bytes = data.value().to_vec();
+                    let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
+                        StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                    })?;
+                    Ok(Some(event))
+                }
+                None => Ok(None),
+            }
+        })
+        .await
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+    }
+
     async fn update_status(&self, seq: u64, status: EventStatus) -> StorageResult<()> {
         let db = Arc::clone(&self.db);
 
@@ -203,6 +230,23 @@ impl EventStore for RedbEventStore {
                 })?;
             }
 
+            // Defensively clean the failed-deliveries index when transitioning
+            // to a terminal state. The invariant is "seq is in the index iff
+            // any delivery is Failed", and a terminal event status implies no
+            // outstanding failures.
+            if matches!(status, EventStatus::Delivered | EventStatus::DeadLettered) {
+                let mut failed_idx =
+                    write_txn
+                        .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                        .map_err(|e| {
+                            StorageError::DatabaseError(format!(
+                                "failed to open failed_deliveries_idx: {}",
+                                e
+                            ))
+                        })?;
+                let _ = failed_idx.remove(seq);
+            }
+
             write_txn
                 .commit()
                 .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))
@@ -217,6 +261,7 @@ impl EventStore for RedbEventStore {
         subscriber_id: &str,
         status: DeliveryStatus,
         error: Option<String>,
+        next_retry: Option<u64>,
     ) -> StorageResult<()> {
         let db = Arc::clone(&self.db);
         let subscriber_id = subscriber_id.to_string();
@@ -250,27 +295,27 @@ impl EventStore for RedbEventStore {
                     .find(|d| d.subscriber_id == subscriber_id)
                 {
                     delivery.status = status;
-                    delivery.attempts += 1;
+                    // Only count failed retries against attempts; success and
+                    // dead-letter transitions preserve the existing count.
+                    if status == DeliveryStatus::Failed {
+                        delivery.attempts += 1;
+                    }
                     delivery.last_attempt = Some(RedbEventStore::current_time_ms());
-                    delivery.error = error;
-                    delivery.next_retry = if status == DeliveryStatus::Failed {
-                        let backoff_ms =
-                            100_u64.saturating_mul(2_u64.saturating_pow(delivery.attempts));
-                        Some(RedbEventStore::current_time_ms() + backoff_ms.min(30_000))
-                    } else {
-                        None
-                    };
+                    // Preserve previous error on success transitions.
+                    if error.is_some() {
+                        delivery.error = error;
+                    }
+                    delivery.next_retry = next_retry;
                 } else {
                     let now = RedbEventStore::current_time_ms();
-                    let next_retry = if status == DeliveryStatus::Failed {
-                        Some(now + 100)
-                    } else {
-                        None
-                    };
                     event.deliveries.push(DeliveryRecord {
                         subscriber_id,
                         status,
-                        attempts: 1,
+                        attempts: if status == DeliveryStatus::Failed {
+                            1
+                        } else {
+                            0
+                        },
                         last_attempt: Some(now),
                         next_retry,
                         error,
@@ -468,7 +513,7 @@ impl EventStore for RedbEventStore {
                     ))
                 })?;
 
-            let mut results = Vec::new();
+            let mut results: Vec<RetryableDelivery> = Vec::new();
             // Iterate only events known to have at least one Failed delivery.
             let iter = failed_idx
                 .iter()
@@ -476,9 +521,6 @@ impl EventStore for RedbEventStore {
 
             let now = RedbEventStore::current_time_ms();
             for item in iter {
-                if results.len() >= limit {
-                    break;
-                }
                 let (key, _) = item.map_err(|e| {
                     StorageError::DatabaseError(format!("failed to iterate: {}", e))
                 })?;
@@ -488,7 +530,13 @@ impl EventStore for RedbEventStore {
                     StorageError::DatabaseError(format!("failed to get event: {}", e))
                 })? {
                     Some(d) => d,
-                    None => continue, // Stale index entry
+                    None => {
+                        tracing::warn!(
+                            seq = seq,
+                            "stale failed_deliveries_idx entry: event not found"
+                        );
+                        continue;
+                    }
                 };
                 let bytes = data.value().to_vec();
                 let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
@@ -496,9 +544,6 @@ impl EventStore for RedbEventStore {
                 })?;
 
                 for delivery in &event.deliveries {
-                    if results.len() >= limit {
-                        break;
-                    }
                     if delivery.status == DeliveryStatus::Failed
                         && delivery.attempts < max_attempts
                         && delivery.next_retry.is_none_or(|t| t <= now)
@@ -509,12 +554,71 @@ impl EventStore for RedbEventStore {
                             subscriber_id: delivery.subscriber_id.clone(),
                             attempts: delivery.attempts,
                             payload: event.payload.clone(),
+                            reply_subject: event.reply_subject.clone(),
+                            next_retry: delivery.next_retry,
                         });
                     }
                 }
             }
 
+            // Sort by next_retry ascending so the earliest-due deliveries
+            // come first. None (no retry scheduled) sorts to the front.
+            results.sort_by_key(|r| r.next_retry.unwrap_or(0));
+            results.truncate(limit);
             Ok(results)
+        })
+        .await
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+    }
+
+    async fn count_retryable(&self, max_attempts: u32) -> StorageResult<u64> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || {
+            let read_txn = db
+                .begin_read()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+            let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+            })?;
+            let failed_idx = read_txn
+                .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                .map_err(|e| {
+                    StorageError::DatabaseError(format!(
+                        "failed to open failed_deliveries_idx: {}",
+                        e
+                    ))
+                })?;
+
+            let now = RedbEventStore::current_time_ms();
+            let mut count = 0u64;
+            let iter = failed_idx
+                .iter()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {}", e)))?;
+            for item in iter {
+                let (key, _) = item.map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
+                })?;
+                let seq: u64 = key.value();
+                let data = match events_table.get(seq).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to get event: {}", e))
+                })? {
+                    Some(d) => d,
+                    None => continue,
+                };
+                let bytes = data.value().to_vec();
+                let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
+                    StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                })?;
+                for delivery in &event.deliveries {
+                    if delivery.status == DeliveryStatus::Failed
+                        && delivery.attempts < max_attempts
+                        && delivery.next_retry.is_none_or(|t| t <= now)
+                    {
+                        count += 1;
+                    }
+                }
+            }
+            Ok(count)
         })
         .await
         .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
@@ -746,7 +850,7 @@ mod tests {
 
         let seq = store.append(&event).await.unwrap();
         store
-            .record_delivery(seq, "sub1", DeliveryStatus::Delivered, None)
+            .record_delivery(seq, "sub1", DeliveryStatus::Delivered, None, None)
             .await
             .unwrap();
 

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -14,6 +14,11 @@ const SUBJECT_IDX_TABLE: redb::TableDefinition<(&str, u64), ()> =
     redb::TableDefinition::new("subject_idx");
 const STATUS_IDX_TABLE: redb::TableDefinition<(u8, u64), ()> =
     redb::TableDefinition::new("status_idx");
+/// Index of events that have at least one delivery in the `Failed` state.
+/// Key: `seq`. Used by `query_retryable` to skip events with no failed
+/// deliveries instead of full-scanning the events table.
+const FAILED_DELIVERIES_IDX_TABLE: redb::TableDefinition<u64, ()> =
+    redb::TableDefinition::new("failed_deliveries_idx");
 
 /// A durable event store using redb as the backing storage engine.
 pub struct RedbEventStore {
@@ -41,6 +46,14 @@ impl RedbEventStore {
                 let _t3 = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
                     StorageError::DatabaseError(format!("failed to open status_idx table: {}", e))
                 })?;
+                let _t4 = write_txn
+                    .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                    .map_err(|e| {
+                        StorageError::DatabaseError(format!(
+                            "failed to open failed_deliveries_idx table: {}",
+                            e
+                        ))
+                    })?;
             }
             write_txn.commit().map_err(|e| {
                 StorageError::DatabaseError(format!("failed to commit transaction: {}", e))
@@ -213,8 +226,9 @@ impl EventStore for RedbEventStore {
                 StorageError::DatabaseError(format!("failed to begin write: {}", e))
             })?;
 
-            // Read the event
-            let serialized = {
+            // Read the event, mutate the delivery record, and capture the
+            // post-update state of the failed-deliveries index.
+            let (serialized, has_failed_deliveries) = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
                     StorageError::DatabaseError(format!("failed to open events table: {}", e))
                 })?;
@@ -263,12 +277,18 @@ impl EventStore for RedbEventStore {
                     });
                 }
 
-                serde_json::to_vec(&event).map_err(|e| {
+                let has_failed = event
+                    .deliveries
+                    .iter()
+                    .any(|d| d.status == DeliveryStatus::Failed);
+
+                let serialized = serde_json::to_vec(&event).map_err(|e| {
                     StorageError::OperationFailed(format!("failed to serialize event: {}", e))
-                })?
+                })?;
+                (serialized, has_failed)
             };
 
-            // Write back
+            // Write back the event
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
                     StorageError::DatabaseError(format!("failed to open events table: {}", e))
@@ -278,6 +298,30 @@ impl EventStore for RedbEventStore {
                     .map_err(|e| {
                         StorageError::DatabaseError(format!("failed to update event: {}", e))
                     })?;
+            }
+
+            // Maintain the failed-deliveries index: insert if any delivery
+            // is currently Failed, otherwise remove the entry.
+            {
+                let mut failed_idx =
+                    write_txn
+                        .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                        .map_err(|e| {
+                            StorageError::DatabaseError(format!(
+                                "failed to open failed_deliveries_idx: {}",
+                                e
+                            ))
+                        })?;
+                if has_failed_deliveries {
+                    failed_idx.insert(seq, ()).map_err(|e| {
+                        StorageError::DatabaseError(format!(
+                            "failed to insert failed_deliveries_idx: {}",
+                            e
+                        ))
+                    })?;
+                } else {
+                    let _ = failed_idx.remove(seq);
+                }
             }
 
             write_txn
@@ -408,8 +452,6 @@ impl EventStore for RedbEventStore {
     ) -> StorageResult<Vec<RetryableDelivery>> {
         let db = Arc::clone(&self.db);
 
-        // TODO(Phase 2): Add a delivery_idx table keyed by (subscriber_id, seq) → DeliveryStatus
-        // to avoid this full-table scan. Currently O(n) over all events.
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
@@ -417,26 +459,42 @@ impl EventStore for RedbEventStore {
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
                 StorageError::DatabaseError(format!("failed to open events table: {}", e))
             })?;
+            let failed_idx = read_txn
+                .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                .map_err(|e| {
+                    StorageError::DatabaseError(format!(
+                        "failed to open failed_deliveries_idx: {}",
+                        e
+                    ))
+                })?;
 
             let mut results = Vec::new();
-            let iter = events_table
+            // Iterate only events known to have at least one Failed delivery.
+            let iter = failed_idx
                 .iter()
                 .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {}", e)))?;
 
+            let now = RedbEventStore::current_time_ms();
             for item in iter {
-                let (_, data) = item.map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
-                })?;
                 if results.len() >= limit {
                     break;
                 }
+                let (key, _) = item.map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
+                })?;
+                let seq: u64 = key.value();
 
+                let data = match events_table.get(seq).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to get event: {}", e))
+                })? {
+                    Some(d) => d,
+                    None => continue, // Stale index entry
+                };
                 let bytes = data.value().to_vec();
                 let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
                     StorageError::OperationFailed(format!("failed to deserialize: {}", e))
                 })?;
 
-                let now = RedbEventStore::current_time_ms();
                 for delivery in &event.deliveries {
                     if results.len() >= limit {
                         break;
@@ -524,6 +582,9 @@ impl EventStore for RedbEventStore {
             let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
                 StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
             })?;
+            let mut failed_idx = write_txn.open_table(FAILED_DELIVERIES_IDX_TABLE).map_err(|e| {
+                StorageError::DatabaseError(format!("failed to open failed_deliveries_idx: {}", e))
+            })?;
 
             for (seq, subject, status_u8) in &to_delete {
                 if let Err(e) = events_table.remove(*seq) {
@@ -535,11 +596,14 @@ impl EventStore for RedbEventStore {
                 if let Err(e) = status_idx.remove((*status_u8, *seq)) {
                     tracing::warn!(seq = seq, status = status_u8, error = %e, "compaction failed to remove status index entry");
                 }
+                // Best-effort: also drop the failed-deliveries index entry.
+                let _ = failed_idx.remove(*seq);
             }
             // Drop the table handles before commit (required by redb borrow rules).
             drop(events_table);
             drop(subject_idx);
             drop(status_idx);
+            drop(failed_idx);
 
             write_txn
                 .commit()

--- a/crates/core/seidrum-eventbus/src/storage/types.rs
+++ b/crates/core/seidrum-eventbus/src/storage/types.rs
@@ -79,6 +79,20 @@ pub struct DeliveryRecord {
     pub error: Option<String>,
 }
 
+impl DeliveryRecord {
+    /// Returns `true` if this delivery is currently eligible for a retry
+    /// attempt: status is `Failed`, `attempts` is below the cap, and the
+    /// `next_retry` schedule has elapsed (or is unset).
+    ///
+    /// Single source of truth used by both `query_retryable` and
+    /// `count_retryable` in every store implementation.
+    pub fn is_retryable(&self, max_attempts: u32, now_ms: u64) -> bool {
+        self.status == DeliveryStatus::Failed
+            && self.attempts < max_attempts
+            && self.next_retry.is_none_or(|t| t <= now_ms)
+    }
+}
+
 /// A delivery that is ready to be retried.
 #[derive(Debug, Clone)]
 pub struct RetryableDelivery {

--- a/crates/core/seidrum-eventbus/src/storage/types.rs
+++ b/crates/core/seidrum-eventbus/src/storage/types.rs
@@ -87,4 +87,11 @@ pub struct RetryableDelivery {
     pub subscriber_id: String,
     pub attempts: u32,
     pub payload: Vec<u8>,
+    /// If the original event was a request, the subject to reply on.
+    /// Propagated through retry so handlers receive a working `Replier`.
+    pub reply_subject: Option<String>,
+    /// Earliest timestamp (unix-millis) at which this delivery is eligible
+    /// for the next retry attempt. Used by `query_retryable` to sort
+    /// results so the earliest-due deliveries are returned first.
+    pub next_retry: Option<u64>,
 }

--- a/crates/core/seidrum-eventbus/src/transport/http.rs
+++ b/crates/core/seidrum-eventbus/src/transport/http.rs
@@ -204,12 +204,16 @@ pub fn create_router(state: AppState) -> Router {
 pub struct HttpServer {
     bus: Arc<dyn EventBus>,
     registry: Arc<ChannelRegistry>,
+    webhook_channel: Arc<WebhookChannel>,
     authenticator: Arc<dyn HttpAuthenticator>,
     shutdown_rx: watch::Receiver<bool>,
 }
 
 impl HttpServer {
     /// Create a new HTTP server with no authentication (development only).
+    /// Constructs its own `WebhookChannel` — prefer
+    /// [`Self::with_webhook_channel`] when called from the builder so the
+    /// engine and HTTP transport share a single channel.
     pub fn new(
         bus: Arc<dyn EventBus>,
         registry: Arc<ChannelRegistry>,
@@ -218,6 +222,7 @@ impl HttpServer {
         Self {
             bus,
             registry,
+            webhook_channel: WebhookChannel::new(),
             authenticator: Arc::new(NoHttpAuth),
             shutdown_rx,
         }
@@ -233,7 +238,26 @@ impl HttpServer {
         Self {
             bus,
             registry,
+            webhook_channel: WebhookChannel::new(),
             authenticator,
+            shutdown_rx,
+        }
+    }
+
+    /// Create a new HTTP server with an explicit shared `WebhookChannel`.
+    /// Used by [`crate::EventBusBuilder`] so the dispatch engine and the
+    /// HTTP transport share the same channel instance.
+    pub fn with_webhook_channel(
+        bus: Arc<dyn EventBus>,
+        registry: Arc<ChannelRegistry>,
+        webhook_channel: Arc<WebhookChannel>,
+        shutdown_rx: watch::Receiver<bool>,
+    ) -> Self {
+        Self {
+            bus,
+            registry,
+            webhook_channel,
+            authenticator: Arc::new(NoHttpAuth),
             shutdown_rx,
         }
     }
@@ -245,7 +269,7 @@ impl HttpServer {
         let state = AppState {
             bus: Arc::clone(&self.bus),
             registry: Arc::clone(&self.registry),
-            webhook_channel: WebhookChannel::new(),
+            webhook_channel: Arc::clone(&self.webhook_channel),
             authenticator: Arc::clone(&self.authenticator),
             subscription_count: Arc::new(AtomicUsize::new(0)),
         };

--- a/crates/core/seidrum-eventbus/src/transport/http.rs
+++ b/crates/core/seidrum-eventbus/src/transport/http.rs
@@ -211,9 +211,19 @@ pub struct HttpServer {
 
 impl HttpServer {
     /// Create a new HTTP server with no authentication (development only).
-    /// Constructs its own `WebhookChannel` — prefer
-    /// [`Self::with_webhook_channel`] when called from the builder so the
-    /// engine and HTTP transport share a single channel.
+    /// Constructs its own `WebhookChannel`.
+    ///
+    /// **Deprecated:** This constructor produces an HTTP server whose
+    /// `WebhookChannel` instance is independent from the dispatch engine's,
+    /// so retry-time and live deliveries cannot share state (connection
+    /// pools, future stats). Use [`crate::EventBusBuilder::with_http`] to
+    /// have the builder wire up a single shared channel, or
+    /// [`Self::with_webhook_channel`] for manual wiring.
+    #[deprecated(
+        since = "0.2.0",
+        note = "use EventBusBuilder::with_http or HttpServer::with_webhook_channel \
+                so the engine and HTTP transport share a single WebhookChannel"
+    )]
     pub fn new(
         bus: Arc<dyn EventBus>,
         registry: Arc<ChannelRegistry>,

--- a/crates/core/seidrum-eventbus/tests/integration_tests.rs
+++ b/crates/core/seidrum-eventbus/tests/integration_tests.rs
@@ -83,7 +83,7 @@ async fn test_crash_recovery_full() {
 
         // Verify delivery records survive crash
         store
-            .record_delivery(events[0].seq, "sub1", DeliveryStatus::Delivered, None)
+            .record_delivery(events[0].seq, "sub1", DeliveryStatus::Delivered, None, None)
             .await
             .unwrap();
         drop(store);

--- a/crates/core/seidrum-eventbus/tests/phase4_transport.rs
+++ b/crates/core/seidrum-eventbus/tests/phase4_transport.rs
@@ -146,34 +146,35 @@ mod tests {
     fn test_retry_backoff() {
         use seidrum_eventbus::delivery::calculate_backoff;
 
-        // Subtractive jitter: result is always in [base - base/4, base]
-        let d1 = calculate_backoff(0, 100, 30000);
+        // attempt 1: base=100, subtractive jitter → 75..100
+        let d1 = calculate_backoff(1, 100, 30000);
         assert!(
             d1.as_millis() >= 75 && d1.as_millis() <= 100,
-            "attempt 0: expected 75..100ms, got {}ms",
+            "attempt 1: expected 75..100ms, got {}ms",
             d1.as_millis()
         );
 
-        let d2 = calculate_backoff(1, 100, 30000);
+        // attempt 2: base=200 → 150..200
+        let d2 = calculate_backoff(2, 100, 30000);
         assert!(
             d2.as_millis() >= 150 && d2.as_millis() <= 200,
-            "attempt 1: expected 150..200ms, got {}ms",
+            "attempt 2: expected 150..200ms, got {}ms",
             d2.as_millis()
         );
 
-        let d5 = calculate_backoff(5, 100, 30000);
-        // 2^5 * 100 = 3200, jitter removes up to 800 → 2400..3200
+        // attempt 6: 100 * 2^5 = 3200 → 2400..3200
+        let d6 = calculate_backoff(6, 100, 30000);
         assert!(
-            d5.as_millis() >= 2400 && d5.as_millis() <= 3200,
-            "attempt 5: expected 2400..3200ms, got {}ms",
-            d5.as_millis()
+            d6.as_millis() >= 2400 && d6.as_millis() <= 3200,
+            "attempt 6: expected 2400..3200ms, got {}ms",
+            d6.as_millis()
         );
 
-        let d10 = calculate_backoff(10, 100, 30000);
+        let d11 = calculate_backoff(11, 100, 30000);
         assert!(
-            d10.as_millis() <= 30000,
-            "attempt 10 should be capped at 30000ms, got {}ms",
-            d10.as_millis()
+            d11.as_millis() <= 30000,
+            "attempt 11 should be capped at 30000ms, got {}ms",
+            d11.as_millis()
         );
     }
 

--- a/crates/core/seidrum-eventbus/tests/phase5_retry.rs
+++ b/crates/core/seidrum-eventbus/tests/phase5_retry.rs
@@ -341,36 +341,171 @@ async fn test_retry_task_not_started_without_with_retry() {
 #[tokio::test]
 async fn test_with_retry_poll_interval_order_independent() {
     // Calling with_retry_poll_interval BEFORE with_retry must still apply.
+    // We verify by registering an always-failing channel via the builder,
+    // seeding a failed delivery, and counting how many retry attempts the
+    // task makes within a fixed window. With a 30ms poll interval and a
+    // 200ms window we expect ~6 attempts; with the default 1s interval we
+    // would expect 0.
+
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+
+    let flaky = FlakyChannel::always_fail();
     let store = Arc::new(InMemoryEventStore::new());
+
+    // Seed the failed delivery first so we can observe retry behavior.
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test.poll_interval".to_string(),
+        payload: b"x".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
+
     let handles = EventBusBuilder::new()
-        .storage(store)
-        .with_retry_poll_interval(Duration::from_millis(75))
-        .with_retry(RetryConfig::default())
+        .storage(Arc::clone(&store) as Arc<dyn EventStore>)
+        // Order: poll_interval BEFORE with_retry.
+        .with_retry_poll_interval(Duration::from_millis(30))
+        .register_channel("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .with_retry(RetryConfig {
+            max_attempts: 1000, // high enough to keep retrying
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+        })
         .build_with_handles()
         .await
         .unwrap();
 
-    // The retry task is spawned (we can't observe the interval directly,
-    // but the test ensures the chained methods work without panicking
-    // and that with_retry_poll_interval doesn't drop the value).
-    assert!(handles.retry_task.is_some());
+    // Subscribe via the bus so the engine has the trie entry the retry
+    // task needs to look up.
+    let opts = SubscribeOpts {
+        priority: 10,
+        mode: SubscriptionMode::Async,
+        channel: ChannelConfig::Custom {
+            channel_type: "flaky".to_string(),
+            config: serde_json::json!({}),
+        },
+        timeout: Duration::from_secs(5),
+        filter: None,
+    };
+    let sub = handles
+        .bus
+        .subscribe("test.poll_interval", opts)
+        .await
+        .unwrap();
+    let sub_id = sub.id.clone();
+
+    // Now seed a failed delivery for the live subscription.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    store
+        .record_delivery(
+            seq,
+            &sub_id,
+            DeliveryStatus::Failed,
+            Some("seed".to_string()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+    // Window: 250ms. With a 30ms poll interval and 1ms backoff we should
+    // see at least 4 retry attempts. With the default 1s interval (the
+    // bug we're guarding against), the channel would be called 0 times.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let calls = flaky.calls();
     handles.shutdown_and_join().await;
+
+    assert!(
+        calls >= 3,
+        "expected at least 3 retry calls with 30ms poll interval, got {}",
+        calls
+    );
 }
 
 #[tokio::test]
 async fn test_register_channel_via_builder() {
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+
+    // FlakyChannel that succeeds on the first call so we can verify the
+    // retry path actually reaches it.
+    let flaky = FlakyChannel::new(0);
     let store = Arc::new(InMemoryEventStore::new());
-    let flaky = FlakyChannel::new(0); // always succeeds
+
+    // Append the event before building so we can record a Failed delivery
+    // against the bus's subscription id afterward.
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test.builder_register".to_string(),
+        payload: b"x".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
 
     let handles = EventBusBuilder::new()
-        .storage(store)
+        .storage(Arc::clone(&store) as Arc<dyn EventStore>)
         .register_channel("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
-        .with_retry(RetryConfig::default())
+        .with_retry(RetryConfig {
+            max_attempts: 5,
+            initial_backoff_ms: 5,
+            max_backoff_ms: 20,
+        })
+        .with_retry_poll_interval(Duration::from_millis(20))
         .build_with_handles()
         .await
         .unwrap();
 
-    assert!(handles.retry_task.is_some());
+    let opts = SubscribeOpts {
+        priority: 10,
+        mode: SubscriptionMode::Async,
+        channel: ChannelConfig::Custom {
+            channel_type: "flaky".to_string(),
+            config: serde_json::json!({}),
+        },
+        timeout: Duration::from_secs(5),
+        filter: None,
+    };
+    let sub = handles
+        .bus
+        .subscribe("test.builder_register", opts)
+        .await
+        .unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    store
+        .record_delivery(
+            seq,
+            &sub.id,
+            DeliveryStatus::Failed,
+            Some("seed".to_string()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+    // Wait for the retry task to call the channel.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline && flaky.calls() == 0 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        flaky.calls() >= 1,
+        "registered channel should be called by the retry task, got {}",
+        flaky.calls()
+    );
+
     handles.shutdown_and_join().await;
 }
 
@@ -427,6 +562,188 @@ async fn test_count_retryable_metric() {
 
     let count = store.count_retryable(10).await.unwrap();
     assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn test_metrics_pending_retry_via_bus() {
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+
+    let store = Arc::new(InMemoryEventStore::new());
+
+    // Build a bus WITH retry enabled — otherwise events_pending_retry
+    // is gated to 0.
+    let handles = EventBusBuilder::new()
+        .storage(Arc::clone(&store) as Arc<dyn EventStore>)
+        .with_retry(RetryConfig {
+            max_attempts: 100,
+            initial_backoff_ms: 100,
+            max_backoff_ms: 1000,
+        })
+        .with_retry_poll_interval(Duration::from_secs(60)) // very slow so we don't drain
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    // Subscribe with InProcess so the retry task can find the entry but
+    // the channel is unconditionally retryable. We'll seed a Failed
+    // delivery for this subscription id.
+    let opts = SubscribeOpts {
+        priority: 10,
+        mode: SubscriptionMode::Async,
+        channel: ChannelConfig::InProcess,
+        timeout: Duration::from_secs(5),
+        filter: None,
+    };
+    let sub = handles.bus.subscribe("test.metrics", opts).await.unwrap();
+
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test.metrics".to_string(),
+        payload: b"x".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
+    let future = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+        + 1_000_000; // far in the future so the retry task can't drain it
+    store
+        .record_delivery(
+            seq,
+            &sub.id,
+            DeliveryStatus::Failed,
+            Some("seed".to_string()),
+            Some(future),
+        )
+        .await
+        .unwrap();
+
+    // The seeded delivery has next_retry in the future, so count_retryable
+    // returns 0 because the delivery isn't yet due. Test the metric path
+    // by lowering next_retry to now.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    store
+        .record_delivery(
+            seq,
+            &sub.id,
+            DeliveryStatus::Failed,
+            Some("retry me".to_string()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+    let metrics = handles.bus.metrics().await.unwrap();
+    assert_eq!(
+        metrics.events_pending_retry, 1,
+        "metrics should report 1 pending retry"
+    );
+
+    handles.shutdown_and_join().await;
+}
+
+#[tokio::test]
+async fn test_metrics_pending_retry_zero_when_no_retry_task() {
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+
+    // No with_retry call — the retry task is not started, so the metric
+    // must report 0 even with failed deliveries on disk.
+    let store = Arc::new(InMemoryEventStore::new());
+    let handles = EventBusBuilder::new()
+        .storage(Arc::clone(&store) as Arc<dyn EventStore>)
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test.no_retry".to_string(),
+        payload: b"x".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
+    store
+        .record_delivery(
+            seq,
+            "sub",
+            DeliveryStatus::Failed,
+            Some("x".into()),
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    let metrics = handles.bus.metrics().await.unwrap();
+    assert_eq!(
+        metrics.events_pending_retry, 0,
+        "events_pending_retry should be 0 when no retry task is running"
+    );
+
+    handles.shutdown_and_join().await;
+}
+
+#[tokio::test]
+async fn test_redb_failed_delivery_survives_restart() {
+    // Crash-recovery test: write a Failed delivery to a ReDB store, drop
+    // the store, reopen, and verify the failed delivery is still queryable.
+    // This is the core durability guarantee of Phase 5.
+    use seidrum_eventbus::storage::redb_store::RedbEventStore;
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("events.db");
+
+    // Open, append, record failure, drop.
+    let seq = {
+        let store = RedbEventStore::open(&path).unwrap();
+        let event = StoredEvent {
+            seq: 0,
+            subject: "test.crash".to_string(),
+            payload: b"durable".to_vec(),
+            stored_at: 0,
+            status: EventStatus::PartiallyDelivered,
+            deliveries: vec![],
+            reply_subject: None,
+        };
+        let seq = store.append(&event).await.unwrap();
+        store
+            .record_delivery(
+                seq,
+                "sub1",
+                DeliveryStatus::Failed,
+                Some("crash test".to_string()),
+                Some(0), // due immediately
+            )
+            .await
+            .unwrap();
+        seq
+    };
+
+    // Reopen and verify the failed delivery is still in the index.
+    let store2 = RedbEventStore::open(&path).unwrap();
+    let pending = store2.query_retryable(10, 100).await.unwrap();
+    assert_eq!(pending.len(), 1, "failed delivery should survive restart");
+    assert_eq!(pending[0].seq, seq);
+    assert_eq!(pending[0].subscriber_id, "sub1");
+    assert_eq!(pending[0].attempts, 1);
+
+    // count_retryable also reflects the persisted state.
+    let count = store2.count_retryable(10).await.unwrap();
+    assert_eq!(count, 1);
 }
 
 #[tokio::test]
@@ -519,7 +836,11 @@ async fn test_redb_retry_succeeds_after_failures() {
 }
 
 #[tokio::test]
-async fn test_concurrent_retries_independent() {
+async fn test_multi_channel_retry_independent() {
+    // Note: the retry task processes deliveries sequentially within a poll
+    // cycle. This test verifies that two independent channels each retry
+    // their own delivery without interfering, not that retries run in
+    // parallel.
     let registry = Arc::new(ChannelRegistry::new());
     let flaky_a = FlakyChannel::new(1); // fail once, succeed
     let flaky_b = FlakyChannel::new(1);

--- a/crates/core/seidrum-eventbus/tests/phase5_retry.rs
+++ b/crates/core/seidrum-eventbus/tests/phase5_retry.rs
@@ -33,6 +33,11 @@ impl FlakyChannel {
         })
     }
 
+    /// Channel that fails every delivery attempt forever.
+    fn always_fail() -> Arc<Self> {
+        Self::new(u32::MAX)
+    }
+
     fn calls(&self) -> u32 {
         self.call_count.load(Ordering::SeqCst)
     }
@@ -76,18 +81,27 @@ async fn setup_engine_with_retry(
     Arc<InMemoryEventStore>,
     tokio::sync::watch::Sender<bool>,
 ) {
+    use seidrum_eventbus::delivery::WebhookChannel;
     let store = Arc::new(InMemoryEventStore::new());
-    let engine = Arc::new(DispatchEngine::with_registry(
+    let retry_config = Arc::new(RetryConfig {
+        max_attempts,
+        initial_backoff_ms: 30,
+        max_backoff_ms: 200,
+    });
+    let engine = Arc::new(DispatchEngine::with_components(
         Arc::clone(&store) as Arc<dyn EventStore>,
         registry,
+        WebhookChannel::new(),
+        Arc::clone(&retry_config),
     ));
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let retry_task = RetryTask::new(
         Arc::clone(&store) as Arc<dyn EventStore>,
         Arc::clone(&engine),
-        max_attempts,
+        retry_config,
         Duration::from_millis(50),
+        256,
         shutdown_rx,
     );
     tokio::spawn(async move {
@@ -142,12 +156,19 @@ async fn seed_failed_event(
         reply_subject: None,
     };
     let seq = store.append(&event).await.unwrap();
+    // Schedule the first retry to fire essentially immediately so tests
+    // don't have to wait for the default backoff.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
     store
         .record_delivery(
             seq,
             sub_id,
             DeliveryStatus::Failed,
             Some("initial failure".to_string()),
+            Some(now), // ready immediately
         )
         .await
         .unwrap();
@@ -201,7 +222,7 @@ async fn test_retry_succeeds_after_failures() {
 #[tokio::test]
 async fn test_retry_dead_letters_after_max_attempts() {
     let registry = Arc::new(ChannelRegistry::new());
-    let flaky = FlakyChannel::new(u32::MAX); // always fails
+    let flaky = FlakyChannel::always_fail();
     registry
         .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
         .await;
@@ -315,4 +336,212 @@ async fn test_retry_task_not_started_without_with_retry() {
         .unwrap();
 
     assert!(handles.retry_task.is_none());
+}
+
+#[tokio::test]
+async fn test_with_retry_poll_interval_order_independent() {
+    // Calling with_retry_poll_interval BEFORE with_retry must still apply.
+    let store = Arc::new(InMemoryEventStore::new());
+    let handles = EventBusBuilder::new()
+        .storage(store)
+        .with_retry_poll_interval(Duration::from_millis(75))
+        .with_retry(RetryConfig::default())
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    // The retry task is spawned (we can't observe the interval directly,
+    // but the test ensures the chained methods work without panicking
+    // and that with_retry_poll_interval doesn't drop the value).
+    assert!(handles.retry_task.is_some());
+    handles.shutdown_and_join().await;
+}
+
+#[tokio::test]
+async fn test_register_channel_via_builder() {
+    let store = Arc::new(InMemoryEventStore::new());
+    let flaky = FlakyChannel::new(0); // always succeeds
+
+    let handles = EventBusBuilder::new()
+        .storage(store)
+        .register_channel("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .with_retry(RetryConfig::default())
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    assert!(handles.retry_task.is_some());
+    handles.shutdown_and_join().await;
+}
+
+#[tokio::test]
+async fn test_count_retryable_metric() {
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+
+    let registry = Arc::new(ChannelRegistry::new());
+    // Register a channel that always fails so retries don't drain the queue.
+    let flaky = FlakyChannel::always_fail();
+    registry
+        .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let store = Arc::new(InMemoryEventStore::new());
+
+    // Seed two failed deliveries, both ready immediately
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test".to_string(),
+        payload: b"x".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq1 = store.append(&event).await.unwrap();
+    let seq2 = store.append(&event).await.unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    store
+        .record_delivery(
+            seq1,
+            "sub1",
+            DeliveryStatus::Failed,
+            Some("a".into()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+    store
+        .record_delivery(
+            seq2,
+            "sub2",
+            DeliveryStatus::Failed,
+            Some("b".into()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+    let count = store.count_retryable(10).await.unwrap();
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn test_redb_retry_succeeds_after_failures() {
+    use seidrum_eventbus::delivery::WebhookChannel;
+    use seidrum_eventbus::storage::redb_store::RedbEventStore;
+    use seidrum_eventbus::storage::DeliveryStatus;
+    use seidrum_eventbus::storage::StoredEvent;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store: Arc<dyn EventStore> =
+        Arc::new(RedbEventStore::open(temp.path().join("events.db")).unwrap());
+
+    let registry = Arc::new(ChannelRegistry::new());
+    let flaky = FlakyChannel::new(2);
+    registry
+        .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let retry_config = Arc::new(RetryConfig {
+        max_attempts: 5,
+        initial_backoff_ms: 30,
+        max_backoff_ms: 200,
+    });
+    let engine = Arc::new(DispatchEngine::with_components(
+        Arc::clone(&store),
+        Arc::clone(&registry),
+        WebhookChannel::new(),
+        Arc::clone(&retry_config),
+    ));
+
+    let sub_id = subscribe_custom(&engine, "test.redb_retry", "flaky").await;
+
+    let event = StoredEvent {
+        seq: 0,
+        subject: "test.redb_retry".to_string(),
+        payload: b"redb".to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    store
+        .record_delivery(
+            seq,
+            &sub_id,
+            DeliveryStatus::Failed,
+            Some("first".into()),
+            Some(now),
+        )
+        .await
+        .unwrap();
+    store
+        .update_status(seq, EventStatus::PartiallyDelivered)
+        .await
+        .unwrap();
+
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let task = RetryTask::new(
+        Arc::clone(&store),
+        Arc::clone(&engine),
+        Arc::clone(&retry_config),
+        Duration::from_millis(50),
+        256,
+        shutdown_rx,
+    );
+    tokio::spawn(async move {
+        task.run().await;
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && flaky.calls() < 3 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        flaky.calls() >= 3,
+        "redb retry: expected 3 calls, got {}",
+        flaky.calls()
+    );
+
+    // The failed_deliveries_idx should be cleaned up after success
+    let pending = store.count_retryable(10).await.unwrap();
+    assert_eq!(pending, 0, "no retryable deliveries should remain");
+}
+
+#[tokio::test]
+async fn test_concurrent_retries_independent() {
+    let registry = Arc::new(ChannelRegistry::new());
+    let flaky_a = FlakyChannel::new(1); // fail once, succeed
+    let flaky_b = FlakyChannel::new(1);
+    registry
+        .register("a", Arc::clone(&flaky_a) as Arc<dyn DeliveryChannel>)
+        .await;
+    registry
+        .register("b", Arc::clone(&flaky_b) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let (engine, store, _shutdown) = setup_engine_with_retry(Arc::clone(&registry), 5).await;
+    let sub_a = subscribe_custom(&engine, "test.a", "a").await;
+    let sub_b = subscribe_custom(&engine, "test.b", "b").await;
+
+    let _seq_a = seed_failed_event(&store, "test.a", b"a", &sub_a).await;
+    let _seq_b = seed_failed_event(&store, "test.b", b"b", &sub_b).await;
+
+    // Wait for both to deliver successfully (each: 1 fail + 1 success = 2 calls)
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (flaky_a.calls() < 2 || flaky_b.calls() < 2) {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(flaky_a.calls() >= 2, "channel a calls={}", flaky_a.calls());
+    assert!(flaky_b.calls() >= 2, "channel b calls={}", flaky_b.calls());
 }

--- a/crates/core/seidrum-eventbus/tests/phase5_retry.rs
+++ b/crates/core/seidrum-eventbus/tests/phase5_retry.rs
@@ -1,0 +1,318 @@
+//! Phase 5 integration tests: durable retry and dead-lettering.
+//!
+//! These tests use a custom delivery channel registered via [`ChannelRegistry`]
+//! that fails N times then succeeds. The retry task wakes up periodically,
+//! polls the store, and re-attempts failed deliveries via the dispatch engine.
+
+#![cfg(test)]
+
+use async_trait::async_trait;
+use seidrum_eventbus::delivery::{
+    ChannelConfig, ChannelRegistry, DeliveryChannel, DeliveryError, DeliveryReceipt,
+    DeliveryResult, RetryConfig, RetryTask,
+};
+use seidrum_eventbus::dispatch::{DispatchEngine, SubscriptionMode};
+use seidrum_eventbus::storage::memory_store::InMemoryEventStore;
+use seidrum_eventbus::storage::{DeliveryStatus, StoredEvent};
+use seidrum_eventbus::{EventBusBuilder, EventStatus, EventStore, SubscribeOpts};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// A delivery channel that fails the first N attempts and then succeeds.
+struct FlakyChannel {
+    fail_attempts: u32,
+    call_count: AtomicU32,
+}
+
+impl FlakyChannel {
+    fn new(fail_attempts: u32) -> Arc<Self> {
+        Arc::new(Self {
+            fail_attempts,
+            call_count: AtomicU32::new(0),
+        })
+    }
+
+    fn calls(&self) -> u32 {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl DeliveryChannel for FlakyChannel {
+    async fn deliver(
+        &self,
+        _event: &[u8],
+        _subject: &str,
+        _config: &ChannelConfig,
+    ) -> DeliveryResult<DeliveryReceipt> {
+        let call = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if call <= self.fail_attempts {
+            Err(DeliveryError::Failed(format!("flaky failure #{}", call)))
+        } else {
+            Ok(DeliveryReceipt {
+                delivered_at: 0,
+                latency_us: 0,
+            })
+        }
+    }
+
+    async fn cleanup(&self, _config: &ChannelConfig) -> DeliveryResult<()> {
+        Ok(())
+    }
+
+    async fn is_healthy(&self, _config: &ChannelConfig) -> bool {
+        true
+    }
+}
+
+/// Set up a DispatchEngine + RetryTask wired to the same store and registry.
+/// Returns the engine, store, and a shutdown sender for the retry task.
+async fn setup_engine_with_retry(
+    registry: Arc<ChannelRegistry>,
+    max_attempts: u32,
+) -> (
+    Arc<DispatchEngine>,
+    Arc<InMemoryEventStore>,
+    tokio::sync::watch::Sender<bool>,
+) {
+    let store = Arc::new(InMemoryEventStore::new());
+    let engine = Arc::new(DispatchEngine::with_registry(
+        Arc::clone(&store) as Arc<dyn EventStore>,
+        registry,
+    ));
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let retry_task = RetryTask::new(
+        Arc::clone(&store) as Arc<dyn EventStore>,
+        Arc::clone(&engine),
+        max_attempts,
+        Duration::from_millis(50),
+        shutdown_rx,
+    );
+    tokio::spawn(async move {
+        retry_task.run().await;
+    });
+
+    (engine, store, shutdown_tx)
+}
+
+/// Subscribe via a `Custom` channel pointing at the given type name and
+/// return the subscription id.
+async fn subscribe_custom(engine: &DispatchEngine, subject: &str, channel_type: &str) -> String {
+    let opts = SubscribeOpts {
+        priority: 10,
+        mode: SubscriptionMode::Async,
+        channel: ChannelConfig::Custom {
+            channel_type: channel_type.to_string(),
+            config: serde_json::json!({}),
+        },
+        timeout: Duration::from_secs(5),
+        filter: None,
+    };
+    let (sub_id, _rx) = engine
+        .subscribe(
+            subject,
+            opts.priority,
+            opts.mode,
+            opts.channel,
+            opts.timeout,
+            opts.filter,
+        )
+        .await
+        .unwrap();
+    sub_id
+}
+
+/// Append an event with one Failed delivery for the given subscriber.
+/// This simulates the state after an initial failed dispatch.
+async fn seed_failed_event(
+    store: &InMemoryEventStore,
+    subject: &str,
+    payload: &[u8],
+    sub_id: &str,
+) -> u64 {
+    let event = StoredEvent {
+        seq: 0,
+        subject: subject.to_string(),
+        payload: payload.to_vec(),
+        stored_at: 0,
+        status: EventStatus::PartiallyDelivered,
+        deliveries: vec![],
+        reply_subject: None,
+    };
+    let seq = store.append(&event).await.unwrap();
+    store
+        .record_delivery(
+            seq,
+            sub_id,
+            DeliveryStatus::Failed,
+            Some("initial failure".to_string()),
+        )
+        .await
+        .unwrap();
+    store
+        .update_status(seq, EventStatus::PartiallyDelivered)
+        .await
+        .unwrap();
+    seq
+}
+
+#[tokio::test]
+async fn test_retry_succeeds_after_failures() {
+    let registry = Arc::new(ChannelRegistry::new());
+    let flaky = FlakyChannel::new(2); // fail twice, then succeed
+    registry
+        .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let (engine, store, _shutdown) = setup_engine_with_retry(Arc::clone(&registry), 5).await;
+    let sub_id = subscribe_custom(&engine, "test.retry", "flaky").await;
+    let seq = seed_failed_event(&store, "test.retry", b"hello", &sub_id).await;
+
+    // Wait for the retry to succeed (3 calls total: 2 fails + 1 success)
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && flaky.calls() < 3 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        flaky.calls() >= 3,
+        "expected at least 3 deliveries, got {}",
+        flaky.calls()
+    );
+
+    // The retry task should transition the event to Delivered after success.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut delivered = false;
+    while Instant::now() < deadline {
+        let events = store
+            .query_by_status(EventStatus::Delivered, 100)
+            .await
+            .unwrap();
+        if events.iter().any(|e| e.seq == seq) {
+            delivered = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(delivered, "event should be marked Delivered after retry");
+}
+
+#[tokio::test]
+async fn test_retry_dead_letters_after_max_attempts() {
+    let registry = Arc::new(ChannelRegistry::new());
+    let flaky = FlakyChannel::new(u32::MAX); // always fails
+    registry
+        .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let (engine, store, _shutdown) = setup_engine_with_retry(Arc::clone(&registry), 3).await;
+    let sub_id = subscribe_custom(&engine, "test.dead", "flaky").await;
+    let seq = seed_failed_event(&store, "test.dead", b"doomed", &sub_id).await;
+
+    // Wait for the event to be dead-lettered
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut dead = false;
+    while Instant::now() < deadline {
+        let events = store.query_dead_lettered(100).await.unwrap();
+        if events.iter().any(|e| e.seq == seq) {
+            dead = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        dead,
+        "event should be dead-lettered after exhausting attempts (calls={})",
+        flaky.calls()
+    );
+}
+
+#[tokio::test]
+async fn test_retry_permanent_error_dead_letters_immediately() {
+    let registry = Arc::new(ChannelRegistry::new());
+    // Don't register any channel — the retry will hit "no channel registered"
+    let (engine, store, _shutdown) = setup_engine_with_retry(Arc::clone(&registry), 10).await;
+    let sub_id = subscribe_custom(&engine, "test.perm", "missing").await;
+    let seq = seed_failed_event(&store, "test.perm", b"x", &sub_id).await;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut dead = false;
+    while Instant::now() < deadline {
+        let events = store.query_dead_lettered(100).await.unwrap();
+        if events.iter().any(|e| e.seq == seq) {
+            dead = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(dead, "permanent error should dead-letter immediately");
+}
+
+#[tokio::test]
+async fn test_retry_dead_letters_when_subscriber_gone() {
+    let registry = Arc::new(ChannelRegistry::new());
+    let flaky = FlakyChannel::new(0); // would always succeed if called
+    registry
+        .register("flaky", Arc::clone(&flaky) as Arc<dyn DeliveryChannel>)
+        .await;
+
+    let (engine, store, _shutdown) = setup_engine_with_retry(Arc::clone(&registry), 5).await;
+    let sub_id = subscribe_custom(&engine, "test.gone", "flaky").await;
+    let seq = seed_failed_event(&store, "test.gone", b"x", &sub_id).await;
+
+    // Unsubscribe before the retry runs — the engine will fail to find the
+    // subscriber and dead-letter the delivery.
+    engine.unsubscribe(&sub_id).await.unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut dead = false;
+    while Instant::now() < deadline {
+        let events = store.query_dead_lettered(100).await.unwrap();
+        if events.iter().any(|e| e.seq == seq) {
+            dead = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(dead, "missing subscriber should dead-letter");
+    // The flaky channel should never have been called
+    assert_eq!(flaky.calls(), 0);
+}
+
+#[tokio::test]
+async fn test_with_retry_builder_spawns_task() {
+    let store = Arc::new(InMemoryEventStore::new());
+    let handles = EventBusBuilder::new()
+        .storage(store)
+        .with_retry(RetryConfig::default())
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    assert!(handles.retry_task.is_some());
+    assert!(!handles.retry_task.as_ref().unwrap().is_finished());
+
+    // Shut down the bus and verify the retry task exits cleanly
+    handles.shutdown();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if handles.retry_task.as_ref().unwrap().is_finished() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("retry task should exit after shutdown signal");
+}
+
+#[tokio::test]
+async fn test_retry_task_not_started_without_with_retry() {
+    let store = Arc::new(InMemoryEventStore::new());
+    let handles = EventBusBuilder::new()
+        .storage(store)
+        .build_with_handles()
+        .await
+        .unwrap();
+
+    assert!(handles.retry_task.is_none());
+}


### PR DESCRIPTION
## Summary

Wires up the retry task that has been a stub since Phase 4. Failed deliveries now retry via the dispatch engine, and exhausted attempts or permanent errors are dead-lettered.

### What's new

**Retry execution** (\`DispatchEngine::retry_to_subscriber\`)
- Looks up the live subscription by id and routes the payload through its configured channel
- \`Webhook\` → built-in \`WebhookChannel\`
- \`Custom\` → \`ChannelRegistry\` lookup
- \`InProcess\` → re-attempt \`try_send\` on the live mpsc sender
- \`WebSocket\` → \`Permanent\` (per-session, can't retry)
- New \`RetryOutcome\` enum: \`Transient\` (retry again) vs \`Permanent\` (dead-letter immediately)

**Retry task wiring**
- \`RetryTask\` now holds an \`Arc<DispatchEngine>\` and calls \`retry_to_subscriber\`
- Dead-letters when attempts reach \`max_attempts\` (otherwise the entry would get stuck in \`Failed\` once \`query_retryable\` stops returning it)
- After successful retry, finalizes the parent event status (Delivered/DeadLettered)

**Builder integration**
- \`EventBusBuilder::with_retry(RetryConfig)\` enables the retry task
- \`with_retry_poll_interval(Duration)\` overrides the default 1s interval
- \`BusHandles\` gains an optional \`retry_task: JoinHandle<()>\`
- The builder creates a single \`ChannelRegistry\` shared between dispatch engine + HTTP transport

**Storage optimization** (replaces O(n) full-scan)
- New \`failed_deliveries_idx\` table in redb keyed by \`seq\`
- Maintained by \`record_delivery\` and cleaned up by \`compact()\`
- \`query_retryable\` iterates this index instead of full-scanning the events table
- Removes the long-standing TODO(Phase 2) comment

**Other**
- New \`EventStore::query_dead_lettered(limit)\` convenience method
- New \`SubjectIndex::find_by_id\` for retry-time subscription lookup

## Test plan

- [x] All 147 tests pass (115 unit + 18 integration + 7 phase4 + 6 phase5 + 1 doctest)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo doc --no-deps\` zero warnings
- [x] \`cargo fmt --check\` clean
- [x] Workspace builds
- [ ] CI green

### New phase 5 integration tests

- \`test_retry_succeeds_after_failures\` — flaky channel fails twice, succeeds on third attempt; event → Delivered
- \`test_retry_dead_letters_after_max_attempts\` — channel always fails; event → DeadLettered after \`max_attempts\`
- \`test_retry_permanent_error_dead_letters_immediately\` — Custom channel with no registered handler dead-letters on first try
- \`test_retry_dead_letters_when_subscriber_gone\` — unsubscribe before retry runs; engine reports Permanent
- \`test_with_retry_builder_spawns_task\` — \`with_retry()\` actually spawns and shuts down cleanly
- \`test_retry_task_not_started_without_with_retry\` — task is not spawned otherwise

## Out of scope

- Webhook circuit breaker — #25
- Dead-letter inspection HTTP endpoint — #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)