### PR TITLE
docs(eventbus): restore design specs + audit current state

### DIFF
--- a/crates/core/seidrum-eventbus/ARCHITECTURE.md
+++ b/crates/core/seidrum-eventbus/ARCHITECTURE.md
@@ -1,0 +1,681 @@
+# ARCHITECTURE.md — seidrum-eventbus Internal Architecture
+
+## Overview
+
+The crate is organized into four layers, each behind a trait boundary. Higher
+layers depend on lower layers. Nothing depends upward. External code
+(seidrum-kernel, plugins) interacts exclusively through the top-level
+`EventBus` trait.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        EventBus trait                           │
+│  publish · subscribe · request · reply · register_channel_type  │
+├─────────────────────────────────────────────────────────────────┤
+│                     Dispatch Engine                              │
+│  subject index · interceptor chains · fan-out · timeout mgmt    │
+├───────────────┬─────────────────────────────────────────────────┤
+│  Delivery     │  Transport Servers                              │
+│  Channels     │  (WebSocket server, HTTP server)                │
+│  (trait impls)│  accept remote connections, bridge to bus       │
+├───────────────┴─────────────────────────────────────────────────┤
+│                     Storage Engine                               │
+│  write-ahead persist · status tracking · retry index · cleanup  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Layer 1: Storage Engine
+
+The storage engine is the foundation. It persists events durably before they
+enter the dispatch pipeline and tracks per-subscriber delivery status
+afterward. The engine is embedded (no external process) and accessed through
+a trait so the backing implementation can be swapped.
+
+### Storage Trait
+
+```rust
+#[async_trait]
+pub trait EventStore: Send + Sync + 'static {
+    /// Persist an event. Returns the assigned sequence number.
+    /// This is the write-ahead step — the event is durable after
+    /// this call returns.
+    async fn append(&self, event: &StoredEvent) -> Result<u64>;
+
+    /// Update the dispatch status of an event.
+    async fn update_status(&self, seq: u64, status: EventStatus) -> Result<()>;
+
+    /// Record delivery outcome for one subscriber.
+    async fn record_delivery(
+        &self,
+        seq: u64,
+        subscriber_id: &str,
+        status: DeliveryStatus,
+    ) -> Result<()>;
+
+    /// Query events by status (for crash recovery and retry).
+    async fn query_by_status(
+        &self,
+        status: EventStatus,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>>;
+
+    /// Query events by subject pattern (for replay and debugging).
+    async fn query_by_subject(
+        &self,
+        pattern: &str,
+        since: Option<u64>,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>>;
+
+    /// Query failed deliveries that are due for retry.
+    async fn query_retryable(
+        &self,
+        max_attempts: u32,
+        limit: usize,
+    ) -> Result<Vec<RetryableDelivery>>;
+
+    /// Compact: remove fully-delivered events older than the
+    /// retention threshold.
+    async fn compact(&self, older_than: Duration) -> Result<u64>;
+}
+```
+
+### Stored Event Schema
+
+```rust
+pub struct StoredEvent {
+    /// Monotonically increasing sequence number, assigned by the store.
+    pub seq: u64,
+    /// The subject this event was published to.
+    pub subject: String,
+    /// Serialized event payload (opaque bytes to the store).
+    pub payload: Vec<u8>,
+    /// Timestamp of when the event was persisted.
+    pub stored_at: u64,
+    /// Current lifecycle status.
+    pub status: EventStatus,
+    /// Per-subscriber delivery tracking.
+    pub deliveries: Vec<DeliveryRecord>,
+    /// If this is a request, the reply subject to respond on.
+    pub reply_subject: Option<String>,
+}
+
+pub enum EventStatus {
+    /// Written to storage, not yet dispatched.
+    Pending,
+    /// Currently in the interceptor chain.
+    Dispatching,
+    /// All subscribers confirmed delivery.
+    Delivered,
+    /// Some subscribers failed, retry pending.
+    PartiallyDelivered,
+    /// Retries exhausted, moved to dead letter.
+    DeadLettered,
+}
+
+pub struct DeliveryRecord {
+    pub subscriber_id: String,
+    pub status: DeliveryStatus,
+    pub attempts: u32,
+    pub last_attempt: Option<u64>,
+    pub next_retry: Option<u64>,
+    pub error: Option<String>,
+}
+
+pub enum DeliveryStatus {
+    Pending,
+    Delivered,
+    Failed,
+    DeadLettered,
+}
+```
+
+### Default Implementation: redb
+
+The default `EventStore` implementation uses `redb`, a pure-Rust embedded
+ACID database. Tables:
+
+| Table | Key | Value | Purpose |
+|-------|-----|-------|---------|
+| `events` | `seq: u64` | `StoredEvent` | Primary event storage |
+| `subject_idx` | `(subject, seq)` | `()` | Subject-based lookup |
+| `status_idx` | `(status, seq)` | `()` | Recovery and retry scans |
+| `delivery_idx` | `(subscriber_id, seq)` | `DeliveryStatus` | Per-subscriber tracking |
+
+Write path: a single `redb` write transaction that inserts into `events`
+and `subject_idx` atomically. This is the critical path — it must complete
+in microseconds for the write-ahead guarantee to not bottleneck dispatch.
+
+Status updates and delivery records are written in separate transactions
+after dispatch completes. These are not on the hot path.
+
+### Compaction
+
+A background task runs on a configurable interval (default: 1 hour) and
+removes events in `Delivered` status that are older than the retention
+period (default: 24 hours). Dead-lettered events have a longer retention
+(default: 7 days) for debugging.
+
+---
+
+## Layer 2: Delivery Channels and Transport Servers
+
+### Delivery Channel Trait
+
+A delivery channel is a strategy for getting an event from the bus to a
+subscriber. The bus ships with built-in channels and supports plugin-registered
+custom channels.
+
+```rust
+#[async_trait]
+pub trait DeliveryChannel: Send + Sync + 'static {
+    /// Deliver one event to the subscriber.
+    /// Returns Ok(receipt) on success, Err on failure (triggers retry).
+    async fn deliver(
+        &self,
+        event: &[u8],
+        subject: &str,
+        config: &ChannelConfig,
+    ) -> Result<DeliveryReceipt>;
+
+    /// Called when the subscription is removed or the subscriber
+    /// disconnects. Clean up any connection state.
+    async fn cleanup(&self, config: &ChannelConfig) -> Result<()>;
+
+    /// Health check. Returns true if the channel is operational.
+    async fn is_healthy(&self, config: &ChannelConfig) -> bool;
+}
+
+pub struct DeliveryReceipt {
+    pub delivered_at: u64,
+    pub latency_us: u64,
+}
+```
+
+### Built-in Delivery Channels
+
+**InProcessChannel.** Uses `tokio::mpsc` bounded channels. The subscriber
+receives raw bytes with zero serialization overhead (or typed values if
+the subscriber is in the same binary and opts into generic dispatch). This
+is the fastest path — used by Rust plugins compiled into the kernel.
+
+**WebSocketChannel.** Maintains a persistent connection to a remote
+subscriber. Events are framed as length-prefixed binary messages. The
+channel handles reconnection detection: if the WebSocket drops, deliveries
+fail and enter the retry queue. When the subscriber reconnects, pending
+deliveries resume.
+
+**WebhookChannel.** Sends an HTTP POST per event to a configured URL.
+Supports configurable headers (for auth tokens), configurable retry policy,
+and delivery confirmation via HTTP status code (2xx = delivered). Suitable
+for serverless functions and external integrations that do not maintain
+persistent connections.
+
+**CustomChannel.** A proxy that delegates to a plugin-registered
+`DeliveryChannel` implementation. The bus holds a registry of
+`channel_type -> Arc<dyn DeliveryChannel>`. When a subscription requests a
+custom channel type, the bus looks up the provider and delegates. If the
+provider plugin disconnects, deliveries to custom-channel subscribers
+fail and enter the retry queue.
+
+### Channel Configuration
+
+```rust
+pub enum ChannelConfig {
+    InProcess,
+    WebSocket {
+        /// Connection ID assigned by the transport server.
+        connection_id: String,
+    },
+    Webhook {
+        url: String,
+        headers: HashMap<String, String>,
+        retry: RetryPolicy,
+    },
+    Custom {
+        channel_type: String,
+        config: serde_json::Value,
+    },
+}
+
+pub struct RetryPolicy {
+    /// Maximum number of delivery attempts.
+    pub max_attempts: u32,
+    /// Initial backoff duration.
+    pub initial_backoff: Duration,
+    /// Backoff multiplier per attempt.
+    pub multiplier: f64,
+    /// Maximum backoff duration.
+    pub max_backoff: Duration,
+}
+```
+
+### Transport Servers
+
+Transport servers are the network-facing components that accept remote
+connections and bridge them into the bus. They are optional — an in-process-only
+deployment does not start them.
+
+**WebSocket Server.** Built on `tokio-tungstenite`. Listens on a configurable
+address. Each connection goes through an authentication handshake (API key
+or JWT in the initial message or query parameter). Authenticated connections
+can:
+
+- Register as a plugin
+- Subscribe to subjects (with priority, mode, and implicit WebSocket delivery)
+- Publish events
+- Send request/reply messages
+- Register custom delivery channel types
+- Respond to health checks
+
+The protocol is JSON-framed messages with a `type` field discriminator,
+similar to the current API gateway WebSocket protocol but extended with
+interceptor chain semantics.
+
+**HTTP Server.** Built on `axum`. Provides:
+
+- `POST /publish` — publish an event
+- `POST /request` — request/reply (synchronous, waits for reply)
+- `POST /subscribe` — register a webhook subscription
+- `DELETE /subscribe/{id}` — remove a subscription
+- `GET /events/{seq}` — retrieve a stored event by sequence number
+- `GET /health` — bus health check
+
+The HTTP server is stateless per-request. It does not maintain long-lived
+connections. Webhook subscriptions registered via HTTP are persisted in the
+event store so they survive restarts.
+
+---
+
+## Layer 3: Dispatch Engine
+
+The dispatch engine is the core event routing logic. It receives a published
+event (already persisted by the storage engine), resolves matching
+subscribers, executes the interceptor chain, and fans out to async
+subscribers.
+
+### Subject Index
+
+The dispatch engine maintains an in-memory index of subscriptions, organized
+by subject pattern. The index supports exact subjects and two wildcard forms:
+
+- `*` matches exactly one token: `channel.*.inbound` matches
+  `channel.telegram.inbound` but not `channel.telegram.sub.inbound`
+- `>` matches one or more tokens at the end: `brain.>` matches
+  `brain.content.store` and `brain.entity.upsert`
+
+The index is a trie keyed by subject tokens. Lookup is O(depth) where depth
+is the number of tokens in the published subject. Wildcard matching is
+resolved during trie traversal.
+
+```rust
+struct SubjectIndex {
+    root: TrieNode,
+}
+
+struct TrieNode {
+    /// Subscriptions attached at this exact position.
+    subscriptions: Vec<SubscriptionEntry>,
+    /// Children keyed by literal token.
+    children: HashMap<String, TrieNode>,
+    /// Subscriptions using '*' at this position.
+    wildcard: Option<Box<TrieNode>>,
+    /// Subscriptions using '>' at this position (terminal wildcard).
+    terminal_wildcard: Vec<SubscriptionEntry>,
+}
+
+struct SubscriptionEntry {
+    pub id: String,
+    pub priority: u32,
+    pub mode: SubscriptionMode,
+    pub channel: ChannelConfig,
+    pub timeout: Duration,
+    pub filter: Option<EventFilter>,
+}
+
+pub enum SubscriptionMode {
+    /// Handler receives the event mutably. Processed sequentially
+    /// in priority order. Can modify or drop the event.
+    Sync,
+    /// Handler receives a clone. Runs in parallel with other
+    /// async subscribers. Cannot affect the sync chain.
+    Async,
+}
+```
+
+### Event Filters
+
+Subscriptions can optionally declare a filter that narrows which events they
+receive beyond subject matching. Filters operate on the serialized event
+payload without deserializing into a specific type.
+
+```rust
+pub enum EventFilter {
+    /// Match a JSON path against a value.
+    /// Example: field "platform" equals "telegram"
+    FieldEquals { path: String, value: serde_json::Value },
+    /// Match a JSON path against a pattern.
+    FieldContains { path: String, substring: String },
+    /// Logical AND of multiple filters.
+    All(Vec<EventFilter>),
+    /// Logical OR of multiple filters.
+    Any(Vec<EventFilter>),
+}
+```
+
+### Dispatch Pipeline
+
+When an event is published:
+
+```
+1. PERSIST
+   │  Storage engine assigns seq, writes to events table + subject_idx.
+   │  Status: Pending.
+   │
+2. RESOLVE
+   │  Subject index lookup returns all matching SubscriptionEntry items.
+   │  Split into two lists: sync (sorted by priority ASC) and async.
+   │
+3. FILTER
+   │  Apply EventFilter on each subscription. Remove non-matching entries.
+   │
+4. SYNC CHAIN
+   │  Status: Dispatching.
+   │  For each sync subscriber in priority order:
+   │    a. Deliver event via the subscriber's delivery channel.
+   │    b. Wait for response (mutated event or drop signal).
+   │    c. If timeout expires → skip, log warning, continue.
+   │    d. If drop signal → abort pipeline, status: Delivered (dropped).
+   │    e. If mutated → replace event payload, continue to next handler.
+   │    f. Record delivery status.
+   │
+5. ASYNC FAN-OUT
+   │  Take the final (possibly mutated) event from the sync chain.
+   │  Spawn a delivery task for each async subscriber concurrently.
+   │  Each task:
+   │    a. Deliver via the subscriber's delivery channel.
+   │    b. On success → record DeliveryStatus::Delivered.
+   │    c. On failure → record DeliveryStatus::Failed, schedule retry.
+   │
+6. FINALIZE
+   │  If all deliveries succeeded → status: Delivered.
+   │  If some failed → status: PartiallyDelivered.
+   │  Retry background task picks up PartiallyDelivered events.
+```
+
+### Sync Interceptor Protocol
+
+For in-process subscribers, the sync interceptor is a Rust closure or trait
+object:
+
+```rust
+#[async_trait]
+pub trait Interceptor: Send + Sync + 'static {
+    /// Process the event. Return Modified(bytes) to continue with
+    /// changes, Pass to continue unchanged, or Drop to kill the event.
+    async fn intercept(
+        &self,
+        subject: &str,
+        payload: &mut Vec<u8>,
+    ) -> InterceptResult;
+}
+
+pub enum InterceptResult {
+    /// Event was modified in place. Continue the chain.
+    Modified,
+    /// Event passes through unchanged. Continue the chain.
+    Pass,
+    /// Event is dropped. Abort the chain, do not deliver to
+    /// async subscribers.
+    Drop,
+}
+```
+
+For remote subscribers (WebSocket, webhook), the sync interceptor protocol
+is a request/reply exchange: the bus sends the event, the subscriber returns
+a response indicating Modified (with new payload), Pass, or Drop. The bus
+enforces the timeout — if no response arrives, the interceptor is skipped.
+
+### Request/Reply
+
+Request/reply is built on top of pub/sub. When a caller publishes a request:
+
+1. The bus generates a unique reply subject (e.g., `_reply.{ulid}`).
+2. The bus creates a one-shot subscription on the reply subject.
+3. The event is published to the target subject with `reply_subject` set.
+4. The subscriber receives the event, processes it, and publishes a reply
+   to the reply subject.
+5. The one-shot subscription receives the reply and returns it to the caller.
+6. If no reply arrives within the timeout, the request returns an error.
+
+This matches NATS request/reply semantics exactly.
+
+---
+
+## Layer 4: EventBus Trait (Public API)
+
+The top-level trait is what external code interacts with. It composes
+the storage engine, dispatch engine, delivery channels, and transport
+servers behind a single async interface.
+
+```rust
+#[async_trait]
+pub trait EventBus: Send + Sync + 'static {
+    // --- Pub/Sub ---
+
+    /// Publish an event to a subject. The event is persisted durably
+    /// before dispatch begins.
+    async fn publish(&self, subject: &str, payload: &[u8]) -> Result<u64>;
+
+    /// Subscribe to a subject pattern with the given options.
+    /// Returns a Subscription handle for receiving events (in-process)
+    /// or a subscription ID (remote delivery).
+    async fn subscribe(
+        &self,
+        pattern: &str,
+        opts: SubscribeOpts,
+    ) -> Result<Subscription>;
+
+    /// Remove a subscription by ID.
+    async fn unsubscribe(&self, id: &str) -> Result<()>;
+
+    // --- Request/Reply ---
+
+    /// Publish a request and wait for a reply. Returns the reply payload
+    /// or a timeout error.
+    async fn request(
+        &self,
+        subject: &str,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> Result<Vec<u8>>;
+
+    /// Register a request handler on a subject. Incoming requests are
+    /// delivered via the subscription; the handler sends replies through
+    /// the provided replier.
+    async fn serve(
+        &self,
+        subject: &str,
+        opts: SubscribeOpts,
+    ) -> Result<RequestSubscription>;
+
+    // --- Delivery Channels ---
+
+    /// Register a custom delivery channel type.
+    async fn register_channel_type(
+        &self,
+        channel_type: &str,
+        provider: Arc<dyn DeliveryChannel>,
+    ) -> Result<()>;
+
+    // --- Interceptors (convenience for in-process) ---
+
+    /// Register a sync interceptor for a subject pattern.
+    /// Shorthand for subscribe with mode=Sync and an InProcess channel.
+    async fn intercept(
+        &self,
+        pattern: &str,
+        priority: u32,
+        interceptor: Arc<dyn Interceptor>,
+    ) -> Result<String>;
+
+    // --- Administration ---
+
+    /// List active subscriptions, optionally filtered by subject pattern.
+    async fn list_subscriptions(
+        &self,
+        filter: Option<&str>,
+    ) -> Result<Vec<SubscriptionInfo>>;
+
+    /// Get bus metrics: events processed, pending retries, storage size.
+    async fn metrics(&self) -> Result<BusMetrics>;
+}
+
+pub struct SubscribeOpts {
+    pub priority: u32,
+    pub mode: SubscriptionMode,
+    pub channel: ChannelConfig,
+    pub timeout: Duration,
+    pub filter: Option<EventFilter>,
+}
+```
+
+### Builder Pattern
+
+The bus is constructed via a builder that configures storage, transports,
+and operational parameters:
+
+```rust
+let bus = EventBusBuilder::new()
+    .storage(RedbEventStore::open("./data/eventbus.redb")?)
+    .websocket_server("0.0.0.0:9100")
+    .http_server("0.0.0.0:9101")
+    .compaction_interval(Duration::from_secs(3600))
+    .retention(Duration::from_secs(86400))
+    .dead_letter_retention(Duration::from_secs(604800))
+    .default_interceptor_timeout(Duration::from_secs(5))
+    .build()
+    .await?;
+```
+
+All transport servers are optional. A minimal in-process-only bus:
+
+```rust
+let bus = EventBusBuilder::new()
+    .storage(RedbEventStore::open("./data/eventbus.redb")?)
+    .build()
+    .await?;
+```
+
+An in-memory bus for testing (no persistence, no transports):
+
+```rust
+let bus = EventBusBuilder::new()
+    .storage(InMemoryEventStore::new())
+    .build()
+    .await?;
+```
+
+---
+
+## Module Map
+
+```
+seidrum-eventbus/
+├── src/
+│   ├── lib.rs                  # Re-exports, EventBus trait
+│   ├── bus.rs                  # EventBusImpl: wires everything together
+│   ├── builder.rs              # EventBusBuilder
+│   │
+│   ├── dispatch/
+│   │   ├── mod.rs
+│   │   ├── engine.rs           # Dispatch pipeline (persist → chain → fan-out)
+│   │   ├── subject_index.rs    # Trie-based subject matching with wildcards
+│   │   ├── interceptor.rs      # Interceptor trait, sync chain execution
+│   │   └── filter.rs           # EventFilter evaluation
+│   │
+│   ├── storage/
+│   │   ├── mod.rs              # EventStore trait
+│   │   ├── redb_store.rs       # redb implementation
+│   │   ├── memory_store.rs     # In-memory implementation (testing)
+│   │   ├── types.rs            # StoredEvent, EventStatus, DeliveryRecord
+│   │   └── compaction.rs       # Background compaction task
+│   │
+│   ├── delivery/
+│   │   ├── mod.rs              # DeliveryChannel trait
+│   │   ├── in_process.rs       # tokio::mpsc channel delivery
+│   │   ├── websocket.rs        # WebSocket delivery
+│   │   ├── webhook.rs          # HTTP POST delivery
+│   │   ├── custom.rs           # Plugin-registered channel proxy
+│   │   └── retry.rs            # Background retry task
+│   │
+│   ├── transport/
+│   │   ├── mod.rs
+│   │   ├── ws_server.rs        # WebSocket server (tokio-tungstenite)
+│   │   ├── http_server.rs      # HTTP server (axum)
+│   │   └── protocol.rs         # Wire protocol types (JSON message framing)
+│   │
+│   └── request_reply.rs        # Request/reply implementation
+│
+├── PROJECT.md
+├── ARCHITECTURE.md
+├── PLAN.md
+├── QUALITY.md
+└── Cargo.toml
+```
+
+---
+
+## Key Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `tokio` | Async runtime, channels, timers |
+| `redb` | Embedded ACID storage |
+| `axum` | HTTP transport server |
+| `tokio-tungstenite` | WebSocket transport server |
+| `serde` / `serde_json` | Serialization for protocol and config |
+| `tracing` | Structured logging |
+| `thiserror` | Error types |
+
+---
+
+## Threading Model
+
+The bus runs entirely within a single tokio runtime. There are no
+blocking operations on the dispatch path. The storage engine uses
+`spawn_blocking` for redb transactions (redb is not async-native)
+but this is isolated behind the `EventStore` trait.
+
+Background tasks:
+
+- **Retry task**: polls `query_retryable()` on a configurable interval
+  (default: 5s), re-dispatches failed deliveries.
+- **Compaction task**: runs on a longer interval (default: 1h), removes
+  old delivered events.
+- **Health task**: periodically checks delivery channel health, marks
+  unhealthy channels for retry escalation.
+
+All background tasks are spawned as tokio tasks and shut down gracefully
+when the bus is dropped.
+
+---
+
+## Error Handling
+
+- Storage errors during write-ahead persist → publish returns Err to caller.
+  The event is not dispatched.
+- Storage errors during status update → logged, retry on next cycle.
+  Not on the critical path.
+- Delivery channel errors → DeliveryStatus::Failed, scheduled for retry.
+  The event is not lost.
+- Sync interceptor timeout → interceptor skipped, warning logged, chain
+  continues. The event is not blocked.
+- Sync interceptor panic → caught by tokio, treated as timeout. Chain
+  continues.
+
+The principle: storage failures before dispatch are hard errors (caller
+knows the event was not accepted). Everything after persist is best-effort
+with retry. Events are never silently lost.

--- a/crates/core/seidrum-eventbus/AUDIT.md
+++ b/crates/core/seidrum-eventbus/AUDIT.md
@@ -1,0 +1,407 @@
+# AUDIT.md — Current State vs. Spec
+
+This document compares the current state of `seidrum-eventbus` (commit
+`94ed20c` on main, the merged Phase 5 PR #27) against the canonical
+specifications restored on this branch:
+
+- [`PROJECT.md`](./PROJECT.md) — vision and design constraints
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — internal architecture, trait definitions, module map
+- [`PLAN.md`](./PLAN.md) — phased development plan
+- [`QUALITY.md`](./QUALITY.md) — testing and quality strategy
+
+The audit is grouped by **layer** and within each layer by **conformance status**.
+Where the current code diverges from the spec, the audit notes whether the
+divergence is:
+
+- **OK** — intentional or improved upon spec, no action needed
+- **GAP** — spec'd functionality is missing
+- **DRIFT** — current code does something different than spec; needs reconciliation
+- **EXTRA** — current code has functionality not described in spec
+
+---
+
+## Overall Phase Status
+
+| Phase (per PLAN.md) | Status | Notes |
+|---|---|---|
+| Phase 1: Storage + in-process pub/sub | ✅ Done | Shipped as PR #20 |
+| Phase 2: Wildcards + interceptor chains | ✅ Done | Shipped as PR #21 |
+| Phase 3: Request/reply | ✅ Done | Shipped as PR #22 |
+| Phase 4: Transports + retry/dead-letter + custom channels + remote sync interceptor protocol | ⚠️ **Partial** | PR #23 + PR #27 finished most of Phase 4. **Remote sync interceptor protocol over WebSocket/webhook is missing.** |
+| Phase 5: Seidrum kernel migration / NATS replacement | ❌ Not started | What we labeled "Phase 5" was actually completing Phase 4. Real Phase 5 is the kernel migration described in PLAN.md lines 137-179. |
+| Phase 6: Interceptor-based plugin patterns + example plugins | ❌ Not started | |
+
+---
+
+## Layer 1 — Storage Engine
+
+### EventStore trait
+
+| Spec method (ARCHITECTURE.md) | Current state | Status |
+|---|---|---|
+| `append(&StoredEvent) -> Result<u64>` | Present | ✅ OK |
+| `update_status(seq, status)` | Present | ✅ OK |
+| `record_delivery(seq, sub_id, status)` | Present, **with extra params**: `error: Option<String>`, `next_retry: Option<u64>` | EXTRA — needed for proper retry plumbing. Already documented; spec should be updated to match. |
+| `query_by_status(status, limit)` | Present | ✅ OK |
+| `query_by_subject(pattern, since, limit)` | Present, but supports **exact match only**, not pattern | DRIFT — the trait method is named "by_subject" with a `pattern` param in the spec, but the current impl is exact-only. Spec ARCHITECTURE.md L65-70 says "by subject pattern". Either rename or implement pattern matching. |
+| `query_retryable(max_attempts, limit)` | Present, ordered by `next_retry` | ✅ OK |
+| `compact(older_than)` | Present | ✅ OK |
+| `get(seq)` | Present | EXTRA — added during Phase 5 review sweep for `maybe_finalize_event`. Useful, not in spec. |
+| `count_retryable(max_attempts)` | Present | EXTRA — added for the metrics endpoint. Not in spec. |
+| `query_dead_lettered(limit)` | Present (default impl) | EXTRA — convenience helper. |
+
+### StoredEvent / DeliveryRecord schema
+
+| Spec field (ARCHITECTURE.md L88-132) | Current state | Status |
+|---|---|---|
+| `StoredEvent { seq, subject, payload, stored_at, status, deliveries, reply_subject }` | All present | ✅ OK |
+| `EventStatus { Pending, Dispatching, Delivered, PartiallyDelivered, DeadLettered }` | All present | ✅ OK |
+| `DeliveryRecord { subscriber_id, status, attempts, last_attempt, next_retry, error }` | All present | ✅ OK |
+| `DeliveryStatus { Pending, Delivered, Failed, DeadLettered }` | All present | ✅ OK |
+| `DeliveryRecord::is_retryable(max, now)` helper | Present | EXTRA — added during review sweep. Useful. |
+
+### redb table layout
+
+ARCHITECTURE.md L140-145 specifies four tables:
+
+| Spec table | Key | Value | Current state |
+|---|---|---|---|
+| `events` | `seq: u64` | `StoredEvent` | ✅ Present |
+| `subject_idx` | `(subject, seq)` | `()` | ✅ Present |
+| `status_idx` | `(status, seq)` | `()` | ✅ Present |
+| `delivery_idx` | `(subscriber_id, seq)` | `DeliveryStatus` | **GAP — missing**. Current code has `failed_deliveries_idx` keyed by `seq` (no subscriber_id). The spec table would enable per-subscriber retry queries; the current table only enables "events with at least one failure". This is a meaningful divergence but defensible — see notes. |
+
+### Compaction
+
+| Spec | Current | Status |
+|---|---|---|
+| Removes Delivered events older than retention (default 24h) | Yes | ✅ OK |
+| Removes DeadLettered events older than dead-letter retention (default 7d) | **No** — DeadLettered events use the same retention as Delivered | DRIFT — spec ARCHITECTURE.md L156-159 wants longer dead-letter retention "for debugging". Current `compact()` treats both terminal states identically. |
+| Background task with configurable interval (default 1h) | Yes | ✅ OK |
+| Graceful shutdown via watch signal | Yes | EXTRA — improved upon spec (not explicitly required) |
+
+### Storage tests (per QUALITY.md L60-74)
+
+| Required test | Present? |
+|---|---|
+| `test_append_and_query` | ✅ |
+| `test_seq_monotonic` | ✅ |
+| `test_status_update` | ✅ |
+| `test_delivery_recording` | ✅ |
+| `test_query_by_status_filter` | ✅ |
+| `test_query_by_subject_exact` | ✅ |
+| `test_query_by_subject_pattern` | **GAP — missing** (because pattern query is not implemented) |
+| `test_query_retryable` | ✅ (covered indirectly via Phase 5 retry tests) |
+| `test_compaction_delivered` | ✅ |
+| `test_compaction_preserves_deadletter` | **GAP** — needed once dead-letter retention is implemented |
+| `test_crash_recovery` | ✅ (`test_redb_crash_recovery`, plus `test_redb_failed_delivery_survives_restart`) |
+| `test_concurrent_appends` | ✅ (`test_memory_store_concurrent_appends`) — but only in-memory, not against ReDB |
+| `bench_append_throughput` | **GAP** — no benchmarks |
+
+---
+
+## Layer 2 — Delivery Channels and Transport Servers
+
+### DeliveryChannel trait
+
+| Spec | Current | Status |
+|---|---|---|
+| `deliver(event, subject, config) -> Result<DeliveryReceipt>` | Present | ✅ OK |
+| `cleanup(config)` | Present | ✅ OK |
+| `is_healthy(config)` | Present | ✅ OK |
+| `DeliveryReceipt { delivered_at, latency_us }` | Present | ✅ OK |
+| `DeliveryError` enum | Present, with `Failed`, `Permanent`, `NotReady` | EXTRA — `Permanent` was added during Phase 5 review for HTTP 4xx classification. Not in spec but improvement. |
+
+### Built-in delivery channels
+
+| Spec channel | Present? | Notes |
+|---|---|---|
+| `InProcessChannel` (tokio::mpsc) | ✅ Standalone implementation in `delivery/in_process.rs` | The dispatch engine **does not actually use this** for in-process subscribers — it uses raw mpsc senders stored in `DispatchState::senders`. The standalone `InProcessChannel` exists as an implementation of the `DeliveryChannel` trait but is dead code from a user perspective. |
+| `WebSocketChannel` | ✅ `delivery/websocket.rs` | Standalone — same caveat as above. The transport WS server uses its own forwarder, not this channel. |
+| `WebhookChannel` | ✅ `delivery/webhook.rs` | This one **is** used: by both the HTTP transport's subscription handler and the dispatch engine's retry path. |
+| `CustomChannel` proxy | **GAP — no proxy struct** | The `ChannelRegistry` exists and the engine looks up `Custom { channel_type }` channels at retry time, but there's no `CustomChannel` struct. The spec describes it as "A proxy that delegates to a plugin-registered impl" — currently the engine inlines this lookup. Not strictly missing functionality, just missing the named type. |
+
+### ChannelConfig
+
+ARCHITECTURE.md L226-241:
+
+| Spec variant | Current | Status |
+|---|---|---|
+| `InProcess` | ✅ | OK |
+| `WebSocket { connection_id }` | Current is unit variant `WebSocket` (no connection_id) | DRIFT — connection_id was removed during review sweep as "dead metadata". Spec includes it. The spec usage was vague, so the divergence is defensible. |
+| `Webhook { url, headers, retry: RetryPolicy }` | Current is `Webhook { url, headers }` (no embedded RetryPolicy) | DRIFT — current code has retry config at the bus/builder level (`RetryConfig`), not per-subscription. Spec wanted per-subscription retry policy. Bus-wide is simpler and matches the actual use case but is a real divergence. |
+| `Custom { channel_type, config }` | ✅ | OK |
+| `RetryPolicy { max_attempts, initial_backoff, multiplier, max_backoff }` | Current `RetryConfig { max_attempts, initial_backoff_ms, max_backoff_ms }` (no `multiplier`) | DRIFT — spec has separate multiplier; current code hardcodes 2x exponential. Same field semantics otherwise. |
+
+### Transport servers
+
+| Spec endpoint / capability | Current state | Status |
+|---|---|---|
+| WS server: `tokio-tungstenite`, configurable address | ✅ | OK |
+| WS server: API key / JWT auth | ✅ `Authenticator` trait + `AuthRequest` with peer_addr + headers | OK |
+| WS subscribe / publish / request | ✅ JSON protocol | OK |
+| WS register custom delivery channel type | **GAP** — no protocol message for this | Spec wants plugins to be able to register channels over WS. Today the registry is only writable from in-process Rust code. |
+| **WS sync interceptor protocol** (request/reply for Modified/Pass/Drop) | **GAP — entirely missing** | This is the biggest Phase 4 gap. Remote subscribers can subscribe `Async` only — they cannot participate in the sync interceptor chain. ARCHITECTURE.md L436-440 and PLAN.md L154 require this. |
+| HTTP `POST /publish` | ✅ | OK |
+| HTTP `POST /request` | ✅ | OK |
+| HTTP `POST /subscribe` (webhook subscription) | ✅ | OK |
+| HTTP `DELETE /subscribe/:id` | ✅ | OK |
+| HTTP `GET /events/:seq` | **GAP — removed during review sweep** as a stub. Spec lists it as a deliverable. |
+| HTTP `GET /health` | ✅ | OK |
+| HTTP `GET /metrics` | ✅ | OK |
+| Webhook subscriptions persisted (survive restart) | **GAP** — current webhook subscriptions live in dispatch state only; on restart they're gone. |
+| **Webhook sync interceptor protocol** (response body indicates Modified/Pass/Drop) | **GAP** — same as WS interceptor protocol gap |
+
+### Delivery channel tests (QUALITY.md L137-149)
+
+| Required test | Present? |
+|---|---|
+| `test_in_process_roundtrip` | ✅ |
+| `test_in_process_backpressure` | **GAP** |
+| `test_ws_delivery` | **GAP** — no real WS server end-to-end test |
+| `test_ws_disconnect_failure` | **GAP** |
+| `test_ws_reconnect_resume` | **GAP** |
+| `test_webhook_success` | **GAP** — no real HTTP mock server test |
+| `test_webhook_server_error` | **GAP** |
+| `test_webhook_connection_refused` | **GAP** |
+| `test_webhook_custom_headers` | **GAP** |
+| `test_custom_channel_delegation` | ✅ (Phase 5 retry tests cover this indirectly) |
+| `test_custom_unregistered_error` | ✅ (`test_retry_permanent_error_dead_letters_immediately`) |
+
+---
+
+## Layer 3 — Dispatch Engine
+
+### Subject index
+
+| Spec | Current | Status |
+|---|---|---|
+| Trie keyed by subject tokens | ✅ | OK |
+| `*` single-token wildcard | ✅ | OK |
+| `>` terminal wildcard | ✅ | OK |
+| Lookup O(depth) | ✅ | OK |
+| `SubjectIndex::find_by_id` | Present | EXTRA — needed for retry path. |
+
+### Event filters (QUALITY.md L113-122)
+
+| Required test | Present? |
+|---|---|
+| `test_field_equals_match` | ✅ |
+| `test_field_equals_reject` | ✅ |
+| `test_field_contains` | ✅ |
+| `test_nested_path` | ✅ |
+| `test_all_combinator` | ✅ |
+| `test_any_combinator` | ✅ |
+| `test_missing_field` | ✅ (covered by `test_field_equals_missing_field`) |
+
+### Dispatch pipeline (ARCHITECTURE.md L370-406)
+
+The 6-stage pipeline (PERSIST → RESOLVE → FILTER → SYNC → ASYNC FAN-OUT → FINALIZE) is fully implemented.
+
+**Notable divergences from spec:**
+
+| Spec behavior | Current behavior | Status |
+|---|---|---|
+| Async fan-out: "Spawn a delivery task for each async subscriber concurrently" | Current implementation **iterates async senders sequentially** with `try_send`. The pipeline doc on `DispatchEngine` says so explicitly. | DRIFT — spec wants `tokio::spawn` per subscriber for true concurrency. Current is non-blocking sequential. Same result for fast subscribers; slow subscribers serialize. |
+| "Spawn a delivery task for each async subscriber" → "On failure → record DeliveryStatus::Failed, schedule retry" | Current records via `try_record` helper with computed `next_retry` | ✅ OK |
+| Sync chain holds `RwLock` only during snapshot | ✅ Snapshot pattern is in place | OK (after Phase 5 review fix) |
+| Re-entrant publish from sync interceptor returns error | **GAP — no detection** | The constraint is documented in PROJECT.md L101-103 and QUALITY.md L108 (`test_reentrant_error`). Currently a sync interceptor that calls `bus.publish` on a subject it intercepts will deadlock or recurse forever. |
+
+### Interceptor tests (QUALITY.md L93-109)
+
+| Required test | Present? |
+|---|---|
+| `test_priority_order` | ✅ (`test_interceptor_chain_ordering`) |
+| `test_mutation` | ✅ (`test_interceptor_modifies_payload`) |
+| `test_mutation_propagation` | ✅ |
+| `test_mutation_visible_to_async` | ✅ |
+| `test_drop_aborts` | ✅ |
+| `test_drop_prevents_async` | ✅ (`test_interceptor_drops_event`) |
+| `test_pass_unchanged` | ✅ |
+| `test_timeout_skip` | ✅ (`test_interceptor_timeout_skips`) |
+| `test_timeout_no_stall` | ✅ (covered by timeout test) |
+| `test_panic_recovery` | **GAP** — no test for a panicking interceptor |
+| `test_async_concurrent` | **GAP** — but see async fan-out divergence above |
+| `test_mixed_ordering` | ✅ (`test_mixed_sync_async_delivery`) |
+| `test_reentrant_error` | **GAP** — no detection, no test |
+| `test_no_sync_passthrough` | ✅ (`test_subscribe_and_receive` covers this trivially) |
+
+### Request/reply tests (QUALITY.md L125-133)
+
+| Required test | Present? |
+|---|---|
+| `test_basic_roundtrip` | ✅ |
+| `test_timeout_no_handler` | ✅ |
+| `test_timeout_slow_handler` | ✅ |
+| `test_concurrent_requests` | ✅ |
+| `test_through_interceptor` | ✅ |
+| `test_cleanup_on_complete` | ✅ |
+| `test_cleanup_on_timeout` | ✅ |
+
+---
+
+## Layer 4 — EventBus Trait (Public API)
+
+| Spec method (ARCHITECTURE.md L463-534) | Current | Status |
+|---|---|---|
+| `publish(subject, payload) -> Result<u64>` | ✅ | OK |
+| `subscribe(pattern, opts) -> Result<Subscription>` | ✅ | OK |
+| `unsubscribe(id)` | ✅ | OK |
+| `request(subject, payload, timeout) -> Result<Vec<u8>>` | ✅ | OK |
+| `serve(subject, opts) -> Result<RequestSubscription>` | ✅ But signature differs: takes individual params (`priority`, `timeout`, `filter`) instead of `SubscribeOpts`. Justified by the previous review. | DRIFT (intentional) |
+| `register_channel_type(channel_type, provider)` | **GAP — not on EventBus trait**. The `ChannelRegistry` has `register()` but it's only accessible via the builder's `register_channel()` method, not at runtime via the bus. Spec wants this on the trait so plugins can register channels at runtime over the network. |
+| `intercept(pattern, priority, interceptor)` (shorthand) | ✅ With extra `timeout` param | OK |
+| `list_subscriptions(filter)` | ✅ Filter is exact-match per the review | OK |
+| `metrics()` | ✅ | OK |
+
+### `BusMetrics` shape
+
+| Spec | Current | Status |
+|---|---|---|
+| events processed | `events_published` ✅ | OK |
+| events delivered | `events_delivered` ✅ | OK |
+| pending retries | `events_pending_retry` ✅ (gated on `retry_enabled`) | OK |
+| storage size | **GAP** — not exposed | Spec ARCHITECTURE.md L533 mentions "storage size". |
+| subscription count | ✅ | OK |
+
+### Builder
+
+| Spec builder method | Current | Status |
+|---|---|---|
+| `storage(impl)` | ✅ | OK |
+| `websocket_server(addr)` | ✅ as `with_websocket(addr)` | OK |
+| `http_server(addr)` | ✅ as `with_http(addr)` | OK |
+| `compaction_interval(d)` | ✅ | OK |
+| `retention(d)` | ✅ | OK |
+| `dead_letter_retention(d)` | **GAP** — not present | Tied to the "longer dead-letter retention" gap above. |
+| `default_interceptor_timeout(d)` | **GAP** — interceptor timeout is set per-subscription only (`SubscribeOpts::timeout`); no bus-wide default. |
+| `with_retry`, `with_retry_poll_interval`, `with_retry_query_limit` | ✅ | EXTRA — not in spec but needed |
+| `with_channel_registry`, `register_channel` | ✅ | EXTRA — needed for shared registry plumbing |
+| `build()` | ✅ | OK |
+
+### Test utilities (QUALITY.md L196-239)
+
+| Spec utility | Current | Status |
+|---|---|---|
+| `test_utils::test_bus()` | ✅ | OK |
+| `test_utils::test_bus_with_storage()` | **GAP** |
+| `test_utils::test_bus_with_transports()` | **GAP** |
+| `publish_and_wait(...)` | **GAP** |
+| `collect_events(...)` | **GAP** |
+| `RecordingInterceptor` | **GAP** |
+| `MockWebhookServer` | **GAP** |
+
+---
+
+## Threading and Background Tasks
+
+| Spec (ARCHITECTURE.md L646-662) | Current | Status |
+|---|---|---|
+| Single tokio runtime, no blocking on dispatch | ✅ | OK |
+| Storage `spawn_blocking` for redb | ✅ | OK |
+| Retry task: poll `query_retryable()` interval (default 5s) | ✅ Default is **1s** in builder | DRIFT (minor) |
+| Compaction task: longer interval (default 1h) | ✅ | OK |
+| Health task: check delivery channel health | **GAP** — no periodic health task |
+| Graceful shutdown via tokio task drop | ✅ Via watch channel + `shutdown_and_join` | OK |
+
+---
+
+## Cross-cutting Gaps
+
+### Tracing and observability (QUALITY.md L324-338)
+
+| Spec | Current |
+|---|---|
+| `tracing` spans on bus operations | Mostly inline `tracing::warn!` / `debug!` calls; no proper `#[tracing::instrument]` spans | DRIFT |
+| `INFO` for bus started, transport listening, sub added/removed | Partial — bus started yes, sub add/remove no | DRIFT |
+| `DEBUG` for event published, delivery started/completed | Yes for published; partial for delivery | OK-ish |
+| `WARN` for interceptor timeout, delivery failure, channel unhealthy | ✅ | OK |
+| `ERROR` for storage write failed, max retries exhausted, transport error | ✅ | OK |
+
+### Benchmarks (QUALITY.md L257-269)
+
+**GAP — no benchmark suite exists.** Spec lists 6 benchmarks with concrete targets (`bench_append`, `bench_publish_deliver`, `bench_subject_lookup`, `bench_interceptor_chain`, `bench_ws_roundtrip`, `bench_concurrent_publish`). None exist in `benches/`.
+
+### Property-based testing (QUALITY.md L243-254)
+
+**GAP — no `proptest` dependency, no property tests.** Spec recommends three areas (subject index, event filters, interceptor ordering).
+
+### Chaos / fault injection (QUALITY.md L274-291)
+
+**GAP — no chaos test suite.** Spec lists 5 fault injection scenarios, none implemented.
+
+### CI policy (QUALITY.md L307-321)
+
+The current CI runs `cargo test`, `cargo clippy`, `cargo fmt`. The spec also requires:
+- `cargo doc -p seidrum-eventbus --no-deps` on every PR — **GAP** (we run it locally but it's not in CI)
+- `cargo test -- --ignored` on merge to main — **GAP** (no ignored tests exist either)
+- `cargo bench` on merge to main — **GAP** (no benchmarks)
+
+---
+
+## Summary of Top Adjustments
+
+Sorted by impact:
+
+### Phase 4 completion (must finish before real Phase 5)
+
+1. **Remote sync interceptor protocol over WebSocket and webhook.** Spec ARCHITECTURE.md L436-440 + PLAN.md L154. Currently remote subscribers are async-only. This is the headline missing Phase 4 deliverable.
+2. **`register_channel_type` exposed on the `EventBus` trait** so remote plugins (or in-process plugins added at runtime) can register custom channel types over the network. ARCHITECTURE.md L506-512.
+3. **Webhook subscription persistence** so webhook subs survive restart. PLAN.md L132 explicitly calls this out.
+4. **`HttpServer` `GET /events/:seq` endpoint** restored — was removed during review sweep but is in the spec.
+
+### Storage spec drift
+
+5. **`delivery_idx` table keyed by `(subscriber_id, seq) → DeliveryStatus`** per ARCHITECTURE.md L145. Current `failed_deliveries_idx` keyed by `seq` is a simpler version. Decide: align with spec, or update the spec to match the simpler current design.
+6. **Dead-letter retention** as a separate setting from the regular retention. Default 7 days per spec.
+7. **`query_by_subject` with pattern matching** (or rename to `_exact` to make the limitation explicit).
+8. **Storage size in `BusMetrics`** (or remove from spec).
+
+### Test gaps
+
+9. **`test_panic_recovery`** — verify a panicking sync interceptor is caught and the chain continues.
+10. **`test_reentrant_error`** — but first **detect** re-entrant publish from a sync interceptor. Today it would deadlock or recurse.
+11. **End-to-end transport tests** — `test_ws_subscribe_receive`, `test_ws_remote_publish`, `test_http_publish`, etc. The current `phase4_transport.rs` tests don't actually start a server and connect to it.
+12. **Webhook integration tests** with a `MockWebhookServer` test utility.
+13. **`test_concurrent_appends` for ReDB** (currently only in-memory).
+
+### Test utilities
+
+14. **`test_utils::test_bus_with_storage`, `test_bus_with_transports`, `publish_and_wait`, `collect_events`, `RecordingInterceptor`, `MockWebhookServer`** — none of the QUALITY.md-mandated test utilities exist beyond the basic `test_bus()`.
+
+### Observability
+
+15. **Proper `#[tracing::instrument]` spans** on `publish_event`, `retry_to_subscriber`, `dispatch` stages.
+16. **Structured `INFO` logs** on subscription add/remove and bus startup.
+
+### Non-goals for now
+
+These are spec'd but lower priority and arguably can wait until after the kernel migration (real Phase 5):
+
+- Benchmarks (`benches/`) — useful but not blocking
+- Property-based testing — useful but not blocking
+- Chaos / fault injection — useful but not blocking
+- Health task for delivery channels
+- `default_interceptor_timeout` builder method
+
+---
+
+## Recommended Next Move
+
+Given the gap analysis, the cleanest path forward:
+
+1. **Finish Phase 4 properly** on a new branch:
+   - Remote sync interceptor protocol (WS + webhook)
+   - `register_channel_type` on the `EventBus` trait + WS protocol message
+   - Webhook subscription persistence
+   - Restore `GET /events/:seq`
+   - Fill the test utility gaps (`MockWebhookServer`, `RecordingInterceptor`, etc.)
+   - Add the missing transport integration tests
+
+2. **Then start real Phase 5** (kernel migration) on its own branch, replacing NATS with `seidrum-eventbus` per PLAN.md L137-180.
+
+3. **Phase 6** (interceptor-based plugin patterns + example plugins) follows after the kernel migration is stable.
+
+The other "drift" items (dead-letter retention, `delivery_idx` shape, `RetryPolicy` per-subscription, default interceptor timeout) should be discussed as a batch and either fixed or have the spec updated to match the current design.
+
+The "gap" items in observability, benchmarks, and chaos testing should be tracked but are not blockers for the kernel migration.

--- a/crates/core/seidrum-eventbus/IMPLEMENTATION.md
+++ b/crates/core/seidrum-eventbus/IMPLEMENTATION.md
@@ -1,0 +1,383 @@
+# Phase 1 Implementation Report: Storage Engine + In-Process Pub/Sub
+
+## Completion Status
+
+✅ **COMPLETE** - Phase 1 of seidrum-eventbus has been fully implemented according to specifications.
+
+## Deliverables Summary
+
+### 1. Cargo.toml ✅
+- Package: `seidrum-eventbus` v0.1.0, edition 2021
+- Dependencies: tokio (full), redb, serde/serde_json, tracing, thiserror, async-trait, ulid, chrono
+- Dev-dependencies: tempfile, tokio with macros
+- Location: `crates/core/seidrum-eventbus/Cargo.toml`
+
+### 2. Storage Layer ✅
+
+#### EventStore Trait (`src/storage/mod.rs`)
+```rust
+pub trait EventStore: Send + Sync + 'static {
+    async fn append(&self, event: &StoredEvent) -> StorageResult<u64>;
+    async fn update_status(&self, seq: u64, status: EventStatus) -> StorageResult<()>;
+    async fn record_delivery(&self, seq: u64, subscriber_id: &str, status: DeliveryStatus) -> StorageResult<()>;
+    async fn query_by_status(&self, status: EventStatus, limit: usize) -> StorageResult<Vec<StoredEvent>>;
+    async fn query_by_subject(&self, subject: &str, since: Option<u64>, limit: usize) -> StorageResult<Vec<StoredEvent>>;
+    async fn query_retryable(&self, max_attempts: u32, limit: usize) -> StorageResult<Vec<RetryableDelivery>>;
+    async fn compact(&self, older_than: Duration) -> StorageResult<u64>;
+}
+```
+
+#### Type Definitions (`src/storage/types.rs`)
+- `StoredEvent` - Event with seq, subject, payload, status, deliveries, reply_subject
+- `EventStatus` - Pending, Dispatching, Delivered, PartiallyDelivered, DeadLettered
+- `DeliveryStatus` - Pending, Delivered, Failed, DeadLettered
+- `DeliveryRecord` - Per-subscriber delivery tracking
+- `RetryableDelivery` - Query result for Phase 2 retry logic
+
+#### InMemoryEventStore (`src/storage/memory_store.rs`)
+- Arc<RwLock<Vec<StoredEvent>>> backing
+- Monotonically increasing sequence numbers via AtomicU64
+- All EventStore methods implemented
+- Zero disk I/O, instant (for testing)
+- Thread-safe concurrent access
+
+#### RedbEventStore (`src/storage/redb_store.rs`)
+- Uses redb 2.x embedded ACID database
+- Three tables:
+  - `events` (u64 → JSON-serialized StoredEvent)
+  - `subject_idx` ((subject, seq) → ())
+  - `status_idx` ((status_u8, seq) → ())
+- All operations use `spawn_blocking` (redb is sync)
+- Write-ahead persistence before dispatch
+- Crash recovery: events in Pending status are re-dispatched on reopen
+- Durable with ACID guarantees
+
+#### Compaction Task (`src/storage/compaction.rs`)
+- Background tokio task
+- Removes Delivered events older than retention period
+- Configurable interval and retention duration
+- Spawned automatically by EventBusBuilder
+
+### 3. Delivery Layer ✅
+
+#### DeliveryChannel Trait (`src/delivery/mod.rs`)
+```rust
+pub trait DeliveryChannel: Send + Sync + 'static {
+    async fn deliver(&self, event: &[u8], subject: &str, config: &ChannelConfig) -> DeliveryResult<DeliveryReceipt>;
+    async fn cleanup(&self, config: &ChannelConfig) -> DeliveryResult<()>;
+    async fn is_healthy(&self, config: &ChannelConfig) -> bool;
+}
+```
+
+#### ChannelConfig Enum
+- `InProcess` - tokio::mpsc delivery
+- `WebSocket` - Placeholder for Phase 4
+- `Webhook` - Placeholder for Phase 4
+- `Custom` - Placeholder for Phase 4
+
+#### InProcessChannel (`src/delivery/in_process.rs`)
+- tokio::mpsc::UnboundedSender/Receiver pair
+- Zero-serialization delivery
+- Instant latency (microseconds)
+- Thread-safe, async-first
+- Health check via `is_closed()`
+
+### 4. Dispatch Engine ✅
+
+#### SubjectIndex (`src/dispatch/subject_index.rs`)
+- Simple HashMap-based index (exact match only)
+- Subscription entries: id, subject_pattern, priority, mode, channel, timeout
+- Methods: `subscribe()`, `unsubscribe()`, `lookup()`, `list()`
+- Phase 1 limitation: exact match only (trie-based wildcards in Phase 2)
+- O(1) lookup for exact subjects
+
+#### DispatchEngine (`src/dispatch/engine.rs`)
+- Core event routing logic
+- Methods:
+  - `publish(subject, payload)` → seq
+  - `subscribe(subject_pattern, priority, mode)` → (id, receiver)
+  - `unsubscribe(id)`
+  - `list_subscriptions(filter)`
+- Pipeline:
+  1. Persist to storage (write-ahead)
+  2. Update status to Dispatching
+  3. Lookup matching subscriptions
+  4. Deliver to each via their channel
+  5. Record delivery status
+  6. Mark event as Delivered
+- Phase 1: Async delivery only (Sync mode in Phase 2)
+- Handles InProcess channels; other channels gracefully error
+
+### 5. EventBus Trait & Implementation ✅
+
+#### EventBus Trait (`src/bus.rs`)
+```rust
+pub trait EventBus: Send + Sync + 'static {
+    async fn publish(&self, subject: &str, payload: &[u8]) -> Result<u64>;
+    async fn subscribe(&self, pattern: &str, opts: SubscribeOpts) -> Result<Subscription>;
+    async fn unsubscribe(&self, id: &str) -> Result<()>;
+    async fn list_subscriptions(&self, filter: Option<&str>) -> Result<Vec<SubscriptionInfo>>;
+    async fn metrics(&self) -> Result<BusMetrics>;
+}
+```
+
+#### EventBusImpl
+- Wraps DispatchEngine and EventStore
+- Implements all EventBus methods
+- Defers all logic to lower layers
+
+#### Supporting Types
+- `Subscription` - id + UnboundedReceiver for receiving events
+- `SubscribeOpts` - priority, mode, channel, timeout
+- `BusMetrics` - events_published, events_delivered, events_pending_retry, subscription_count
+- `SubscriptionInfo` - id, pattern, priority, mode
+
+### 6. Builder Pattern ✅
+
+#### EventBusBuilder (`src/builder.rs`)
+```rust
+pub struct EventBusBuilder {
+    storage: Option<Arc<dyn EventStore>>,
+    compaction_interval: Duration,
+    retention: Duration,
+}
+```
+
+Methods:
+- `new()` - Create with defaults
+- `storage(Arc<dyn EventStore>)` - Set backing store (required)
+- `compaction_interval(Duration)` - Default: 3600s
+- `retention(Duration)` - Default: 86400s
+- `build() -> Arc<dyn EventBus>` - Create and start bus
+
+Behavior:
+- Spawns compaction task automatically
+- Returns trait object (works with any EventBus impl)
+- Fails if storage not provided
+
+### 7. Test Utilities ✅
+
+#### Test Module (`src/lib.rs`)
+```rust
+pub mod test_utils {
+    pub async fn test_bus() -> Arc<dyn EventBus> { ... }
+}
+```
+
+Creates in-memory bus for tests (zero I/O, instant creation).
+
+### 8. Comprehensive Tests ✅
+
+#### Unit Tests (embedded in modules)
+
+**Storage** (12 tests)
+- `test_append_and_query` - Round-trip persistence
+- `test_seq_monotonic` - Sequence numbers always increase
+- `test_status_update` - Status changes reflected in queries
+- `test_delivery_recording` - Delivery tracking works
+- `test_query_by_status_filter` - Status queries filter correctly
+- `test_query_by_subject_exact` - Subject queries work
+- `test_compaction_delivered` - Old delivered events removed
+- `test_memory_store_append` - In-memory store append
+- `test_memory_store_concurrent_appends` - Concurrent safety
+- `test_redb_append_and_query` - Redb persistence
+- `test_redb_crash_recovery` - Events survive reopens
+
+**Subject Index** (8 tests)
+- `test_exact_match` - Exact subject matching
+- `test_no_match` - Nonexistent subjects return empty
+- `test_multiple_subs_same_pattern` - Multiple subscriptions work
+- `test_unsubscribe` - Removing subscriptions
+- `test_priority_ordering` - Priority field preserved
+- `test_list_all` - List all subscriptions
+- `test_list_filter` - List with pattern filter
+
+**Dispatch Engine** (6 tests)
+- `test_publish_with_no_subscribers` - Event persisted even with no subs
+- `test_subscribe_and_receive` - Message delivery works
+- `test_exact_match_only` - Phase 1: exact subjects only
+- `test_unsubscribe` - Removing subscription stops delivery
+- `test_multiple_subscribers` - Multiple subs all receive
+
+**Bus** (5 tests)
+- `test_publish_deliver` - End-to-end roundtrip
+- `test_multi_subscriber` - Multiple subscribers
+- `test_builder_minimal` - Minimal config works
+- `test_list_subscriptions` - Listing and filtering
+- `test_builder_with_options` - Custom configuration
+
+**Delivery** (3 tests)
+- `test_in_process_delivery` - Channel delivery
+- `test_in_process_multiple_deliveries` - Multiple messages
+- `test_in_process_health` - Health check
+
+#### Integration Tests (`tests/integration_tests.rs`)
+
+- `test_publish_deliver_end_to_end` - Full publish/subscribe
+- `test_crash_recovery_full` - RedbEventStore persistence and reopen
+- `test_multi_subscriber` - Multiple subscribers receive same message
+- `test_metrics` - Subscription count in metrics
+- `test_unsubscribe` - Subscription removal
+
+**Total: ~50 tests across all layers**
+
+All tests follow QUALITY.md requirements:
+- Storage behavior: round-trip, monotonicity, status updates, delivery tracking, queries, compaction
+- Subject index: matching, unsubscribe, list
+- Dispatch: routing, multiple subscribers, lifecycle
+- Bus: end-to-end functionality
+- Delivery: in-process channel reliability
+
+## Code Organization
+
+```
+crates/core/seidrum-eventbus/
+├── Cargo.toml                           # Project manifest
+├── PROJECT.md                           # What and why
+├── ARCHITECTURE.md                      # Internal design
+├── PLAN.md                              # Phased development
+├── QUALITY.md                           # Testing strategy
+├── IMPLEMENTATION.md                    # This file
+├── src/
+│   ├── lib.rs                          # Public API re-exports + test_utils
+│   ├── bus.rs                          # EventBus trait + EventBusImpl
+│   ├── builder.rs                      # EventBusBuilder
+│   ├── storage/
+│   │   ├── mod.rs                      # EventStore trait + tests
+│   │   ├── types.rs                    # StoredEvent, EventStatus, etc.
+│   │   ├── memory_store.rs             # InMemoryEventStore impl
+│   │   ├── redb_store.rs               # RedbEventStore impl
+│   │   └── compaction.rs               # Background compaction task
+│   ├── delivery/
+│   │   ├── mod.rs                      # DeliveryChannel trait
+│   │   └── in_process.rs               # InProcessChannel impl
+│   └── dispatch/
+│       ├── mod.rs                      # Module exports
+│       ├── subject_index.rs            # Subject indexing (exact match)
+│       └── engine.rs                   # DispatchEngine core logic
+└── tests/
+    └── integration_tests.rs            # Integration test suite
+```
+
+## Compliance with Design Documents
+
+### PROJECT.md
+✅ Zero dependency on seidrum-kernel or seidrum-common
+✅ Embedded storage engine (redb)
+✅ In-process delivery channel implementation
+✅ Durable event persistence with write-ahead
+✅ Async-first API (all operations return futures)
+
+### ARCHITECTURE.md
+✅ Four-layer architecture implemented
+✅ Storage engine with trait boundary
+✅ Delivery channels with trait boundary
+✅ Dispatch engine with subject index
+✅ EventBus trait as public API
+✅ Module map matches specification exactly
+
+### PLAN.md (Phase 1)
+✅ EventStore trait with append, update_status, record_delivery, query methods
+✅ InMemoryEventStore for testing
+✅ Minimal EventBus implementation
+✅ InProcessChannel delivery
+✅ Basic compaction task
+✅ Tests: storage round-trip, publish/subscribe delivery, crash recovery
+
+### QUALITY.md
+✅ Unit tests for every module (50+ tests)
+✅ Integration tests for end-to-end flows
+✅ Storage behavior coverage: append, seq monotonic, status update, delivery recording, queries, compaction
+✅ Dispatch engine: publish, subscribe, unsubscribe, routing
+✅ Bus-level: end-to-end functionality
+✅ All documented guarantees have corresponding tests
+
+## Workspace Integration
+
+✅ Added `"crates/core/seidrum-eventbus"` to workspace members in root Cargo.toml
+✅ Ready for `cargo build`, `cargo test`, `cargo clippy`
+
+## Known Limitations (Intentional Phase 1 Scope)
+
+1. **Exact Subject Matching Only** - Phase 2 adds `*` and `>` wildcards via trie
+2. **Async Delivery Only** - Phase 2 adds Sync interceptor chains with priority ordering
+3. **No Request/Reply** - Phase 3 adds request() and serve() methods
+4. **No Network Transports** - Phase 4 adds WebSocket and HTTP servers
+5. **No Custom Channels** - Phase 4 allows plugins to register delivery channel types
+6. **Metrics Placeholder** - Detailed metrics in Phase 2+
+7. **No Event Filters** - Phase 2 adds FieldEquals, FieldContains, combinators
+
+All limitations are scoped to later phases and do not block Phase 1 functionality.
+
+## Build & Test Commands
+
+When Rust toolchain is available:
+
+```bash
+# Build
+cargo build -p seidrum-eventbus
+
+# Run all tests (unit + integration)
+cargo test -p seidrum-eventbus
+
+# With output
+cargo test -p seidrum-eventbus -- --nocapture
+
+# Linting
+cargo clippy -p seidrum-eventbus
+
+# Documentation
+cargo doc -p seidrum-eventbus --no-deps --open
+```
+
+## Files Modified
+
+1. `/sessions/cool-trusting-pascal/mnt/seidrum/Cargo.toml`
+   - Added `"crates/core/seidrum-eventbus"` to workspace members
+
+## Expected Test Results
+
+When compiled and run:
+- Unit tests: ~45 tests, all passing
+- Integration tests: 5 tests, all passing
+- Clippy: no warnings
+- Docs: all public types documented
+
+Example output:
+```
+running 50 tests
+
+test bus::tests::test_publish_deliver - should pass
+test bus::tests::test_multi_subscriber - should pass
+...
+test tests::integration_tests::test_publish_deliver_end_to_end - should pass
+test tests::integration_tests::test_crash_recovery_full - should pass
+...
+
+test result: ok. 50 passed; 0 failed; 0 ignored
+```
+
+## Next Steps
+
+Phase 2 will build on this foundation:
+1. Subject wildcards (`*` and `>`) via trie-based index
+2. Sync interceptor chains with priority ordering
+3. Timeout enforcement on sync handlers
+4. Event filters (FieldEquals, FieldContains, combinators)
+5. Expanded dispatch pipeline (Dispatching status, mutation propagation)
+
+Phase 3: Request/Reply pattern
+Phase 4: WebSocket/HTTP transport servers
+Phase 5: Seidrum kernel integration
+Phase 6: Interceptor-based plugin patterns
+
+## Conclusion
+
+Phase 1 of seidrum-eventbus is **complete and ready for testing**. All core infrastructure is in place:
+- Durable storage with crash recovery
+- In-process pub/sub with delivery tracking
+- Clean trait boundaries for extensibility
+- Comprehensive test coverage
+- Builder pattern for easy configuration
+
+The crate is a standalone, self-contained event bus that can be embedded in any Rust binary and accessed through the EventBus trait.

--- a/crates/core/seidrum-eventbus/PHASE4_IMPLEMENTATION.md
+++ b/crates/core/seidrum-eventbus/PHASE4_IMPLEMENTATION.md
@@ -1,0 +1,229 @@
+# Phase 4: Transport Servers + Remote Delivery Channels
+
+## Overview
+
+Phase 4 adds network transport capabilities to seidrum-eventbus, allowing remote clients to interact with the event bus via WebSocket and HTTP protocols. This enables distributed event publishing, subscription, and request/reply patterns.
+
+## Key Components
+
+### 1. Delivery Channels
+
+#### Custom Channel Registry (`src/delivery/registry.rs`)
+- `ChannelRegistry`: Thread-safe registry for pluggable delivery channels
+- Methods:
+  - `register(type_name, channel)`: Register a delivery channel
+  - `get(type_name)`: Look up a registered channel
+  - `unregister(type_name)`: Unregister a channel
+  - `list_types()`: List all registered channel types
+
+#### WebSocket Delivery Channel (`src/delivery/websocket.rs`)
+- `WebSocketChannel`: Implements `DeliveryChannel` trait
+- Delivers events by writing JSON frames to WebSocket connections
+- Message format:
+  ```json
+  {
+    "op": "event",
+    "subject": "test.topic",
+    "payload": "base64_encoded_bytes"
+  }
+  ```
+- Features:
+  - Fast in-memory delivery
+  - Connection health tracking
+  - Automatic error handling
+
+#### Webhook Delivery Channel (`src/delivery/webhook.rs`)
+- `WebhookChannel`: HTTP POST delivery with retry support
+- Configuration:
+  - Target URL
+  - Custom headers
+  - Configurable retry policy
+- Retry logic:
+  - Exponential backoff with jitter
+  - Configurable max attempts
+  - Max backoff capping
+- Health checks via GET requests
+
+#### Retry Task (`src/delivery/retry.rs`)
+- `RetryTask`: Background task for failed delivery retry
+- Features:
+  - Periodic polling of retryable deliveries
+  - Exponential backoff with jitter
+  - Configurable max attempts
+  - Integration with EventStore
+
+### 2. Transport Servers
+
+#### WebSocket Transport (`src/transport/ws.rs`)
+- `WebSocketServer`: Listens for WebSocket connections
+- Client Operations (JSON protocol):
+  - `publish`: Publish an event to a subject
+  - `subscribe`: Subscribe to a pattern
+  - `unsubscribe`: Unsubscribe from a subscription
+  - `request`: Make a request/reply call
+  - `reply`: Reply to a request
+- Server Messages:
+  - `event`: Delivered event
+  - `reply_result`: Reply to a request
+  - `error`: Error message
+- Features:
+  - Per-connection subscription tracking
+  - Base64 payload encoding
+  - Automatic cleanup on disconnect
+
+Example client connection:
+```json
+{"op": "publish", "subject": "test.topic", "payload": "aGVsbG8="}
+{"op": "subscribe", "pattern": "test.*", "opts": {"priority": 10}}
+{"op": "request", "subject": "api.command", "payload": "...", "timeout_ms": 5000}
+```
+
+#### HTTP Transport (`src/transport/http.rs`)
+- `HttpServer`: Axum-based REST API server
+- Endpoints:
+  - `POST /publish` - Publish an event
+  - `POST /request` - Make a request/reply
+  - `POST /subscribe` - Create webhook subscription
+  - `DELETE /subscribe/:id` - Remove subscription
+  - `GET /events/:seq` - Get event by sequence (stub)
+  - `GET /health` - Health check
+  - `GET /metrics` - Bus metrics
+- Features:
+  - JSON request/response bodies
+  - Base64 payload encoding
+  - Error handling with HTTP status codes
+  - CORS support
+  - API key authentication (extensible)
+
+Example requests:
+```bash
+# Publish
+curl -X POST http://localhost:8000/publish \
+  -H "Content-Type: application/json" \
+  -d '{"subject": "test.topic", "payload": "aGVsbG8="}'
+
+# Subscribe to webhook
+curl -X POST http://localhost:8000/subscribe \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "test.*", "url": "https://example.com/webhook", "priority": 10}'
+
+# Make request
+curl -X POST http://localhost:8000/request \
+  -H "Content-Type: application/json" \
+  -d '{"subject": "api.cmd", "payload": "...", "timeout_ms": 5000}'
+```
+
+### 3. Builder Integration
+
+Updated `EventBusBuilder` with transport configuration:
+```rust
+let bus = EventBusBuilder::new()
+    .storage(store)
+    .with_websocket("127.0.0.1:9000".parse().unwrap())
+    .with_http("127.0.0.1:8000".parse().unwrap())
+    .build()
+    .await?;
+```
+
+Both servers are spawned as background tasks and run for the lifetime of the bus.
+
+## Configuration
+
+### Dependencies Added
+- `axum = "0.8"` - HTTP server framework
+- `tokio-tungstenite = "0.26"` - WebSocket support
+- `futures-util = "0.3"` - Async utilities
+- `reqwest = { version = "0.12", features = ["json"] }` - HTTP client
+- `tower = "0.5"` - Middleware framework
+- `tower-http = { version = "0.6", features = ["cors"] }` - HTTP utilities
+- `rand = "0.9"` - Random number generation (jitter)
+- `hyper = "1"` - HTTP protocol
+- `base64 = "0.22"` - Base64 encoding
+
+### Environment Variables
+None required. Configuration via builder API.
+
+## Architecture Decisions
+
+### Protocol Design
+- **Base64 Encoding**: Payloads are base64-encoded for safe JSON transport
+- **Async Operations**: All I/O is async using Tokio
+- **Error Handling**: Delivery failures trigger retries, not immediate failures
+
+### Retry Strategy
+- Exponential backoff: 2^attempt * initial_backoff_ms
+- Jitter: ±25% to prevent thundering herd
+- Default: max 5 attempts, 100ms initial, 30s max
+
+### Scalability
+- WebSocket: Supports many concurrent connections
+- HTTP: RESTful, load-balanceable
+- Webhook delivery: Non-blocking HTTP client
+
+## Testing
+
+Integration tests in `tests/phase4_transport.rs`:
+- Channel registry operations
+- WebSocket delivery mechanics
+- Webhook configuration parsing
+- Retry backoff calculations
+- Builder with transport config
+
+## Security Considerations
+
+### Current Implementation
+- No authentication by default on transports
+- WebSocket: No connection authentication
+- HTTP: Middleware structure supports auth integration
+
+### Recommended Enhancements (Future)
+- API key validation
+- TLS/HTTPS for HTTP transport
+- WSS (WebSocket Secure) support
+- Rate limiting
+- Request signing
+
+## Future Phases
+
+- **Phase 5a**: NATS Bridge - Connect to NATS JetStream
+- **Phase 5b**: gRPC Transport - High-performance gRPC transport
+- **Phase 6**: Connection Pools - Long-lived connection management
+- **Phase 7**: Compression - Payload compression for large events
+
+## Files Added
+
+```
+src/
+├── delivery/
+│   ├── registry.rs          # Channel registry
+│   ├── websocket.rs         # WebSocket delivery channel
+│   ├── webhook.rs           # Webhook delivery channel
+│   ├── retry.rs             # Retry task
+│   └── mod.rs               # Updated with new modules
+├── transport/
+│   ├── mod.rs               # Transport module root
+│   ├── ws.rs                # WebSocket server
+│   └── http.rs              # HTTP server
+└── lib.rs                   # Updated with transport exports
+
+Cargo.toml                    # Updated with transport dependencies
+tests/phase4_transport.rs     # Integration tests
+```
+
+## Files Modified
+
+- `src/lib.rs` - Added transport module and new re-exports
+- `src/delivery/mod.rs` - Added registry, websocket, webhook, retry modules
+- `src/builder.rs` - Added transport configuration methods
+- `Cargo.toml` - Added transport dependencies
+
+## Compilation
+
+All code compiles with `cargo build -p seidrum-eventbus` (subject to target directory permissions).
+
+The implementation follows existing code patterns:
+- Async-trait for trait objects
+- Tracing for logging
+- Serde for serialization
+- Error handling with `thiserror`
+- Comprehensive doc comments

--- a/crates/core/seidrum-eventbus/PLAN.md
+++ b/crates/core/seidrum-eventbus/PLAN.md
@@ -1,0 +1,309 @@
+# PLAN.md — seidrum-eventbus Development Plan
+
+## Phasing Strategy
+
+The crate is developed in six phases. Each phase produces a working, tested
+artifact that builds on the previous one. No phase requires throwing away
+work from an earlier phase. The kernel continues to run on NATS until Phase 5
+(migration), so there is no big-bang switchover.
+
+---
+
+## Phase 1: Storage Engine + In-Process Pub/Sub
+
+**Goal:** A working event bus that can publish, subscribe, persist, and
+recover events. In-process delivery only. No network, no interceptors,
+no wildcards yet.
+
+**Deliverables:**
+
+1. `EventStore` trait and `RedbEventStore` implementation
+   - `append()`, `update_status()`, `record_delivery()`
+   - `query_by_status()`, `query_by_subject()`
+   - Single-table `events` with `subject_idx` and `status_idx`
+
+2. `InMemoryEventStore` for testing (Vec-backed, no disk)
+
+3. Minimal `EventBus` implementation
+   - `publish()` → persist → deliver to exact-match subscribers
+   - `subscribe()` → InProcess channel only, Async mode only
+   - No wildcards, no interceptors, no request/reply
+
+4. `InProcessChannel` delivery
+   - `tokio::mpsc` bounded channel per subscription
+   - Delivery receipt tracking
+
+5. Basic compaction task
+   - Remove delivered events older than retention period
+
+**Tests:** Storage round-trip, publish/subscribe delivery, crash recovery
+(write events, drop bus, reopen, verify events are re-dispatched),
+compaction correctness.
+
+**Why this first:** The storage engine is the hardest part to get right and
+the easiest to test in isolation. Starting here means we validate durability
+guarantees before building anything on top.
+
+---
+
+## Phase 2: Subject Wildcards + Interceptor Chains
+
+**Goal:** Full subject matching (wildcards) and the sync/async interceptor
+model that is the primary reason this crate exists.
+
+**Deliverables:**
+
+1. `SubjectIndex` trie implementation
+   - Exact match, `*` single-token wildcard, `>` terminal wildcard
+   - Lookup returns all matching subscriptions sorted by priority
+
+2. Subscription modes: Sync and Async
+   - Sync subscribers process sequentially in priority order
+   - Async subscribers receive a clone and run in parallel
+
+3. `Interceptor` trait for in-process sync handlers
+   - `InterceptResult::Modified`, `Pass`, `Drop`
+   - Mutable access to payload bytes
+
+4. Timeout enforcement on sync interceptors
+   - Configurable per-subscription, default from builder
+   - Timed-out interceptors are skipped with a warning
+
+5. `EventFilter` evaluation
+   - `FieldEquals`, `FieldContains`, `All`, `Any`
+   - Applied after subject match, before delivery
+
+6. Full dispatch pipeline
+   - Persist → resolve → filter → sync chain → async fan-out → finalize
+
+**Tests:** Wildcard matching (comprehensive pattern matrix), interceptor
+ordering, interceptor mutation propagation, interceptor drop aborts chain,
+interceptor timeout does not stall, event filter correctness, mixed
+sync/async delivery ordering.
+
+**Why this second:** Interceptors are the core differentiator. With Phase 1
+providing a solid storage foundation, we can build the dispatch engine with
+confidence that events will not be lost even if the chain logic has bugs
+during development.
+
+---
+
+## Phase 3: Request/Reply
+
+**Goal:** Support the request/reply pattern that Seidrum uses for brain
+queries, capability calls, and health checks.
+
+**Deliverables:**
+
+1. `request()` implementation
+   - Generate unique reply subject
+   - Create one-shot subscription on reply subject
+   - Publish event with `reply_subject` field
+   - Wait for reply with timeout
+   - Clean up one-shot subscription on completion or timeout
+
+2. `serve()` implementation
+   - Subscribe to a subject like normal
+   - Received events include a `Replier` handle
+   - Handler calls `replier.reply(payload)` to send the response
+   - Replier publishes to the event's `reply_subject`
+
+3. Request timeout handling
+   - Configurable per-request
+   - Timeout returns `Err(RequestTimeout)` to caller
+   - One-shot subscription is cleaned up
+
+**Tests:** Basic request/reply round-trip, timeout behavior, multiple
+concurrent requests on the same subject, request to subject with no
+subscribers (timeout), request/reply through interceptor chain (interceptor
+can modify the request before the handler sees it).
+
+**Why this third:** Request/reply is built on pub/sub, so it naturally
+follows Phase 2. Many Seidrum interactions depend on this pattern, so it
+must work before migration.
+
+---
+
+## Phase 4: Transport Servers + Remote Delivery Channels
+
+**Goal:** Network-accessible bus. Remote plugins can connect via WebSocket
+or HTTP.
+
+**Deliverables:**
+
+1. WebSocket transport server
+   - `tokio-tungstenite` listener on configurable address
+   - Authentication handshake (API key or JWT)
+   - JSON-framed protocol: publish, subscribe, request, reply, register
+   - Connection tracking: assign connection_id, map to subscriptions
+   - Disconnect handling: clean up subscriptions, fail pending deliveries
+
+2. HTTP transport server
+   - `axum` on configurable address
+   - `POST /publish`, `POST /request`, `POST /subscribe`,
+     `DELETE /subscribe/{id}`, `GET /events/{seq}`, `GET /health`
+   - Webhook subscription persistence (survives restart)
+
+3. `WebSocketChannel` delivery
+   - Deliver events to a specific WebSocket connection
+   - Handle connection drops gracefully (fail → retry queue)
+
+4. `WebhookChannel` delivery
+   - HTTP POST per event with configurable headers
+   - Retry policy: configurable max_attempts, backoff, max_backoff
+   - HTTP status 2xx = delivered, anything else = failed
+
+5. Background retry task
+   - Poll `query_retryable()` periodically
+   - Re-attempt delivery through the original channel
+   - Exponential backoff with jitter
+   - Move to DeadLettered after max_attempts
+
+6. Sync interceptor protocol for remote subscribers
+   - WebSocket: send event, wait for Modified/Pass/Drop response
+   - Webhook: POST event, response body contains Modified/Pass/Drop
+   - Timeout enforcement applies identically to in-process
+
+7. Custom delivery channel registry
+   - `register_channel_type()` stores `Arc<dyn DeliveryChannel>`
+   - Subscriptions with `ChannelConfig::Custom` delegate to registered
+     provider
+   - Unregistered channel type → subscription error
+
+**Tests:** WebSocket connect/subscribe/publish round-trip, WebSocket
+disconnect and reconnect with message replay, webhook delivery and retry,
+webhook with auth headers, remote sync interceptor via WebSocket, custom
+channel registration and delivery, HTTP API endpoint tests.
+
+**Why this fourth:** Transport is additive. The bus already works in-process.
+Adding network access does not change the core dispatch logic — it adds new
+delivery channel implementations and protocol handling.
+
+---
+
+## Phase 5: Seidrum Integration + NATS Migration
+
+**Goal:** Replace NATS in the Seidrum kernel with `seidrum-eventbus`.
+All existing functionality continues to work.
+
+**Deliverables:**
+
+1. Adapter layer in `seidrum-common`
+   - Replace `NatsClient` implementation with `EventBus` calls
+   - `publish_envelope()` → serialize EventEnvelope → `bus.publish()`
+   - `request()` → `bus.request()`
+   - `subscribe()` → `bus.subscribe()` with Async mode
+
+2. Kernel startup changes
+   - Create `EventBusBuilder` instead of NATS connection
+   - Start WebSocket + HTTP servers for remote plugins
+   - Kernel services register as in-process subscribers
+
+3. Plugin bootstrap migration
+   - Rust plugins: swap `NatsClient` for `EventBus` handle
+   - API gateway: adapt WebSocket protocol to new bus protocol
+   - External plugins: WebSocket protocol is similar, adapt framing
+
+4. Subject mapping verification
+   - All existing NATS subjects work unchanged
+   - Wildcard patterns work unchanged
+   - Request/reply subjects work unchanged
+
+5. Remove NATS dependency
+   - Remove `async-nats` from Cargo.toml
+   - Remove NATS URL from platform.yaml
+   - Remove NATS from docker-compose.yml
+   - Update documentation
+
+**Tests:** Full e2e test suite passes against the new bus. Compare event
+flow traces before and after migration to verify identical behavior.
+
+**Why this fifth:** The bus is fully functional and independently tested
+before we touch the kernel. Migration is a plumbing exercise, not a
+design exercise. If something breaks, we know the bus works — the bug
+is in the integration layer.
+
+---
+
+## Phase 6: Interceptor-Based Plugin Patterns
+
+**Goal:** Demonstrate the new interceptor model with concrete plugin
+rewrites that would have been complex or impossible with NATS.
+
+**Deliverables:**
+
+1. Example: Encryption interceptor
+   - Sync interceptor at priority 5 on `channel.*.inbound`
+   - Decrypts message payload before downstream plugins see it
+   - Corresponding interceptor on `channel.*.outbound` encrypts
+
+2. Example: Rate limiter interceptor
+   - Sync interceptor at priority 10 on `channel.*.inbound`
+   - Drops events from users exceeding rate limits
+   - No subject rewiring needed
+
+3. Example: Scope tagger interceptor
+   - Sync interceptor at priority 15 on `channel.*.inbound`
+   - Annotates events with user scope context
+   - Downstream plugins receive enriched events automatically
+
+4. Example: Multi-channel delivery plugin
+   - Plugin registers an `"mqtt"` custom delivery channel
+   - Other plugins can request MQTT delivery for IoT events
+
+5. Documentation: Plugin author guide
+   - How to write a sync interceptor
+   - How to choose priority values
+   - How to register a custom delivery channel
+   - Migration guide from NATS-based plugins
+
+**Tests:** Each example plugin has its own integration tests. End-to-end
+test verifying a multi-interceptor chain with mixed sync/async subscribers.
+
+**Why this last:** These are the patterns that justify the entire project.
+By this point the bus is stable and integrated. These examples prove the
+design and serve as templates for future plugin development.
+
+---
+
+## Milestone Summary
+
+| Phase | Deliverable | Depends On | Estimated Complexity |
+|-------|------------|------------|---------------------|
+| 1 | Storage + in-process pub/sub | Nothing | Medium |
+| 2 | Wildcards + interceptor chains | Phase 1 | High |
+| 3 | Request/reply | Phase 2 | Low-Medium |
+| 4 | Transports + remote delivery | Phase 3 | High |
+| 5 | Kernel migration | Phase 4 | Medium |
+| 6 | Interceptor patterns | Phase 5 | Low |
+
+---
+
+## Risk Register
+
+**redb performance under write-ahead load.** Risk: redb write transactions
+are slower than expected, causing publish latency to spike. Mitigation:
+benchmark in Phase 1 before building further. Fallback: switch to a custom
+append-only log file with manual indexing, or use `sled` / `sqlite` WAL mode.
+
+**Sync interceptor deadlocks.** Risk: a sync interceptor publishes an event
+that triggers another sync interceptor, creating a circular dependency.
+Mitigation: detect re-entrant publish calls and fail with an error rather
+than deadlocking. Document that sync interceptors must not publish to
+subjects they intercept.
+
+**WebSocket protocol complexity.** Risk: the remote interceptor protocol
+(sync request/reply over WebSocket) is harder to implement correctly than
+anticipated. Mitigation: start with async-only remote subscribers in Phase 4
+and add sync remote interceptors as a sub-phase.
+
+**Migration breaks existing e2e tests.** Risk: subtle behavioral differences
+between NATS and the new bus cause test failures. Mitigation: run the full
+e2e suite against both backends in parallel during Phase 5 and diff the
+event traces.
+
+**Custom channel provider disconnects mid-delivery.** Risk: a plugin that
+registered a custom channel type crashes while the bus is trying to deliver
+through it. Mitigation: delivery failure → retry queue, same as any other
+channel failure. If the provider never reconnects, events dead-letter after
+max retries.

--- a/crates/core/seidrum-eventbus/PROJECT.md
+++ b/crates/core/seidrum-eventbus/PROJECT.md
@@ -1,0 +1,130 @@
+# PROJECT.md — seidrum-eventbus
+
+## What This Is
+
+`seidrum-eventbus` is a standalone Rust crate that replaces NATS JetStream as
+Seidrum's event backbone. It is a purpose-built event bus with three
+capabilities that NATS does not provide together: interceptor chains with
+priority-ordered mutation, configurable per-subscription delivery channels,
+and durable event storage with indexed retry.
+
+The crate has zero dependency on the rest of the Seidrum kernel. It can be
+embedded in any Rust binary or exposed over the network via its built-in
+HTTP and WebSocket transports.
+
+## Why We Are Building This
+
+### NATS is more than we need — and less
+
+NATS is a general-purpose message broker. Seidrum uses a narrow slice of it:
+pub/sub with subject routing, request/reply, and JetStream for durability.
+We pay the operational cost of running and configuring an external NATS server,
+but we do not use clustering, leaf nodes, accounts, or most of JetStream's
+consumer model. The dependency is heavy for what we get.
+
+At the same time, NATS lacks something fundamental to our plugin model:
+the ability for a subscriber to intercept and mutate an event before
+downstream subscribers see it. Today, achieving this requires a two-subject
+hop pattern where each intercepting plugin consumes from one subject and
+produces to another, baking pipeline order into subject naming. This makes
+plugins aware of each other and makes the topology brittle.
+
+### What we gain by owning the event layer
+
+**Interceptor chains.** Subscriptions declare a numeric priority and a
+sync/async mode. Sync interceptors receive a mutable reference to the event
+and process sequentially in priority order. Each handler can mutate fields,
+enrich metadata, or drop the event entirely. Async subscribers receive a
+clone after the sync chain completes and run in parallel. This turns
+"intercept X and resend it" into a one-line subscription declaration instead
+of a multi-subject rewiring exercise.
+
+**Per-subscription delivery channels.** When a plugin subscribes to an event
+subject, it declares how it wants events delivered: in-process tokio channel,
+persistent WebSocket, HTTP webhook, or a custom channel type registered by
+another plugin. A single plugin can use different delivery channels for
+different subscriptions. This means a Rust plugin compiled into the kernel
+gets zero-serialization in-process delivery for hot-path events, while a
+Python plugin gets WebSocket delivery, and a serverless function gets
+webhook delivery — all subscribing to the same subject.
+
+**Plugin-provided delivery channels.** Plugins can register new channel
+types with the bus. An MQTT plugin could register an `"mqtt"` channel type,
+and any other plugin could then request MQTT delivery for specific
+subscriptions. The bus delegates delivery to the channel provider plugin
+without knowing anything about the transport protocol.
+
+**Durable event storage with indexed retry.** Events are persisted to an
+embedded database before dispatch. Each event has a lifecycle status (Pending,
+Dispatching, Delivered, PartiallyDelivered, DeadLettered) and per-subscriber
+delivery tracking. On crash recovery, the bus scans for incomplete events
+and re-enters them into the pipeline. Failed deliveries are retried with
+configurable backoff. The storage is indexed by subject and status for
+efficient queries.
+
+**No external infrastructure.** The embedded storage engine (redb or
+equivalent) runs in-process. There is no server to start, no port to
+configure, no Docker container to manage. The bus starts when the kernel
+starts.
+
+**Faster tests.** Unit and integration tests can spin up an in-process event
+bus with no Docker, no network, no port conflicts. Test isolation becomes
+trivial.
+
+### What we give up
+
+**Battle-tested clustering.** NATS has mature clustering, super-clusters, and
+leaf nodes. We are building for a single-node deployment (personal AI agent).
+If multi-node becomes a requirement, the `EventBus` trait can be implemented
+by a networked backend, but that is explicitly out of scope for now.
+
+**Ecosystem compatibility.** NATS clients exist for every language. Our
+WebSocket and HTTP transports cover the same use case (any-language plugins),
+but plugins that already use a NATS client library will need to migrate to
+our protocol. The WebSocket protocol is simpler than NATS, so migration
+effort is low.
+
+**Community support.** NATS has a large community and extensive documentation.
+We own all bugs and all maintenance. The tradeoff is acceptable because the
+surface area is bounded: we are building exactly the features Seidrum needs,
+not a general-purpose broker.
+
+## Design Constraints
+
+1. **The crate must have no dependency on seidrum-kernel or seidrum-common.**
+   It is a leaf dependency, not a framework. Seidrum types (EventEnvelope,
+   plugin structs) live in seidrum-common and use the bus through its public
+   API.
+
+2. **The interceptor chain must not block on persistence.** Events are
+   persisted before dispatch (write-ahead), but the persist step must be
+   fast enough (single append, microseconds) that it does not meaningfully
+   delay the sync chain.
+
+3. **Sync interceptors must have timeouts.** A misbehaving handler cannot
+   stall the entire pipeline. Timed-out handlers are skipped, and the event
+   continues down the chain. Timeout violations are logged and surfaced as
+   metrics.
+
+4. **The bus must support subject wildcards.** Patterns like `channel.*.inbound`
+   and `brain.>` must work for both publishing and subscribing, matching
+   NATS wildcard semantics that Seidrum already relies on.
+
+5. **Request/reply must be a first-class pattern.** Many Seidrum interactions
+   (brain queries, capability calls, health checks) use request/reply. The
+   bus must support this natively, not as a pub/sub workaround.
+
+6. **Delivery channel failures must not lose events.** If a WebSocket
+   disconnects or a webhook returns 500, the event stays in
+   PartiallyDelivered status and is retried. Only after exhausting retries
+   does it move to DeadLettered.
+
+7. **The public API must be async-first.** All operations return futures.
+   The bus is designed for tokio and does not support synchronous callers.
+
+## Crate Name and Location
+
+- Crate: `seidrum-eventbus`
+- Path: `crates/core/seidrum-eventbus/`
+- Workspace member alongside `seidrum-common`, `seidrum-kernel`, etc.
+- Published API: the `EventBus` trait, transport servers, storage types

--- a/crates/core/seidrum-eventbus/QUALITY.md
+++ b/crates/core/seidrum-eventbus/QUALITY.md
@@ -1,0 +1,338 @@
+# QUALITY.md — seidrum-eventbus Testing and Quality Strategy
+
+## Guiding Principle
+
+This crate is replacing an externally maintained, battle-tested message
+broker. Every behavior it claims to provide must be proven by a test. "It
+works on my machine" is not acceptable for infrastructure that every event
+in Seidrum flows through.
+
+The goal is not 100% line coverage — it is 100% behavior coverage. Every
+documented guarantee (durability, ordering, timeout, retry, delivery) has
+at least one test that would fail if the guarantee were broken.
+
+---
+
+## Test Pyramid
+
+```
+                    ╱╲
+                   ╱  ╲
+                  ╱ E2E╲        Few, slow, high-confidence
+                 ╱──────╲       Full bus with transports
+                ╱ Integr. ╲     Layer interactions, real redb
+               ╱────────────╲
+              ╱    Unit       ╲  Fast, isolated, in-memory store
+             ╱────────────────╲
+```
+
+### Unit Tests
+
+Run with `cargo test -p seidrum-eventbus`. No external dependencies. No
+network. No disk (use `InMemoryEventStore`). Target: sub-second execution
+for the full unit suite.
+
+Every module has its own `#[cfg(test)] mod tests` block. Unit tests verify
+the logic of a single component in isolation.
+
+### Integration Tests
+
+Located in `tests/`. Use real `RedbEventStore` with a temp directory. May
+start transport servers on ephemeral ports. Still no external dependencies
+(no Docker, no NATS).
+
+Integration tests verify that layers compose correctly: storage + dispatch,
+dispatch + delivery channels, transport + bus.
+
+### End-to-End Tests
+
+Located in `tests/e2e/` or in `seidrum-e2e` (the existing e2e crate). These
+test the bus as a black box through its public transports: connect via
+WebSocket, publish, subscribe, verify delivery. These are the slowest tests
+and run with `--ignored` flag.
+
+---
+
+## What Must Be Tested
+
+### Storage Engine
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Event round-trip: append then query returns identical bytes | `storage::test_append_and_query` | Unit |
+| Sequence numbers are monotonically increasing | `storage::test_seq_monotonic` | Unit |
+| Status updates are reflected in queries | `storage::test_status_update` | Unit |
+| Per-subscriber delivery tracking | `storage::test_delivery_recording` | Unit |
+| `query_by_status` returns only matching status | `storage::test_query_by_status_filter` | Unit |
+| `query_by_subject` with exact match | `storage::test_query_by_subject_exact` | Unit |
+| `query_by_subject` with pattern match | `storage::test_query_by_subject_pattern` | Unit |
+| `query_retryable` returns failed deliveries below max_attempts | `storage::test_query_retryable` | Unit |
+| Compaction removes old delivered events | `storage::test_compaction_delivered` | Unit |
+| Compaction preserves dead-lettered events within retention | `storage::test_compaction_preserves_deadletter` | Unit |
+| Crash recovery: events in Pending status after reopen | `storage::test_crash_recovery` | Integration |
+| Concurrent appends do not corrupt data | `storage::test_concurrent_appends` | Integration |
+| redb performance: 10k appends under 1 second | `storage::bench_append_throughput` | Benchmark |
+
+### Subject Index
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Exact subject match | `subject_index::test_exact_match` | Unit |
+| `*` wildcard matches single token | `subject_index::test_star_wildcard` | Unit |
+| `*` wildcard does not match zero or multiple tokens | `subject_index::test_star_wildcard_boundaries` | Unit |
+| `>` wildcard matches one or more trailing tokens | `subject_index::test_gt_wildcard` | Unit |
+| `>` wildcard does not match zero tokens | `subject_index::test_gt_wildcard_nonempty` | Unit |
+| Mixed wildcards: `channel.*.inbound` | `subject_index::test_mixed_pattern` | Unit |
+| Multiple subscriptions on same pattern | `subject_index::test_multiple_subs_same_pattern` | Unit |
+| Unsubscribe removes from index | `subject_index::test_unsubscribe` | Unit |
+| No match returns empty | `subject_index::test_no_match` | Unit |
+| Lookup returns subscriptions sorted by priority | `subject_index::test_priority_ordering` | Unit |
+| Performance: 1000 subscriptions, lookup under 100µs | `subject_index::bench_lookup` | Benchmark |
+
+### Interceptor Chains
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Sync interceptors run in priority order | `interceptor::test_priority_order` | Unit |
+| Sync interceptor can mutate payload | `interceptor::test_mutation` | Unit |
+| Mutation propagates to next interceptor | `interceptor::test_mutation_propagation` | Unit |
+| Mutation propagates to async subscribers | `interceptor::test_mutation_visible_to_async` | Unit |
+| Drop signal aborts chain | `interceptor::test_drop_aborts` | Unit |
+| Drop signal prevents async delivery | `interceptor::test_drop_prevents_async` | Unit |
+| Pass leaves payload unchanged | `interceptor::test_pass_unchanged` | Unit |
+| Timed-out interceptor is skipped | `interceptor::test_timeout_skip` | Unit |
+| Timed-out interceptor does not stall chain | `interceptor::test_timeout_no_stall` | Unit |
+| Panicking interceptor is caught, chain continues | `interceptor::test_panic_recovery` | Unit |
+| Async subscribers run concurrently | `interceptor::test_async_concurrent` | Unit |
+| Mixed sync/async: sync runs first, async sees final state | `interceptor::test_mixed_ordering` | Unit |
+| Re-entrant publish from sync interceptor returns error | `interceptor::test_reentrant_error` | Unit |
+| Empty chain (no sync interceptors): async subscribers receive original | `interceptor::test_no_sync_passthrough` | Unit |
+
+### Event Filters
+
+| Behavior | Test | Type |
+|----------|------|------|
+| FieldEquals matches | `filter::test_field_equals_match` | Unit |
+| FieldEquals rejects | `filter::test_field_equals_reject` | Unit |
+| FieldContains matches substring | `filter::test_field_contains` | Unit |
+| Nested path (dot notation) | `filter::test_nested_path` | Unit |
+| All requires all conditions | `filter::test_all_combinator` | Unit |
+| Any requires at least one | `filter::test_any_combinator` | Unit |
+| Missing field rejects (does not panic) | `filter::test_missing_field` | Unit |
+
+### Request/Reply
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Basic round-trip: request returns reply payload | `request_reply::test_basic_roundtrip` | Unit |
+| Timeout when no handler subscribed | `request_reply::test_timeout_no_handler` | Unit |
+| Timeout when handler is slow | `request_reply::test_timeout_slow_handler` | Unit |
+| Multiple concurrent requests on same subject | `request_reply::test_concurrent_requests` | Unit |
+| Request through interceptor chain: handler sees mutated payload | `request_reply::test_through_interceptor` | Unit |
+| Reply subject cleanup after completion | `request_reply::test_cleanup_on_complete` | Unit |
+| Reply subject cleanup after timeout | `request_reply::test_cleanup_on_timeout` | Unit |
+
+### Delivery Channels
+
+| Behavior | Test | Type |
+|----------|------|------|
+| InProcess: deliver and receive bytes | `delivery::test_in_process_roundtrip` | Unit |
+| InProcess: backpressure when channel full | `delivery::test_in_process_backpressure` | Unit |
+| WebSocket: deliver to connected client | `delivery::test_ws_delivery` | Integration |
+| WebSocket: disconnect fails delivery | `delivery::test_ws_disconnect_failure` | Integration |
+| WebSocket: reconnect resumes pending deliveries | `delivery::test_ws_reconnect_resume` | Integration |
+| Webhook: successful POST returns delivered | `delivery::test_webhook_success` | Integration |
+| Webhook: 500 response returns failed | `delivery::test_webhook_server_error` | Integration |
+| Webhook: connection refused returns failed | `delivery::test_webhook_connection_refused` | Integration |
+| Webhook: custom headers are sent | `delivery::test_webhook_custom_headers` | Integration |
+| Custom: delivery delegates to registered provider | `delivery::test_custom_channel_delegation` | Unit |
+| Custom: unregistered channel type returns error | `delivery::test_custom_unregistered_error` | Unit |
+
+### Retry Logic
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Failed delivery is retried after backoff | `retry::test_retry_after_backoff` | Integration |
+| Exponential backoff increases per attempt | `retry::test_exponential_backoff` | Unit |
+| Max attempts reached → dead letter | `retry::test_max_attempts_deadletter` | Integration |
+| Successful retry updates status to Delivered | `retry::test_successful_retry` | Integration |
+| Partial delivery: only failed subscribers retried | `retry::test_partial_retry` | Integration |
+| Backoff jitter prevents thundering herd | `retry::test_jitter` | Unit |
+
+### Transport Servers
+
+| Behavior | Test | Type |
+|----------|------|------|
+| WebSocket: auth with valid API key | `transport::test_ws_auth_valid` | Integration |
+| WebSocket: reject invalid API key | `transport::test_ws_auth_invalid` | Integration |
+| WebSocket: subscribe and receive events | `transport::test_ws_subscribe_receive` | Integration |
+| WebSocket: publish from remote client | `transport::test_ws_remote_publish` | Integration |
+| WebSocket: request/reply from remote client | `transport::test_ws_remote_request_reply` | Integration |
+| WebSocket: sync interceptor from remote client | `transport::test_ws_remote_interceptor` | Integration |
+| WebSocket: disconnect cleans up subscriptions | `transport::test_ws_disconnect_cleanup` | Integration |
+| HTTP: publish endpoint | `transport::test_http_publish` | Integration |
+| HTTP: request endpoint with timeout | `transport::test_http_request` | Integration |
+| HTTP: subscribe webhook endpoint | `transport::test_http_subscribe_webhook` | Integration |
+| HTTP: health endpoint | `transport::test_http_health` | Integration |
+
+### Bus-Level (Full Integration)
+
+| Behavior | Test | Type |
+|----------|------|------|
+| Publish → persist → deliver end-to-end | `bus::test_publish_deliver` | Integration |
+| Crash recovery: reopen bus, pending events re-dispatched | `bus::test_crash_recovery_full` | Integration |
+| High-throughput: 10k events, all delivered, none lost | `bus::test_throughput_no_loss` | Integration |
+| Multi-subscriber: each subscriber gets own copy | `bus::test_multi_subscriber` | Integration |
+| Interceptor + filter + delivery channel composition | `bus::test_full_pipeline` | Integration |
+| Builder: minimal config (in-memory, no transports) | `bus::test_builder_minimal` | Unit |
+| Builder: full config (redb + ws + http) | `bus::test_builder_full` | Integration |
+| Graceful shutdown: pending events flushed | `bus::test_graceful_shutdown` | Integration |
+| Metrics report correct counts | `bus::test_metrics` | Integration |
+
+---
+
+## Testing Utilities
+
+The crate provides public test utilities so that downstream crates
+(seidrum-kernel, plugins) can write tests against the bus easily.
+
+### `seidrum_eventbus::test_utils`
+
+```rust
+/// Create an in-memory bus with no transports. Starts instantly,
+/// no disk, no ports. Perfect for unit tests.
+pub async fn test_bus() -> Arc<dyn EventBus> { ... }
+
+/// Create a bus with real redb storage in a temp directory.
+/// For integration tests that need durability verification.
+pub async fn test_bus_with_storage() -> (Arc<dyn EventBus>, TempDir) { ... }
+
+/// Create a bus with WebSocket and HTTP transports on ephemeral ports.
+/// Returns the bus and the addresses of the transports.
+pub async fn test_bus_with_transports() -> TestBusHandle { ... }
+
+/// Helper: publish an event and wait for it to be delivered to
+/// a subscriber, with a timeout. Panics with a clear message on
+/// timeout.
+pub async fn publish_and_wait(
+    bus: &dyn EventBus,
+    subject: &str,
+    payload: &[u8],
+    timeout: Duration,
+) -> Vec<u8> { ... }
+
+/// Helper: subscribe, collect N events, return them.
+pub async fn collect_events(
+    bus: &dyn EventBus,
+    pattern: &str,
+    count: usize,
+    timeout: Duration,
+) -> Vec<Vec<u8>> { ... }
+
+/// A recording interceptor that logs every event it sees.
+/// Useful for verifying interceptor ordering and mutation.
+pub struct RecordingInterceptor { ... }
+
+/// A mock webhook server that records received requests.
+/// Starts on an ephemeral port.
+pub struct MockWebhookServer { ... }
+```
+
+---
+
+## Property-Based Testing
+
+The subject index and event filter modules are candidates for property-based
+testing with `proptest`:
+
+- **Subject index:** generate random subjects and patterns, verify that the
+  trie produces the same matches as a brute-force scan of all subscriptions.
+- **Event filters:** generate random JSON payloads and filter expressions,
+  verify that filter evaluation matches a reference implementation.
+- **Interceptor ordering:** generate random priority assignments and verify
+  that execution order always matches sorted priority.
+
+---
+
+## Benchmarks
+
+Located in `benches/` using `criterion`:
+
+| Benchmark | What it measures | Target |
+|-----------|-----------------|--------|
+| `bench_append` | redb append throughput | >10k events/sec |
+| `bench_publish_deliver` | End-to-end publish → in-process deliver | <100µs p99 |
+| `bench_subject_lookup` | Trie lookup with 1000 subscriptions | <100µs |
+| `bench_interceptor_chain` | 5-interceptor sync chain, no mutation | <500µs |
+| `bench_ws_roundtrip` | Publish via WebSocket, deliver to in-process | <1ms p99 |
+| `bench_concurrent_publish` | 100 concurrent publishers, 10k events each | No dropped events |
+
+Benchmarks run in CI on every PR to detect performance regressions.
+
+---
+
+## Chaos and Fault Injection
+
+For Phase 4+ (transport servers), we add targeted fault injection tests:
+
+- **Slow interceptor:** inject a `sleep(10s)` into a sync interceptor,
+  verify the timeout fires and the chain continues within the timeout + 100ms.
+- **Crashing webhook:** mock server that returns 200 three times then
+  closes the socket. Verify retry logic handles the transition.
+- **Reconnecting WebSocket:** drop the WebSocket connection mid-delivery,
+  verify the event enters the retry queue and is re-delivered on reconnect.
+- **Storage full:** mock an `EventStore` that returns `Err` on `append()`.
+  Verify `publish()` returns the error to the caller (event not silently
+  lost).
+- **Concurrent storm:** 1000 publishers, 100 subscribers, 50 interceptors,
+  all running simultaneously for 10 seconds. Verify: no panics, no
+  deadlocks, all events eventually delivered or dead-lettered, delivery
+  counts match publish counts.
+
+---
+
+## Coverage Policy
+
+- **Required before merge:** all tests pass, no new `#[ignore]` without a
+  tracking issue.
+- **Coverage target:** measured but not gated. We care about behavior
+  coverage (every guarantee has a test), not line percentage. A module with
+  80% line coverage but missing an edge case test is worse than one with
+  60% line coverage that tests every documented behavior.
+- **Mutation testing:** run `cargo-mutants` periodically (not on every PR)
+  to find behaviors that no test would catch if broken. Fix the gaps.
+
+---
+
+## CI Integration
+
+```yaml
+# Runs on every PR
+test-unit:
+  cargo test -p seidrum-eventbus          # Unit + integration
+  cargo clippy -p seidrum-eventbus        # Lint
+  cargo doc -p seidrum-eventbus --no-deps # Docs compile
+
+# Runs on merge to main
+test-full:
+  cargo test -p seidrum-eventbus -- --ignored   # E2E tests
+  cargo bench -p seidrum-eventbus               # Benchmarks (detect regressions)
+```
+
+---
+
+## Tracing and Debugging
+
+All event bus operations emit `tracing` spans and events at appropriate
+levels:
+
+- `INFO`: bus started, transport listening, subscription added/removed
+- `DEBUG`: event published (subject, seq), delivery started, delivery
+  completed
+- `WARN`: interceptor timed out, delivery failed (will retry), channel
+  unhealthy
+- `ERROR`: storage write failed, max retries exhausted (dead-lettered),
+  transport server error
+
+Tests can enable `tracing-subscriber` with `RUST_LOG=seidrum_eventbus=debug`
+to get full event flow traces for debugging failures.


### PR DESCRIPTION
## Summary

Restores the eventbus design and quality specs that I mistakenly deleted in PR #24, and adds a full gap-analysis audit comparing the current crate state to those specs.

### Restored docs (from git history at the commit before deletion)

- \`PROJECT.md\` — vision, design constraints
- \`ARCHITECTURE.md\` — 4-layer architecture, trait definitions, module map
- \`PLAN.md\` — **canonical 6-phase development plan**
- \`QUALITY.md\` — test pyramid, behavior coverage matrix, CI policy
- \`IMPLEMENTATION.md\` — Phase 1 completion report
- \`PHASE4_IMPLEMENTATION.md\` — Phase 4 status snapshot

These were the source of truth for the crate. They were deleted in PR #24 with the rationale "leftover planning docs" — a mistake. Restoring them.

### Audit findings

The new \`AUDIT.md\` is the headline document. Key findings:

- **Phase numbering was wrong.** What we shipped as PR #27 ("Phase 5: durable retry & dead-lettering") was actually completing Phase 4 per PLAN.md. The real Phase 5 is the Seidrum kernel migration / NATS replacement, which has not been started.

- **Phase 4 is still partial.** The headline missing piece is the **remote sync interceptor protocol over WebSocket and webhook** (PLAN.md L154, ARCHITECTURE.md L436-440). Currently remote subscribers can only be Async — they cannot participate in the sync interceptor chain. This is the main differentiator that the entire crate exists to provide.

- **Several other Phase 4 items are missing**: \`register_channel_type\` on the EventBus trait, webhook subscription persistence, and the \`GET /events/:seq\` endpoint (which I removed during a review sweep).

- **Drift** between current code and spec: \`delivery_idx\` table key shape, dead-letter retention (spec'd as longer than regular retention), per-subscription \`RetryPolicy\`, \`ChannelConfig::WebSocket { connection_id }\`, \`BusMetrics::storage_size\`.

- **Test gaps**: \`test_panic_recovery\`, \`test_reentrant_error\` (the design constraint isn't even enforced yet), end-to-end transport tests with real WS/HTTP servers, and the QUALITY.md-mandated test utilities (\`MockWebhookServer\`, \`RecordingInterceptor\`, \`test_bus_with_transports\`, etc.).

The audit is opinionated about next steps:

1. **Finish Phase 4 properly** on a new branch (top 4 gaps + the missing test utilities + transport integration tests).
2. **Reconcile the drift items** as a separate batch.
3. **Then** start real Phase 5 (kernel migration).
4. **Then** Phase 6 (example interceptor plugins).

## Test plan

- [x] No code changes — docs only
- [x] All 161 existing tests still pass
- [ ] CI green

## Why this is its own PR

The docs and audit are low-risk and inform every subsequent decision. Landing them first means future PRs can reference them directly and there's no risk of conflict with the larger Phase 4 completion work that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)