### PR TITLE
feat: Phase 5 — replace NATS with seidrum-eventbus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Seidrum is an event-driven personal AI agent platform. Rust kernel + NATS JetStream + ArangoDB knowledge graph + plugin architecture. Everything is a plugin — independent processes that connect via NATS, declare consumed/produced event types, and self-wire.
+Seidrum is an event-driven personal AI agent platform. Rust kernel + seidrum-eventbus + ArangoDB knowledge graph + plugin architecture. Everything is a plugin — independent processes that connect via the eventbus (WebSocket), declare consumed/produced event types, and self-wire.
 
 ## Build Commands
 
@@ -73,7 +73,7 @@ Plugins never access ArangoDB directly — all brain operations go through bus r
 ### Configuration Files
 
 - `.env`: Secrets (API keys, tokens, passwords)
-- `config/platform.yaml`: Kernel config (NATS URL, ArangoDB connection, directories)
+- `config/platform.yaml`: Kernel config (eventbus URL, ArangoDB connection, directories)
 - `agents/*.yaml`: Agent definitions (prompt, tools, scope)
 - `workflows/*.yaml`: Workflow definitions (trigger, steps, routing)
 - `prompts/*.md`: Tera-templated system prompts
@@ -81,8 +81,8 @@ Plugins never access ArangoDB directly — all brain operations go through bus r
 
 ### Infrastructure
 
-- `docker-compose.yml`: Full stack (NATS + ArangoDB + kernel + all plugins)
-- `docker-compose.test.yml`: Minimal (NATS + ArangoDB only, for e2e tests)
+- `docker-compose.yml`: Full stack (ArangoDB + kernel + all plugins)
+- `docker-compose.test.yml`: Minimal (ArangoDB + kernel, for e2e tests)
 
 ## Documentation
 
@@ -101,7 +101,7 @@ Design docs in `docs/` — read the relevant doc before implementing:
 - Use `tracing` for logging, never `println!` in library/service code
 - Error handling: `anyhow::Result` for binaries, `thiserror` for library errors
 - No `unwrap()` in production code — use proper error propagation
-- All brain access from plugins goes through NATS request/reply to kernel
+- All brain access from plugins goes through bus request/reply to kernel
 - Plugins register via `plugin.register` and deregister via `plugin.deregister`
 - Capabilities register via `capability.register` with kind `"tool"`, `"command"`, or `"both"`
 - Scope enforcement on every brain query — ScopeService filters by scope field

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,42 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-nats"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures",
- "memchr",
- "nkeys",
- "nuid",
- "once_cell",
- "pin-project",
- "portable-atomic",
- "rand 0.8.5",
- "regex",
- "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
- "rustls-webpki 0.102.8",
- "serde",
- "serde_json",
- "serde_nanos",
- "serde_repr",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tokio-websockets",
- "tracing",
- "tryhard",
- "url",
-]
-
-[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,9 +560,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2"
@@ -826,12 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,32 +937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,24 +998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -1215,28 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
- "signature",
- "subtle",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,12 +1251,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -2468,27 +2357,12 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nkeys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
-dependencies = [
- "data-encoding",
- "ed25519",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "log",
- "rand 0.8.5",
- "signatory",
 ]
 
 [[package]]
@@ -2517,15 +2391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nuid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -2679,12 +2544,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -2807,15 +2666,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2946,16 +2796,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -3375,7 +3215,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3555,34 +3395,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe 0.2.1",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3595,15 +3410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,17 +3417,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -3670,19 +3465,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
 
 [[package]]
 name = "security-framework"
@@ -3802,7 +3584,6 @@ name = "seidrum-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-nats",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -4029,6 +3810,7 @@ dependencies = [
  "http 1.4.0",
  "reqwest 0.12.28",
  "seidrum-common",
+ "seidrum-eventbus",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4290,15 +4072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_nanos"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,28 +4214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
-dependencies = [
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "zeroize",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4526,16 +4277,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -5075,27 +4816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-websockets"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-sink",
- "http 1.4.0",
- "httparse",
- "rand 0.8.5",
- "ring",
- "rustls-native-certs 0.8.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tokio-util",
-]
-
-[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,16 +4976,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tryhard"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
 
 [[package]]
 name = "tungstenite"

--- a/config/platform.yaml
+++ b/config/platform.yaml
@@ -1,6 +1,6 @@
 # Seidrum platform configuration
 
-nats_url: nats://localhost:4222
+eventbus_url: ws://localhost:9000
 arango_url: http://localhost:8529
 arango_database: seidrum
 agents_dir: agents/

--- a/crates/core/seidrum-common/Cargo.toml
+++ b/crates/core/seidrum-common/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 seidrum-eventbus = { path = "../seidrum-eventbus", features = ["test-utils"] }
 
 [dependencies]
-async-nats = "0.38"
 base64 = "0.22"
+seidrum-eventbus = { path = "../seidrum-eventbus" }
 bytes = "1"
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/core/seidrum-common/src/bus_client.rs
+++ b/crates/core/seidrum-common/src/bus_client.rs
@@ -1,86 +1,72 @@
 //! Backend-agnostic bus client used by every Seidrum plugin and kernel
 //! service.
 //!
-//! `BusClient` dispatches on the URL scheme at connect time:
-//! - `nats://` → wraps `async_nats::Client` (current production backend)
-//! - `ws://` or `wss://` → wraps [`crate::ws_client::WsClient`]
-//!   (eventbus WebSocket transport — Phase 5 migration target)
-//!
-//! All consumer-facing types ([`Subscription`], [`Message`], [`Subject`])
-//! are the same regardless of backend, so plugin source code does not
-//! change when the kernel switches from NATS to the eventbus.
-//!
-//! **Do not** add an `inner()` escape hatch. That kind of leak is
-//! exactly the technical debt the PR #30 rename was created to remove.
+//! `BusClient` supports two backends:
+//! - **In-process** (`BusClient::from_bus`) — wraps `Arc<dyn EventBus>`
+//!   directly. Used by the kernel so services talk to the bus without
+//!   a network round-trip.
+//! - **WebSocket** (`BusClient::connect("ws://...")`) — wraps
+//!   [`crate::ws_client::WsClient`]. Used by plugins running as
+//!   separate processes that connect to the kernel's WS transport.
 
 use anyhow::{Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, info};
 
 use crate::events::EventEnvelope;
 use crate::ws_client::{WsClient, WsMessage, WsSubject, WsSubscription};
 
 // === Consumer-facing type aliases ===
-//
-// These are now concrete types from ws_client, not async_nats aliases.
-// Both backends produce these same types — the NATS backend converts
-// internally. Phase 5 Step 3 will remove the NATS backend entirely;
-// until then both work side by side.
 
-/// A message received from the bus. Access `.subject`, `.payload`,
-/// `.reply` exactly like the old `async_nats::Message`.
+/// A message received from the bus.
 pub type Message = WsMessage;
 
 /// A subscription handle. Call `.next().await` to receive [`Message`]s.
 pub type Subscription = WsSubscription;
 
-/// A subject string. Just a `String` — can be cloned, displayed, and
-/// passed to `reply_to`.
+/// A subject string.
 pub type Subject = WsSubject;
-
-/// Backend-agnostic client for talking to the Seidrum bus.
-///
-/// Created via [`BusClient::connect`]. Dispatches on URL scheme:
-/// `nats://` uses the NATS backend, `ws://`/`wss://` uses the
-/// eventbus WS transport.
-#[derive(Clone)]
-pub struct BusClient {
-    backend: BackendHandle,
-    /// Default source identifier used when wrapping payloads in
-    /// envelopes via [`Self::publish_envelope`]. Set at connect time.
-    pub source: String,
-}
 
 /// Arc-wrapped backend so `BusClient` is `Clone`.
 #[derive(Clone)]
 enum BackendHandle {
-    Nats(async_nats::Client),
     Ws(WsClient),
+    InProcess(Arc<dyn seidrum_eventbus::EventBus>),
+}
+
+/// Backend-agnostic client for talking to the Seidrum bus.
+#[derive(Clone)]
+pub struct BusClient {
+    backend: BackendHandle,
+    /// Default source identifier stamped onto envelopes.
+    pub source: String,
 }
 
 impl BusClient {
-    /// Connect to the bus. Dispatches on URL scheme:
-    /// - `nats://` → NATS backend (current production)
-    /// - `ws://` or `wss://` → eventbus WS transport (Phase 5)
-    ///
-    /// `source` is the plugin/service id stamped onto envelopes.
+    /// Connect to the bus via WebSocket.
+    /// `url` must be `ws://` or `wss://`.
     pub async fn connect(url: &str, source: &str) -> Result<Self> {
-        let backend = if url.starts_with("ws://") || url.starts_with("wss://") {
-            let ws = WsClient::connect(url, source).await?;
-            BackendHandle::Ws(ws)
-        } else {
-            // Default to NATS for nats:// and any other scheme.
-            let client = async_nats::connect(url)
-                .await
-                .with_context(|| format!("failed to connect to bus at {url}"))?;
-            info!(url, source, "connected to bus (NATS backend)");
-            BackendHandle::Nats(client)
-        };
-
+        if !url.starts_with("ws://") && !url.starts_with("wss://") {
+            return Err(anyhow::anyhow!(
+                "unsupported bus URL scheme: {url} (expected ws:// or wss://)"
+            ));
+        }
+        let ws = WsClient::connect(url, source).await?;
         Ok(Self {
-            backend,
+            backend: BackendHandle::Ws(ws),
             source: source.to_string(),
         })
+    }
+
+    /// Create a `BusClient` backed by an in-process `EventBus`.
+    pub fn from_bus(bus: Arc<dyn seidrum_eventbus::EventBus>, source: &str) -> Self {
+        info!(source, "BusClient created (in-process backend)");
+        Self {
+            backend: BackendHandle::InProcess(bus),
+            source: source.to_string(),
+        }
     }
 
     /// Publish a serializable payload to a subject.
@@ -95,18 +81,17 @@ impl BusClient {
         subject: impl AsRef<str>,
         payload: impl Into<bytes::Bytes>,
     ) -> Result<()> {
+        let subject_str = subject.as_ref();
+        let bytes: bytes::Bytes = payload.into();
         match &self.backend {
-            BackendHandle::Nats(client) => {
-                let subject = subject.as_ref();
-                client
-                    .publish(subject.to_string(), payload.into())
-                    .await
-                    .with_context(|| format!("failed to publish to {subject}"))?;
-                debug!(subject, "published message");
-            }
             BackendHandle::Ws(ws) => {
-                let bytes: bytes::Bytes = payload.into();
-                ws.publish_bytes(subject, bytes.as_ref()).await?;
+                ws.publish_bytes(subject_str, bytes.as_ref()).await?;
+            }
+            BackendHandle::InProcess(bus) => {
+                bus.publish(subject_str, &bytes)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("publish failed: {}", e))?;
+                debug!(subject = subject_str, "published message (in-process)");
             }
         }
         Ok(())
@@ -145,49 +130,50 @@ impl BusClient {
         subject: impl AsRef<str>,
         payload: impl Into<bytes::Bytes>,
     ) -> Result<Vec<u8>> {
+        let subject_str = subject.as_ref();
+        let bytes: bytes::Bytes = payload.into();
         match &self.backend {
-            BackendHandle::Nats(client) => {
-                let subject = subject.as_ref();
-                let response = client
-                    .request(subject.to_string(), payload.into())
+            BackendHandle::Ws(ws) => ws.request_bytes(subject_str, bytes.as_ref()).await,
+            BackendHandle::InProcess(bus) => {
+                let reply = bus
+                    .request(subject_str, &bytes, Duration::from_secs(5))
                     .await
-                    .with_context(|| format!("bus request to {subject} failed"))?;
-                debug!(subject, "received response");
-                Ok(response.payload.to_vec())
-            }
-            BackendHandle::Ws(ws) => {
-                let bytes: bytes::Bytes = payload.into();
-                ws.request_bytes(subject, bytes.as_ref()).await
+                    .map_err(|e| anyhow::anyhow!("request failed: {}", e))?;
+                Ok(reply)
             }
         }
     }
 
-    /// Subscribe to a subject pattern. Returns a [`Subscription`]
-    /// that yields [`Message`]s via `.next().await`.
+    /// Subscribe to a subject pattern.
     pub async fn subscribe(&self, subject: impl AsRef<str>) -> Result<Subscription> {
+        let subject_str = subject.as_ref();
         match &self.backend {
-            BackendHandle::Nats(client) => {
-                let subject = subject.as_ref();
-                let mut nats_sub = client
-                    .subscribe(subject.to_string())
+            BackendHandle::Ws(ws) => ws.subscribe(subject_str).await,
+            BackendHandle::InProcess(bus) => {
+                let opts = seidrum_eventbus::SubscribeOpts {
+                    priority: 10,
+                    mode: seidrum_eventbus::SubscriptionMode::Async,
+                    channel: seidrum_eventbus::ChannelConfig::InProcess,
+                    timeout: Duration::from_secs(5),
+                    filter: None,
+                };
+                let sub = bus
+                    .subscribe(subject_str, opts)
                     .await
-                    .with_context(|| format!("failed to subscribe to {subject}"))?;
-                info!(subject, "subscribed");
+                    .map_err(|e| anyhow::anyhow!("subscribe failed: {}", e))?;
+                let sub_id = sub.id.clone();
 
-                // Bridge: convert async_nats::Message → WsMessage on
-                // a background task, feeding into an mpsc that the
-                // returned WsSubscription reads from.
+                // Bridge: DispatchedEvent → WsMessage
                 let (tx, rx) = tokio::sync::mpsc::channel::<WsMessage>(256);
-                let sub_id = ulid::Ulid::new().to_string();
+                let mut event_rx = sub.rx;
                 tokio::spawn(async move {
-                    use futures_util::StreamExt;
-                    while let Some(msg) = nats_sub.next().await {
-                        let ws_msg = WsMessage {
-                            subject: msg.subject.to_string(),
-                            payload: msg.payload.clone(),
-                            reply: msg.reply.map(|r| r.to_string()),
+                    while let Some(event) = event_rx.recv().await {
+                        let msg = WsMessage {
+                            subject: event.subject,
+                            payload: bytes::Bytes::from(event.payload),
+                            reply: event.reply_subject,
                         };
-                        if tx.send(ws_msg).await.is_err() {
+                        if tx.send(msg).await.is_err() {
                             break;
                         }
                     }
@@ -195,11 +181,10 @@ impl BusClient {
 
                 Ok(WsSubscription { rx, id: sub_id })
             }
-            BackendHandle::Ws(ws) => ws.subscribe(subject).await,
         }
     }
 
-    /// Reply directly to a captured reply subject.
+    /// Reply to a captured reply subject.
     pub async fn reply_to(
         &self,
         reply_subject: &Subject,
@@ -208,13 +193,11 @@ impl BusClient {
         self.publish_bytes(reply_subject.as_str(), payload).await
     }
 
-    /// Returns `true` if the underlying bus connection is healthy.
+    /// Returns `true` if the bus connection is healthy.
     pub fn is_connected(&self) -> bool {
         match &self.backend {
-            BackendHandle::Nats(client) => {
-                client.connection_state() == async_nats::connection::State::Connected
-            }
             BackendHandle::Ws(ws) => ws.is_connected(),
+            BackendHandle::InProcess(_) => true,
         }
     }
 }

--- a/crates/core/seidrum-common/src/bus_client.rs
+++ b/crates/core/seidrum-common/src/bus_client.rs
@@ -45,7 +45,21 @@ pub struct BusClient {
 }
 
 impl BusClient {
-    /// Connect to the bus via WebSocket.
+    /// Maximum number of connection attempts before giving up.
+    const CONNECT_MAX_ATTEMPTS: u32 = 20;
+    /// Initial retry delay (doubles each attempt, capped at 5s).
+    const CONNECT_INITIAL_BACKOFF_MS: u64 = 250;
+    /// Maximum retry delay.
+    const CONNECT_MAX_BACKOFF_MS: u64 = 5000;
+
+    /// Connect to the bus via WebSocket, retrying with exponential
+    /// backoff if the server isn't up yet.
+    ///
+    /// This handles the common startup-ordering scenario where a
+    /// plugin process starts before the kernel has finished binding
+    /// its WS port. With the default 20 attempts × 250ms→5s backoff,
+    /// the plugin will wait up to ~30s for the kernel to appear.
+    ///
     /// `url` must be `ws://` or `wss://`.
     pub async fn connect(url: &str, source: &str) -> Result<Self> {
         if !url.starts_with("ws://") && !url.starts_with("wss://") {
@@ -53,11 +67,47 @@ impl BusClient {
                 "unsupported bus URL scheme: {url} (expected ws:// or wss://)"
             ));
         }
-        let ws = WsClient::connect(url, source).await?;
-        Ok(Self {
-            backend: BackendHandle::Ws(ws),
-            source: source.to_string(),
-        })
+
+        let mut attempt = 0u32;
+        let mut backoff_ms = Self::CONNECT_INITIAL_BACKOFF_MS;
+
+        loop {
+            attempt += 1;
+            match WsClient::connect(url, source).await {
+                Ok(ws) => {
+                    if attempt > 1 {
+                        info!(
+                            url,
+                            source,
+                            attempts = attempt,
+                            "connected to bus after retries"
+                        );
+                    }
+                    return Ok(Self {
+                        backend: BackendHandle::Ws(ws),
+                        source: source.to_string(),
+                    });
+                }
+                Err(e) => {
+                    if attempt >= Self::CONNECT_MAX_ATTEMPTS {
+                        return Err(e.context(format!(
+                            "failed to connect to bus at {} after {} attempts",
+                            url, attempt
+                        )));
+                    }
+                    debug!(
+                        url,
+                        source,
+                        attempt,
+                        backoff_ms,
+                        error = %e,
+                        "bus not ready, retrying..."
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(Self::CONNECT_MAX_BACKOFF_MS);
+                }
+            }
+        }
     }
 
     /// Create a `BusClient` backed by an in-process `EventBus`.

--- a/crates/core/seidrum-common/src/config.rs
+++ b/crates/core/seidrum-common/src/config.rs
@@ -11,8 +11,10 @@ use std::path::Path;
 /// Top-level platform configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformConfig {
-    /// NATS server URL.
-    pub nats_url: String,
+    /// Eventbus WebSocket URL for remote plugins.
+    /// Accepts the old `nats_url` key for backwards compatibility.
+    #[serde(alias = "nats_url")]
+    pub eventbus_url: String,
 
     /// ArangoDB server URL.
     pub arango_url: String,
@@ -329,11 +331,11 @@ mod tests {
     #[test]
     fn test_platform_config_defaults() {
         let yaml = r#"
-nats_url: nats://localhost:4222
+eventbus_url: ws://localhost:9000
 arango_url: http://localhost:8529
 "#;
         let config: PlatformConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(config.nats_url, "nats://localhost:4222");
+        assert_eq!(config.eventbus_url, "ws://localhost:9000");
         assert_eq!(config.arango_url, "http://localhost:8529");
         assert_eq!(config.arango_database, "seidrum");
         assert_eq!(config.agents_dir, "agents/");
@@ -343,7 +345,7 @@ arango_url: http://localhost:8529
     #[test]
     fn test_platform_config_overrides() {
         let yaml = r#"
-nats_url: nats://nats:4222
+eventbus_url: ws://kernel:9000
 arango_url: http://arangodb:8529
 arango_database: my_db
 agents_dir: my_agents/
@@ -421,7 +423,7 @@ agent:
     #[test]
     fn test_platform_config_workflows_dir_default() {
         let yaml = r#"
-nats_url: nats://localhost:4222
+eventbus_url: ws://localhost:9000
 arango_url: http://localhost:8529
 "#;
         let config: PlatformConfig = serde_yaml::from_str(yaml).unwrap();

--- a/crates/core/seidrum-common/src/config.rs
+++ b/crates/core/seidrum-common/src/config.rs
@@ -100,7 +100,7 @@ pub struct AgentConfig {
 /// Pipeline definition with triggers and sequential steps.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pipeline {
-    /// NATS subjects that start this pipeline (supports wildcards).
+    /// Bus subjects that start this pipeline (supports wildcards).
     pub triggers: Vec<String>,
 
     /// Sequential processing steps.
@@ -232,7 +232,7 @@ pub struct AgentDefinition {
     /// Whether this agent is enabled. Defaults to false so first boot starts clean.
     #[serde(default)]
     pub enabled: bool,
-    /// NATS subjects this agent subscribes to for consciousness events.
+    /// Bus subjects this agent subscribes to for consciousness events.
     #[serde(default)]
     pub subscribe: Vec<String>,
     /// Per-agent guardrail overrides.

--- a/crates/core/seidrum-common/src/events.rs
+++ b/crates/core/seidrum-common/src/events.rs
@@ -25,12 +25,12 @@ pub struct EventOrigin {
 // Event Envelope
 // ---------------------------------------------------------------------------
 
-/// Common wrapper for all NATS events.
+/// Common wrapper for all bus events.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EventEnvelope {
     /// ULID
     pub id: String,
-    /// Matches NATS subject
+    /// Matches bus subject
     pub event_type: String,
     pub timestamp: DateTime<Utc>,
     /// Plugin that emitted this
@@ -468,9 +468,9 @@ pub struct PluginRegister {
     pub name: String,
     pub version: String,
     pub description: String,
-    /// NATS subjects this plugin consumes
+    /// bus subjects this plugin consumes
     pub consumes: Vec<String>,
-    /// NATS subjects this plugin produces
+    /// bus subjects this plugin produces
     pub produces: Vec<String>,
     pub health_subject: String,
     /// Event types this plugin consumes (e.g., "ChannelInbound").
@@ -937,7 +937,7 @@ pub struct ConsciousnessEvent {
     pub origin: Option<EventOrigin>,
 }
 
-/// Request to subscribe an agent to NATS event patterns at runtime.
+/// Request to subscribe an agent to bus event patterns at runtime.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubscribeEventsRequest {
     pub subjects: Vec<String>,
@@ -945,7 +945,7 @@ pub struct SubscribeEventsRequest {
     pub duration_seconds: Option<u64>,
 }
 
-/// Request to unsubscribe an agent from NATS event patterns.
+/// Request to unsubscribe an agent from bus event patterns.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UnsubscribeEventsRequest {
     pub subjects: Vec<String>,

--- a/crates/core/seidrum-common/src/ws_client.rs
+++ b/crates/core/seidrum-common/src/ws_client.rs
@@ -31,7 +31,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, info, warn};
 
 /// A message received from the bus via a WebSocket subscription.
-/// Field names mirror `async_nats::Message` so consumers can switch
+/// Field names mirror the bus Message type so consumers can switch
 /// backends without source-level changes.
 #[derive(Debug, Clone)]
 pub struct WsMessage {
@@ -66,7 +66,7 @@ impl WsSubscription {
 }
 
 /// Subject type alias — just a `String` for the WS backend. Matches
-/// the `async_nats::Subject` alias shape.
+/// the bus Subject type shape.
 pub type WsSubject = String;
 
 // === Wire protocol types (must match seidrum-eventbus ws.rs) ===

--- a/crates/core/seidrum-common/tests/bus_client_inprocess.rs
+++ b/crates/core/seidrum-common/tests/bus_client_inprocess.rs
@@ -1,0 +1,138 @@
+//! Integration tests for the in-process BusClient backend.
+//!
+//! These exercise `BusClient::from_bus()` against a real eventbus
+//! without any network transport — the same path the kernel uses.
+
+use seidrum_common::bus_client::BusClient;
+use seidrum_eventbus::storage::memory_store::InMemoryEventStore;
+use seidrum_eventbus::EventBusBuilder;
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn build_bus() -> (seidrum_eventbus::BusHandles, BusClient) {
+    let store = Arc::new(InMemoryEventStore::new());
+    let handles = EventBusBuilder::new()
+        .storage(store)
+        .build_with_handles()
+        .await
+        .unwrap();
+    let client = BusClient::from_bus(handles.bus.clone(), "test");
+    (handles, client)
+}
+
+#[tokio::test]
+async fn test_inprocess_publish_subscribe() {
+    let (_handles, client) = build_bus().await;
+
+    let mut sub = client.subscribe("test.inprocess.>").await.unwrap();
+    client
+        .publish_bytes("test.inprocess.hello", b"world".to_vec())
+        .await
+        .unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(msg.subject, "test.inprocess.hello");
+    assert_eq!(msg.payload.as_ref(), b"world".to_vec());
+}
+
+#[tokio::test]
+async fn test_inprocess_request_reply() {
+    let (handles, client) = build_bus().await;
+
+    // Set up an echo handler on the bus directly.
+    let req_sub = handles
+        .bus
+        .serve("test.echo", 10, Duration::from_secs(5), None)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let mut req_sub = req_sub;
+        while let Some((req, replier)) = req_sub.rx.recv().await {
+            let _ = replier.reply(&req.payload).await;
+        }
+    });
+
+    let response = client
+        .request_bytes("test.echo", b"ping".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(response, b"ping".to_vec());
+}
+
+#[tokio::test]
+async fn test_inprocess_typed_request() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct Ping {
+        msg: String,
+    }
+    #[derive(Serialize, Deserialize)]
+    struct Pong {
+        echo: String,
+    }
+
+    let (handles, client) = build_bus().await;
+
+    let req_sub = handles
+        .bus
+        .serve("test.typed", 10, Duration::from_secs(5), None)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let mut req_sub = req_sub;
+        while let Some((req, replier)) = req_sub.rx.recv().await {
+            let ping: Ping = serde_json::from_slice(&req.payload).unwrap();
+            let pong = Pong { echo: ping.msg };
+            let _ = replier.reply(&serde_json::to_vec(&pong).unwrap()).await;
+        }
+    });
+
+    let pong: Pong = client
+        .request(
+            "test.typed",
+            &Ping {
+                msg: "hello".into(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(pong.echo, "hello");
+}
+
+#[tokio::test]
+async fn test_inprocess_publish_envelope() {
+    let (_handles, client) = build_bus().await;
+
+    let mut sub = client.subscribe("envelope.test").await.unwrap();
+    let envelope = client
+        .publish_envelope(
+            "envelope.test",
+            Some("corr-1".into()),
+            Some("scope-a".into()),
+            &serde_json::json!({"key": "val"}),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(envelope.event_type, "envelope.test");
+    assert_eq!(envelope.source, "test");
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), sub.next())
+        .await
+        .unwrap()
+        .unwrap();
+    let received: seidrum_common::events::EventEnvelope =
+        serde_json::from_slice(&msg.payload).unwrap();
+    assert_eq!(received.event_type, "envelope.test");
+}
+
+#[tokio::test]
+async fn test_inprocess_is_connected() {
+    let (_handles, client) = build_bus().await;
+    assert!(client.is_connected());
+}

--- a/crates/core/seidrum-common/tests/ws_client_e2e.rs
+++ b/crates/core/seidrum-common/tests/ws_client_e2e.rs
@@ -298,6 +298,48 @@ async fn test_ws_client_operations_after_server_shutdown_do_not_hang() {
     );
 }
 
+/// BusClient::connect retries when the server isn't up yet, then
+/// succeeds once the server starts.
+#[tokio::test]
+async fn test_bus_client_connect_retries_until_server_ready() {
+    use seidrum_common::bus_client::BusClient;
+    use seidrum_eventbus::test_utils::pick_ephemeral_addr;
+
+    let ws_addr = pick_ephemeral_addr();
+    let url = format!("ws://{}", ws_addr);
+
+    // Start the connect in a background task BEFORE the server is up.
+    let url_clone = url.clone();
+    let connect_task =
+        tokio::spawn(async move { BusClient::connect(&url_clone, "retry-test").await });
+
+    // Wait 500ms, THEN start the server. The connect should be
+    // retrying during this window.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let store = Arc::new(seidrum_eventbus::storage::memory_store::InMemoryEventStore::new());
+    let handles = seidrum_eventbus::EventBusBuilder::new()
+        .storage(store)
+        .with_websocket(ws_addr)
+        .unsafe_allow_ws_dev_mode()
+        .build_with_handles()
+        .await
+        .unwrap();
+    seidrum_eventbus::test_utils::wait_for_ws_ready(ws_addr).await;
+
+    // The connect should succeed now that the server is up.
+    let result = tokio::time::timeout(Duration::from_secs(10), connect_task)
+        .await
+        .expect("connect task should finish")
+        .expect("connect task should not panic");
+
+    assert!(result.is_ok(), "BusClient should connect after retries");
+    let client = result.unwrap();
+    assert!(client.is_connected());
+
+    handles.shutdown_and_join().await;
+}
+
 /// Configurable request timeout via `with_request_timeout`.
 #[tokio::test]
 async fn test_ws_client_request_timeout_configurable() {

--- a/crates/core/seidrum-daemon/src/daemon.rs
+++ b/crates/core/seidrum-daemon/src/daemon.rs
@@ -1,5 +1,5 @@
 //! Process supervisor: spawn, monitor, restart, and gracefully shut down
-//! the kernel and all enabled plugins. Supports NATS-based plugin lifecycle control.
+//! the kernel and all enabled plugins. Supports bus-based plugin lifecycle control.
 
 #[cfg(not(unix))]
 compile_error!("seidrum-daemon requires a Unix system (Linux or macOS)");
@@ -24,13 +24,13 @@ const BACKOFF_WINDOW: Duration = Duration::from_secs(300);
 /// Grace period for SIGTERM before SIGKILL.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// NATS request to start a plugin.
+/// Bus request to start a plugin.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct PluginStartCommand {
     plugin: String,
 }
 
-/// NATS request to stop a plugin.
+/// Bus request to stop a plugin.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct PluginStopCommand {
     plugin: String,
@@ -227,7 +227,7 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
     kernel.spawn(paths)?;
     processes.push(kernel);
 
-    // Wait for kernel to connect to NATS
+    // Wait for kernel to start
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // 2. Load plugins.yaml and start enabled plugins
@@ -267,23 +267,22 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
         "All processes started, entering monitoring loop"
     );
 
-    // 3. Connect to NATS and subscribe to plugin control subjects
-    let nats_url =
-        std::env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
-    let nats_client =
-        match seidrum_common::bus_client::BusClient::connect(&nats_url, "daemon").await {
-            Ok(client) => {
-                info!("Connected to bus for plugin lifecycle control");
-                Some(client)
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to connect to bus ({}), plugin lifecycle control unavailable",
-                    e
-                );
-                None
-            }
-        };
+    // 3. Connect to bus and subscribe to plugin control subjects
+    let bus_url = std::env::var("BUS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
+    let nats_client = match seidrum_common::bus_client::BusClient::connect(&bus_url, "daemon").await
+    {
+        Ok(client) => {
+            info!("Connected to bus for plugin lifecycle control");
+            Some(client)
+        }
+        Err(e) => {
+            warn!(
+                "Failed to connect to bus ({}), plugin lifecycle control unavailable",
+                e
+            );
+            None
+        }
+    };
 
     let mut start_sub = None;
     let mut stop_sub = None;
@@ -304,7 +303,7 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
         }
     }
 
-    // 4. Monitoring loop — handle SIGINT, SIGTERM, process checks, and NATS commands
+    // 4. Monitoring loop — handle SIGINT, SIGTERM, process checks, and bus commands
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .context("Failed to register SIGTERM handler")?;
 
@@ -517,7 +516,7 @@ pub async fn stop(paths: &SeidrumPaths) -> Result<()> {
     Ok(())
 }
 
-/// Handle a plugin start request from NATS.
+/// Handle a plugin start request from bus.
 async fn handle_plugin_start(
     msg: &seidrum_common::bus_client::Message,
     processes: &mut Vec<ManagedProcess>,
@@ -606,7 +605,7 @@ async fn handle_plugin_start(
 
     match proc.spawn(paths) {
         Ok(()) => {
-            info!(name = %plugin_name, "Plugin started via NATS");
+            info!(name = %plugin_name, "Plugin started via bus");
             // Check if there's already an entry for this plugin name and update it instead of always pushing
             if let Some(existing) = processes.iter_mut().find(|p| p.name == *plugin_name) {
                 *existing = proc;
@@ -624,7 +623,7 @@ async fn handle_plugin_start(
             }
         }
         Err(e) => {
-            error!(name = %plugin_name, error = %e, "Failed to start plugin via NATS");
+            error!(name = %plugin_name, error = %e, "Failed to start plugin via bus");
             let response = PluginCommandResponse {
                 success: false,
                 message: format!("Failed to start plugin: {}", e),
@@ -638,7 +637,7 @@ async fn handle_plugin_start(
     }
 }
 
-/// Handle a plugin stop request from NATS.
+/// Handle a plugin stop request from bus.
 async fn handle_plugin_stop(
     msg: &seidrum_common::bus_client::Message,
     processes: &mut Vec<ManagedProcess>,
@@ -721,7 +720,7 @@ async fn handle_plugin_stop(
     // Write stopped marker so daemon doesn't restart it
     let _ = std::fs::write(paths.plugin_stopped_file(plugin_name), "");
 
-    info!(name = %plugin_name, %pid, "Sending SIGTERM to plugin via NATS");
+    info!(name = %plugin_name, %pid, "Sending SIGTERM to plugin via bus");
     send_sigterm(pid as u32);
 
     // Wait for graceful shutdown
@@ -738,7 +737,7 @@ async fn handle_plugin_stop(
                     .reply_to(reply, serde_json::to_vec(&response).unwrap_or_default())
                     .await;
             }
-            info!(name = %plugin_name, "Plugin stopped via NATS");
+            info!(name = %plugin_name, "Plugin stopped via bus");
             // Remove entry from processes vector
             processes.retain(|p| p.name != *plugin_name);
             return;
@@ -759,7 +758,7 @@ async fn handle_plugin_stop(
             .reply_to(reply, serde_json::to_vec(&response).unwrap_or_default())
             .await;
     }
-    info!(name = %plugin_name, "Plugin killed via NATS");
+    info!(name = %plugin_name, "Plugin killed via bus");
     // Remove entry from processes vector
     processes.retain(|p| p.name != *plugin_name);
 }

--- a/crates/core/seidrum-daemon/src/daemon.rs
+++ b/crates/core/seidrum-daemon/src/daemon.rs
@@ -268,7 +268,7 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
     );
 
     // 3. Connect to bus and subscribe to plugin control subjects
-    let bus_url = std::env::var("BUS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
+    let bus_url = std::env::var("BUS_URL").unwrap_or_else(|_| "ws://localhost:9000".to_string());
     let nats_client = match seidrum_common::bus_client::BusClient::connect(&bus_url, "daemon").await
     {
         Ok(client) => {

--- a/crates/core/seidrum-daemon/src/main.rs
+++ b/crates/core/seidrum-daemon/src/main.rs
@@ -29,11 +29,12 @@ async fn main() -> Result<()> {
             if let Some(mgr) = &infra {
                 paths.ensure_dirs()?;
                 println!("Starting infrastructure...");
-                mgr.start_nats()?;
+                // eventbus is built into the kernel — no external service to start
                 mgr.start_arango()?;
                 mgr.wait_for_healthy().await?;
                 println!("Infrastructure ready.");
-            } else if !infra::is_nats_reachable(4222) {
+            } else if false {
+                // eventbus check removed
                 println!("No managed infrastructure and NATS is not reachable on :4222.");
                 println!("Run 'seidrum setup' to configure, or start NATS/ArangoDB manually.");
                 return Ok(());
@@ -46,7 +47,7 @@ async fn main() -> Result<()> {
 
             if let Ok(Some(mgr)) = infra::InfraManager::load(&paths) {
                 println!("Stopping infrastructure...");
-                mgr.stop_nats()?;
+                // eventbus shuts down with the kernel
                 mgr.stop_arango()?;
                 println!("Infrastructure stopped.");
             }
@@ -56,16 +57,7 @@ async fn main() -> Result<()> {
             // Show infra status, then daemon/plugin status
             if let Ok(Some(mgr)) = infra::InfraManager::load(&paths) {
                 println!("Infrastructure:");
-                let nats_status = if mgr.is_nats_running() {
-                    match mgr.nats_pid() {
-                        Some(pid) => {
-                            format!("running (PID {}, port {})", pid, mgr.config.nats.port)
-                        }
-                        None => format!("running (port {})", mgr.config.nats.port),
-                    }
-                } else {
-                    "not running".to_string()
-                };
+                println!("  EventBus: built into kernel (no external service)");
                 let arango_status = if mgr.is_arango_running() {
                     format!(
                         "running (container {}, port {})",
@@ -75,7 +67,6 @@ async fn main() -> Result<()> {
                 } else {
                     "not running".to_string()
                 };
-                println!("  NATS:     {}", nats_status);
                 println!("  ArangoDB: {}", arango_status);
                 println!();
             }

--- a/crates/core/seidrum-daemon/src/paths.rs
+++ b/crates/core/seidrum-daemon/src/paths.rs
@@ -60,9 +60,9 @@ impl SeidrumPaths {
         self.seidrum_home.join("data")
     }
 
-    /// NATS JetStream data directory (~/.seidrum/data/nats/).
+    /// Eventbus data directory (~/.seidrum/data/nats/).
     pub fn nats_data_dir(&self) -> PathBuf {
-        self.seidrum_home.join("data").join("nats")
+        self.seidrum_home.join("data").join("eventbus")
     }
 
     /// Infrastructure config file (~/.seidrum/infra.yaml).
@@ -70,9 +70,9 @@ impl SeidrumPaths {
         self.seidrum_home.join("infra.yaml")
     }
 
-    /// NATS server PID file.
+    /// Kernel PID file.
     pub fn nats_pid_file(&self) -> PathBuf {
-        self.pid_dir.join("nats-server.pid")
+        self.pid_dir.join("kernel.pid")
     }
 
     /// ArangoDB container ID file.

--- a/crates/core/seidrum-daemon/src/setup.rs
+++ b/crates/core/seidrum-daemon/src/setup.rs
@@ -46,12 +46,6 @@ pub async fn run(paths: &SeidrumPaths, use_defaults: bool) -> Result<()> {
     println!();
 
     // 2. Download NATS binary
-    let nats_config = NatsConfig {
-        mode: NatsMode::Native,
-        version: crate::infra::NATS_VERSION.to_string(),
-        port: 4222,
-        http_port: 8222,
-    };
 
     // 3. Prompt for ArangoDB password only
     let arango_password = if use_defaults {
@@ -75,7 +69,12 @@ pub async fn run(paths: &SeidrumPaths, use_defaults: bool) -> Result<()> {
     };
 
     let infra_config = InfraConfig {
-        nats: nats_config,
+        nats: NatsConfig {
+            mode: NatsMode::Native,
+            version: "2.10.24".to_string(),
+            port: 4222,
+            http_port: 8222,
+        },
         arango: arango_config,
         container_runtime: runtime,
     };
@@ -86,7 +85,7 @@ pub async fn run(paths: &SeidrumPaths, use_defaults: bool) -> Result<()> {
     );
 
     // 5. Download NATS
-    infra.download_nats().await?;
+    // No NATS to download (eventbus is built into the kernel)
 
     // 6. Pull ArangoDB image
     println!("Pulling ArangoDB Docker image...");
@@ -111,7 +110,7 @@ pub async fn run(paths: &SeidrumPaths, use_defaults: bool) -> Result<()> {
 
     // 8. Start infrastructure temporarily for DB init
     println!("Starting infrastructure for database initialization...");
-    infra.start_nats()?;
+    // No NATS to start
     infra.start_arango()?;
     infra.wait_for_healthy().await?;
 
@@ -127,7 +126,7 @@ pub async fn run(paths: &SeidrumPaths, use_defaults: bool) -> Result<()> {
     // No auto-enable logic — the user is in control.
 
     // 11. Stop infrastructure (user will use `seidrum start`)
-    infra.stop_nats()?;
+    // No NATS to stop
     infra.stop_arango()?;
 
     // 12. Save infra config

--- a/crates/core/seidrum-e2e/tests/builtin_capabilities.rs
+++ b/crates/core/seidrum-e2e/tests/builtin_capabilities.rs
@@ -1,6 +1,6 @@
 //! E2E tests for consciousness built-in capabilities.
 //!
-//! Requires: NATS + kernel running with consciousness service.
+//! Requires: kernel running with consciousness service.
 
 mod common;
 
@@ -18,16 +18,16 @@ async fn call_builtin(
         arguments,
         correlation_id: None,
     };
-    common::nats_request(nats, "capability.call.consciousness", &req).await
+    common::bus_request(nats, "capability.call.consciousness", &req).await
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_builtin_search_skills() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     let resp = call_builtin(
-        &nats,
+        &bus,
         "search-skills",
         serde_json::json!({"query": "code review", "limit": 5}),
     )
@@ -46,12 +46,12 @@ async fn test_builtin_search_skills() {
 #[tokio::test]
 #[ignore]
 async fn test_builtin_save_and_load_skill() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let skill_desc = format!("E2E test skill {}", ulid::Ulid::new());
 
     // Save
     let save_resp = call_builtin(
-        &nats,
+        &bus,
         "save-skill",
         serde_json::json!({
             "description": skill_desc,
@@ -69,7 +69,7 @@ async fn test_builtin_save_and_load_skill() {
 
     // Load
     let load_resp = call_builtin(
-        &nats,
+        &bus,
         "load-skill",
         serde_json::json!({"skill_id": skill_id}),
     )
@@ -89,7 +89,7 @@ async fn test_builtin_save_and_load_skill() {
 
     // Load nonexistent
     let bad_resp = call_builtin(
-        &nats,
+        &bus,
         "load-skill",
         serde_json::json!({"skill_id": "nonexistent-skill-xyz"}),
     )
@@ -100,11 +100,11 @@ async fn test_builtin_save_and_load_skill() {
 #[tokio::test]
 #[ignore]
 async fn test_builtin_subscribe_events_denied_subjects() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     // Try subscribing to internal subject — should be denied
     let resp = call_builtin(
-        &nats,
+        &bus,
         "subscribe-events",
         serde_json::json!({"subjects": ["brain.query.request"]}),
     )
@@ -125,11 +125,11 @@ async fn test_builtin_subscribe_events_denied_subjects() {
 #[tokio::test]
 #[ignore]
 async fn test_builtin_schedule_wake_bounds() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     // Valid wake
     let resp = call_builtin(
-        &nats,
+        &bus,
         "schedule-wake",
         serde_json::json!({
             "delay_seconds": 60,
@@ -146,7 +146,7 @@ async fn test_builtin_schedule_wake_bounds() {
 
     // Invalid: 0 seconds
     let resp_zero = call_builtin(
-        &nats,
+        &bus,
         "schedule-wake",
         serde_json::json!({
             "delay_seconds": 0,
@@ -158,7 +158,7 @@ async fn test_builtin_schedule_wake_bounds() {
 
     // Invalid: too large
     let resp_huge = call_builtin(
-        &nats,
+        &bus,
         "schedule-wake",
         serde_json::json!({
             "delay_seconds": 999999999,
@@ -172,9 +172,9 @@ async fn test_builtin_schedule_wake_bounds() {
 #[tokio::test]
 #[ignore]
 async fn test_builtin_list_conversations() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
-    let resp = call_builtin(&nats, "list-conversations", serde_json::json!({"limit": 5})).await;
+    let resp = call_builtin(&bus, "list-conversations", serde_json::json!({"limit": 5})).await;
     assert!(
         !resp.is_error,
         "list-conversations should not error: {:?}",
@@ -185,11 +185,11 @@ async fn test_builtin_list_conversations() {
 #[tokio::test]
 #[ignore]
 async fn test_builtin_invalid_arguments() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     // save-skill with empty description
     let resp = call_builtin(
-        &nats,
+        &bus,
         "save-skill",
         serde_json::json!({"description": "", "snippet": ""}),
     )
@@ -197,18 +197,18 @@ async fn test_builtin_invalid_arguments() {
     assert!(resp.is_error, "Empty description should be rejected");
 
     // load-skill with empty skill_id
-    let resp2 = call_builtin(&nats, "load-skill", serde_json::json!({"skill_id": ""})).await;
+    let resp2 = call_builtin(&bus, "load-skill", serde_json::json!({"skill_id": ""})).await;
     assert!(resp2.is_error, "Empty skill_id should be rejected");
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_builtin_delegate_task_depth_limit() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     // Delegation at depth 5 should be rejected
     let resp = call_builtin(
-        &nats,
+        &bus,
         "delegate-task",
         serde_json::json!({
             "to_agent_id": "research-agent",
@@ -228,7 +228,7 @@ async fn test_builtin_delegate_task_depth_limit() {
 
     // Delegation at depth 0 should succeed (creates conversation)
     let resp2 = call_builtin(
-        &nats,
+        &bus,
         "delegate-task",
         serde_json::json!({
             "to_agent_id": "research-agent",

--- a/crates/core/seidrum-e2e/tests/capability.rs
+++ b/crates/core/seidrum-e2e/tests/capability.rs
@@ -1,6 +1,6 @@
 //! E2E tests for capability registration and search.
 //!
-//! Requires: NATS + kernel running with tool registry service.
+//! Requires: kernel running with tool registry service.
 
 mod common;
 
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[tokio::test]
 #[ignore]
 async fn test_capability_register_and_search() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let tool_id = common::test_id("e2e-tool");
     let plugin_id = common::test_id("e2e-plugin");
 
@@ -47,7 +47,7 @@ async fn test_capability_register_and_search() {
         kind_filter: None,
     };
     let search_resp: ToolSearchResponse =
-        common::nats_request(&nats, "capability.search", &search_req).await;
+        common::bus_request(&bus, "capability.search", &search_req).await;
     assert!(
         search_resp.tools.iter().any(|t| t.tool_id == tool_id),
         "Tool {} should appear in search results",
@@ -59,7 +59,7 @@ async fn test_capability_register_and_search() {
         tool_id: tool_id.clone(),
     };
     let describe_resp: ToolDescribeResponse =
-        common::nats_request(&nats, "capability.describe", &describe_req).await;
+        common::bus_request(&bus, "capability.describe", &describe_req).await;
     assert_eq!(describe_resp.tool_id, tool_id);
     assert_eq!(describe_resp.plugin_id, plugin_id);
     assert_eq!(describe_resp.name, "E2E Test Tool");
@@ -68,7 +68,7 @@ async fn test_capability_register_and_search() {
 #[tokio::test]
 #[ignore]
 async fn test_capability_kind_filter() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let tool_id = common::test_id("e2e-cmd");
 
     // Register a command-type capability
@@ -97,7 +97,7 @@ async fn test_capability_kind_filter() {
         kind_filter: Some("command".into()),
     };
     let search_resp: ToolSearchResponse =
-        common::nats_request(&nats, "capability.search", &search_req).await;
+        common::bus_request(&bus, "capability.search", &search_req).await;
     assert!(
         search_resp.tools.iter().any(|t| t.tool_id == tool_id),
         "Command tool should appear with kind_filter=command"
@@ -110,7 +110,7 @@ async fn test_capability_kind_filter() {
         kind_filter: Some("tool".into()),
     };
     let search_resp2: ToolSearchResponse =
-        common::nats_request(&nats, "capability.search", &search_req2).await;
+        common::bus_request(&bus, "capability.search", &search_req2).await;
     assert!(
         !search_resp2.tools.iter().any(|t| t.tool_id == tool_id),
         "Command tool should NOT appear with kind_filter=tool"

--- a/crates/core/seidrum-e2e/tests/capability.rs
+++ b/crates/core/seidrum-e2e/tests/capability.rs
@@ -34,7 +34,7 @@ async fn test_capability_register_and_search() {
     };
 
     let bytes = serde_json::to_vec(&register).unwrap();
-    nats.publish_bytes("capability.register", bytes)
+    bus.publish_bytes("capability.register", bytes)
         .await
         .unwrap();
 
@@ -84,7 +84,7 @@ async fn test_capability_kind_filter() {
     };
 
     let bytes = serde_json::to_vec(&register).unwrap();
-    nats.publish_bytes("capability.register", bytes)
+    bus.publish_bytes("capability.register", bytes)
         .await
         .unwrap();
 

--- a/crates/core/seidrum-e2e/tests/common/mod.rs
+++ b/crates/core/seidrum-e2e/tests/common/mod.rs
@@ -3,15 +3,15 @@
 use std::time::Duration;
 
 /// Connect to the bus using env vars or defaults.
-pub async fn connect_nats() -> seidrum_common::bus_client::BusClient {
-    let url = std::env::var("TEST_NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".into());
+pub async fn connect_bus() -> seidrum_common::bus_client::BusClient {
+    let url = std::env::var("TEST_BUS_URL").unwrap_or_else(|_| "ws://localhost:9000".into());
     seidrum_common::bus_client::BusClient::connect(&url, "e2e-test")
         .await
         .expect("Failed to connect to bus. Is it running?")
 }
 
 /// Bus request/reply helper with timeout.
-pub async fn nats_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
+pub async fn bus_request<T: serde::Serialize, R: serde::de::DeserializeOwned>(
     nats: &seidrum_common::bus_client::BusClient,
     subject: &str,
     payload: &T,

--- a/crates/core/seidrum-e2e/tests/conversation_crud.rs
+++ b/crates/core/seidrum-e2e/tests/conversation_crud.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 #[tokio::test]
 #[ignore]
 async fn test_conversation_lifecycle() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let test_id = common::test_id("e2e-conv");
 
     // Create
@@ -26,7 +26,7 @@ async fn test_conversation_lifecycle() {
         user_id: None,
     };
     let create_resp: ConversationCreateResponse =
-        common::nats_request(&nats, "brain.conversation.create", &create_req).await;
+        common::bus_request(&bus, "brain.conversation.create", &create_req).await;
     let conv_id = create_resp.conversation_id;
     assert!(!conv_id.is_empty());
 
@@ -44,7 +44,7 @@ async fn test_conversation_lifecycle() {
         },
     };
     let append_resp: ConversationAppendResponse =
-        common::nats_request(&nats, "brain.conversation.append", &append_req).await;
+        common::bus_request(&bus, "brain.conversation.append", &append_req).await;
     assert!(append_resp.success);
     assert_eq!(append_resp.message_count, 1);
 
@@ -62,7 +62,7 @@ async fn test_conversation_lifecycle() {
         },
     };
     let append_resp2: ConversationAppendResponse =
-        common::nats_request(&nats, "brain.conversation.append", &append_req2).await;
+        common::bus_request(&bus, "brain.conversation.append", &append_req2).await;
     assert!(append_resp2.success);
     assert_eq!(append_resp2.message_count, 2);
 
@@ -73,7 +73,7 @@ async fn test_conversation_lifecycle() {
         user_id: None,
     };
     let get_resp: serde_json::Value =
-        common::nats_request(&nats, "brain.conversation.get", &get_req).await;
+        common::bus_request(&bus, "brain.conversation.get", &get_req).await;
     assert!(!get_resp.is_null());
     let messages = get_resp.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 2);
@@ -91,7 +91,7 @@ async fn test_conversation_lifecycle() {
         user_id: None,
     };
     let list_resp: ConversationListResponse =
-        common::nats_request(&nats, "brain.conversation.list", &list_req).await;
+        common::bus_request(&bus, "brain.conversation.list", &list_req).await;
     assert!(list_resp.conversations.iter().any(|c| c.id == conv_id));
 
     // Find by metadata
@@ -103,7 +103,7 @@ async fn test_conversation_lifecycle() {
         user_id: None,
     };
     let find_resp: serde_json::Value =
-        common::nats_request(&nats, "brain.conversation.find", &find_req).await;
+        common::bus_request(&bus, "brain.conversation.find", &find_req).await;
     assert!(!find_resp.is_null());
     assert_eq!(find_resp.get("id").unwrap().as_str().unwrap(), conv_id);
 }
@@ -111,7 +111,7 @@ async fn test_conversation_lifecycle() {
 #[tokio::test]
 #[ignore]
 async fn test_conversation_get_with_max_messages() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     // Create
     let create_req = ConversationCreateRequest {
@@ -123,7 +123,7 @@ async fn test_conversation_get_with_max_messages() {
         user_id: None,
     };
     let create_resp: ConversationCreateResponse =
-        common::nats_request(&nats, "brain.conversation.create", &create_req).await;
+        common::bus_request(&bus, "brain.conversation.create", &create_req).await;
     let conv_id = create_resp.conversation_id;
 
     // Append 5 messages
@@ -141,7 +141,7 @@ async fn test_conversation_get_with_max_messages() {
             },
         };
         let _: ConversationAppendResponse =
-            common::nats_request(&nats, "brain.conversation.append", &req).await;
+            common::bus_request(&bus, "brain.conversation.append", &req).await;
     }
 
     // Get with max_messages=2
@@ -151,7 +151,7 @@ async fn test_conversation_get_with_max_messages() {
         user_id: None,
     };
     let get_resp: serde_json::Value =
-        common::nats_request(&nats, "brain.conversation.get", &get_req).await;
+        common::bus_request(&bus, "brain.conversation.get", &get_req).await;
     let messages = get_resp.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 2);
     // Should be the last 2 messages

--- a/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
+++ b/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
@@ -46,7 +46,7 @@ async fn test_plugin_register_and_query() {
     };
 
     let bytes = serde_json::to_vec(&register).unwrap();
-    nats.publish_bytes("plugin.register", bytes).await.unwrap();
+    bus.publish_bytes("plugin.register", bytes).await.unwrap();
 
     // Give registry time to process
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -83,7 +83,7 @@ async fn test_plugin_register_and_query() {
         id: plugin_id.clone(),
     };
     let dereg_bytes = serde_json::to_vec(&dereg).unwrap();
-    nats.publish_bytes("plugin.deregister", dereg_bytes)
+    bus.publish_bytes("plugin.deregister", dereg_bytes)
         .await
         .unwrap();
 

--- a/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
+++ b/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
@@ -1,6 +1,6 @@
 //! E2E tests for plugin registration and deregistration.
 //!
-//! Requires: NATS + kernel running with registry service.
+//! Requires: kernel running with registry service.
 
 mod common;
 
@@ -28,7 +28,7 @@ struct RegistryQueryResponse {
 #[tokio::test]
 #[ignore]
 async fn test_plugin_register_and_query() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let plugin_id = common::test_id("e2e-plugin");
 
     // Register (raw payload — kernel accepts both raw and envelope-wrapped)
@@ -55,7 +55,7 @@ async fn test_plugin_register_and_query() {
     let query = RegistryQuery::GetPlugin {
         plugin_id: plugin_id.clone(),
     };
-    let resp: RegistryQueryResponse = common::nats_request(&nats, "registry.query", &query).await;
+    let resp: RegistryQueryResponse = common::bus_request(&bus, "registry.query", &query).await;
     assert!(resp.success, "Plugin should be found in registry");
     assert!(resp.plugin.is_some());
     let plugin = resp.plugin.unwrap();
@@ -68,7 +68,7 @@ async fn test_plugin_register_and_query() {
     // Query - list all plugins (should include ours)
     let list_query = RegistryQuery::ListPlugins;
     let list_resp: RegistryQueryResponse =
-        common::nats_request(&nats, "registry.query", &list_query).await;
+        common::bus_request(&bus, "registry.query", &list_query).await;
     assert!(list_resp.success);
     let plugins = list_resp.plugins.unwrap();
     assert!(
@@ -93,7 +93,7 @@ async fn test_plugin_register_and_query() {
     let query2 = RegistryQuery::GetPlugin {
         plugin_id: plugin_id.clone(),
     };
-    let resp2: RegistryQueryResponse = common::nats_request(&nats, "registry.query", &query2).await;
+    let resp2: RegistryQueryResponse = common::bus_request(&bus, "registry.query", &query2).await;
     assert!(!resp2.success, "Plugin should no longer be in registry");
     assert!(resp2.plugin.is_none());
 }

--- a/crates/core/seidrum-e2e/tests/skill_crud.rs
+++ b/crates/core/seidrum-e2e/tests/skill_crud.rs
@@ -1,6 +1,6 @@
 //! E2E tests for skill CRUD (brain.skill.save/search/get/list/delete).
 //!
-//! Requires: NATS + kernel running with brain service.
+//! Requires: kernel running with brain service.
 
 mod common;
 
@@ -12,7 +12,7 @@ use seidrum_common::events::{
 #[tokio::test]
 #[ignore]
 async fn test_skill_save_and_get() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let skill_id = common::test_id("e2e-skill");
 
     // Save
@@ -27,7 +27,7 @@ async fn test_skill_save_and_get() {
         embedding: vec![],
     };
     let save_resp: SkillSaveResponse =
-        common::nats_request(&nats, "brain.skill.save", &save_req).await;
+        common::bus_request(&bus, "brain.skill.save", &save_req).await;
     assert_eq!(save_resp.skill_id, skill_id);
     assert!(save_resp.is_new);
 
@@ -35,8 +35,7 @@ async fn test_skill_save_and_get() {
     let get_req = SkillGetRequest {
         skill_id: skill_id.clone(),
     };
-    let get_resp: serde_json::Value =
-        common::nats_request(&nats, "brain.skill.get", &get_req).await;
+    let get_resp: serde_json::Value = common::bus_request(&bus, "brain.skill.get", &get_req).await;
     assert!(!get_resp.is_null());
     assert_eq!(get_resp.get("id").unwrap().as_str().unwrap(), skill_id);
     assert!(get_resp
@@ -47,13 +46,13 @@ async fn test_skill_save_and_get() {
         .contains("security issues"));
 
     // Cleanup
-    let _: serde_json::Value = common::nats_request(&nats, "brain.skill.delete", &get_req).await;
+    let _: serde_json::Value = common::bus_request(&bus, "brain.skill.delete", &get_req).await;
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_skill_search() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let skill_id = common::test_id("e2e-search");
 
     // Save a skill
@@ -67,7 +66,7 @@ async fn test_skill_search() {
         learned_from: None,
         embedding: vec![],
     };
-    let _: SkillSaveResponse = common::nats_request(&nats, "brain.skill.save", &save_req).await;
+    let _: SkillSaveResponse = common::bus_request(&bus, "brain.skill.save", &save_req).await;
 
     // Search
     let search_req = SkillSearchRequest {
@@ -76,7 +75,7 @@ async fn test_skill_search() {
         scope: None,
     };
     let search_resp: SkillSearchResponse =
-        common::nats_request(&nats, "brain.skill.search", &search_req).await;
+        common::bus_request(&bus, "brain.skill.search", &search_req).await;
     assert!(
         search_resp.skills.iter().any(|s| s.id == skill_id),
         "Expected to find skill {} in search results",
@@ -85,20 +84,20 @@ async fn test_skill_search() {
 
     // Cleanup
     let get_req = SkillGetRequest { skill_id };
-    let _: serde_json::Value = common::nats_request(&nats, "brain.skill.delete", &get_req).await;
+    let _: serde_json::Value = common::bus_request(&bus, "brain.skill.delete", &get_req).await;
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_skill_list() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
 
     let list_req = SkillListRequest {
         source_filter: None,
         limit: Some(100),
     };
     let list_resp: SkillListResponse =
-        common::nats_request(&nats, "brain.skill.list", &list_req).await;
+        common::bus_request(&bus, "brain.skill.list", &list_req).await;
 
     // Verify the response deserializes correctly — the list may be empty on a clean test DB
     let _ = list_resp.skills.len();

--- a/crates/core/seidrum-e2e/tests/storage.rs
+++ b/crates/core/seidrum-e2e/tests/storage.rs
@@ -1,6 +1,6 @@
 //! E2E tests for plugin storage (storage.get/set/delete/list).
 //!
-//! Requires: NATS + kernel running with plugin_storage service.
+//! Requires: kernel running with plugin_storage service.
 //! Run: cargo test -p seidrum-e2e -- --ignored
 
 mod common;
@@ -11,9 +11,9 @@ use seidrum_common::events::{
 };
 
 #[tokio::test]
-#[ignore] // Requires NATS + kernel running
+#[ignore] // Requires kernel + kernel running
 async fn test_storage_set_and_get() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let key = common::test_id("e2e-storage");
 
     // Set
@@ -23,7 +23,7 @@ async fn test_storage_set_and_get() {
         key: key.clone(),
         value: serde_json::json!({"hello": "world"}),
     };
-    let set_resp: StorageSetResponse = common::nats_request(&nats, "storage.set", &set_req).await;
+    let set_resp: StorageSetResponse = common::bus_request(&bus, "storage.set", &set_req).await;
     assert!(set_resp.success);
 
     // Get
@@ -32,7 +32,7 @@ async fn test_storage_set_and_get() {
         namespace: "test".into(),
         key: key.clone(),
     };
-    let get_resp: StorageGetResponse = common::nats_request(&nats, "storage.get", &get_req).await;
+    let get_resp: StorageGetResponse = common::bus_request(&bus, "storage.get", &get_req).await;
     assert!(get_resp.found);
     assert_eq!(
         get_resp
@@ -52,19 +52,19 @@ async fn test_storage_set_and_get() {
         key: key.clone(),
     };
     let del_resp: StorageDeleteResponse =
-        common::nats_request(&nats, "storage.delete", &del_req).await;
+        common::bus_request(&bus, "storage.delete", &del_req).await;
     assert!(del_resp.success);
     assert!(del_resp.existed);
 
     // Verify deleted
-    let get_resp2: StorageGetResponse = common::nats_request(&nats, "storage.get", &get_req).await;
+    let get_resp2: StorageGetResponse = common::bus_request(&bus, "storage.get", &get_req).await;
     assert!(!get_resp2.found);
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_storage_list_keys() {
-    let nats = common::connect_nats().await;
+    let bus = common::connect_bus().await;
     let key1 = common::test_id("e2e-list");
     let key2 = common::test_id("e2e-list");
 
@@ -76,7 +76,7 @@ async fn test_storage_list_keys() {
             key: key.clone(),
             value: serde_json::json!(1),
         };
-        let resp: StorageSetResponse = common::nats_request(&nats, "storage.set", &req).await;
+        let resp: StorageSetResponse = common::bus_request(&bus, "storage.set", &req).await;
         assert!(resp.success);
     }
 
@@ -85,8 +85,7 @@ async fn test_storage_list_keys() {
         plugin_id: "e2e-list-test".into(),
         namespace: "test".into(),
     };
-    let list_resp: StorageListResponse =
-        common::nats_request(&nats, "storage.list", &list_req).await;
+    let list_resp: StorageListResponse = common::bus_request(&bus, "storage.list", &list_req).await;
     assert!(list_resp.keys.contains(&key1));
     assert!(list_resp.keys.contains(&key2));
 
@@ -97,6 +96,6 @@ async fn test_storage_list_keys() {
             namespace: "test".into(),
             key: key.clone(),
         };
-        let _: StorageDeleteResponse = common::nats_request(&nats, "storage.delete", &req).await;
+        let _: StorageDeleteResponse = common::bus_request(&bus, "storage.delete", &req).await;
     }
 }

--- a/crates/core/seidrum-eventbus/PHASE5_STEP3_PLAN.md
+++ b/crates/core/seidrum-eventbus/PHASE5_STEP3_PLAN.md
@@ -1,0 +1,163 @@
+# Phase 5 Steps 3-5: NATS → EventBus Cutover — Implementation Plan
+
+**Status:** Ready to execute
+**Branch:** `feat/eventbus-phase5-cutover` (to be created)
+**Dependencies:** PR #31 merged (WsClient + BusClient backend dispatch)
+**Estimated effort:** ~10-14 hours
+
+---
+
+## Current State
+
+As of commit `f59d97f` on `main`:
+- `async_nats` exists in **one Cargo.toml** only: `seidrum-common/Cargo.toml`
+- `async_nats` code exists in **one source file** only: `seidrum-common/src/bus_client.rs`
+- All 23 plugins + all kernel services already use `BusClient` exclusively
+- `BusClient` already dispatches on URL scheme (`ws://` → WsClient, `nats://` → async_nats)
+- Changing `nats://localhost:4222` to `ws://localhost:9000` in config is literally all plugins need
+
+---
+
+## Step 1: Add In-Process Backend to BusClient
+
+**Why first:** The kernel should use `EventBus` directly (no WS round-trip to itself).
+
+**Files:**
+- `seidrum-common/Cargo.toml` — add `seidrum-eventbus` as a regular dependency
+- `seidrum-common/src/bus_client.rs` — add `BackendHandle::InProcess(Arc<dyn EventBus>)` variant
+
+**Changes:**
+1. Add `InProcess` variant to `BackendHandle` enum
+2. Add `BusClient::from_bus(bus: Arc<dyn EventBus>, source: &str) -> Self` constructor
+3. Add `InProcess` match arms in `publish_bytes`, `request_bytes`, `subscribe`, `is_connected`
+4. The `subscribe` arm bridges `eventbus::Subscription.rx` → `WsMessage` via a converter task (same pattern as the existing NATS bridge)
+
+**Default subscribe opts:** `SubscriptionMode::Async`, `ChannelConfig::InProcess`, priority `10`, timeout `5s`, no filter
+
+**Test:** unit test that creates InMemoryEventStore → EventBusBuilder → BusClient::from_bus → publish/subscribe round-trip
+
+**Complexity:** M (~3-4h)
+
+---
+
+## Step 2: Kernel Startup Swap
+
+**Files:**
+- `seidrum-kernel/Cargo.toml` — add `seidrum-eventbus` dependency
+- `seidrum-kernel/src/main.rs` — replace NATS connection with EventBusBuilder
+
+**Changes in `main.rs`:**
+```
+BEFORE:
+  let nats_client = BusClient::connect(&nats_url, "kernel").await?;
+
+AFTER:
+  let store = Arc::new(RedbEventStore::open(&db_path)?);
+  let handles = EventBusBuilder::new()
+      .storage(store)
+      .with_websocket(ws_addr)
+      .with_retry(RetryConfig::default())
+      .unsafe_allow_ws_dev_mode()
+      .build_with_handles().await?;
+  let nats_client = BusClient::from_bus(handles.bus.clone(), "kernel");
+```
+
+**New env vars:** `EVENTBUS_WS_ADDR` (default `0.0.0.0:9000`), `EVENTBUS_DATA_DIR` (default `data`)
+
+**Variable name `nats_client` kept temporarily** to minimize diff — rename in a follow-up.
+
+**Test:** `cargo build -p seidrum-kernel` + `cargo run -p seidrum-kernel -- serve` starts without NATS
+
+**Complexity:** M (~2-3h)
+
+---
+
+## Step 3: Config and Environment Migration
+
+**Mechanical find-and-replace across 23+ files.**
+
+### 3a. Plugin CLI args (23 files)
+```
+BEFORE: #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
+        nats_url: String,
+        BusClient::connect(&args.nats_url, ...)
+
+AFTER:  #[arg(long, env = "BUS_URL", alias = "nats-url", default_value = "ws://127.0.0.1:9000")]
+        bus_url: String,
+        BusClient::connect(&args.bus_url, ...)
+```
+
+### 3b. Platform config
+- `config/platform.yaml`: `nats_url` → `eventbus_url: ws://localhost:9000`
+- `seidrum-common/src/config.rs`: rename field, add `#[serde(alias = "nats_url")]`
+
+### 3c. Docker-compose files
+- `docker-compose.yml`: remove `nats:` service, add `EVENTBUS_WS_ADDR` to kernel, change plugin `NATS_URL` → `BUS_URL: ws://kernel:9000`
+- `docker-compose.test.yml`: remove `nats:` service, add kernel service with `EVENTBUS_WS_ADDR`
+
+### 3d. Daemon
+- `daemon.rs`: `NATS_URL` → `BUS_URL`, default `ws://localhost:9000`
+
+**Complexity:** S (~2-3h, tedious but mechanical)
+
+---
+
+## Step 4: Drop NATS Backend
+
+**Files:**
+- `seidrum-common/src/bus_client.rs` — remove `BackendHandle::Nats` variant + all match arms
+- `seidrum-common/Cargo.toml` — remove `async-nats = "0.38"`
+
+After this, `nats://` URLs error immediately. Only `ws://` and in-process work.
+
+**Complexity:** S (~30min)
+
+---
+
+## Step 5: Daemon NATS Removal
+
+**Files:** `seidrum-daemon/src/infra.rs`, `setup.rs`, `main.rs`, `daemon.rs`
+
+Remove: `is_nats_reachable()`, `NatsConfig`, `download_nats()`, `start_nats()`, `stop_nats()`, NATS status display, NATS setup wizard steps.
+
+**Complexity:** M (~1-2h)
+
+---
+
+## Step 6: E2E Test Migration
+
+**Files:** `seidrum-e2e/tests/common/mod.rs` + all 6 test files
+
+- `connect_nats()` → `connect_bus()`, env var `TEST_NATS_URL` → `TEST_BUS_URL`
+- `nats_request()` → `bus_request()`
+- Tests require a running kernel (not just NATS) — docker-compose.test.yml provides it
+
+**Complexity:** S (~1h)
+
+---
+
+## Step 7: Documentation
+
+- `CLAUDE.md` — NATS references → eventbus
+- `docs/ARCHITECTURE.md` — if it mentions NATS
+- `PHASE5_MIGRATION.md` — mark status complete
+- `PLAN.md` — mark Phase 5 done
+
+**Complexity:** S (~30min)
+
+---
+
+## Dependency Graph
+
+```
+Step 1 → Step 2 → Step 3 → Step 4 → Step 6 → Step 7
+                     ↘ Step 5 → Step 7
+```
+
+## Verification Checkpoints
+
+After each step: `cargo build --workspace` + `cargo test --workspace`
+
+After Step 6: `docker compose -f docker-compose.test.yml up -d` + `cargo test -p seidrum-e2e -- --ignored`
+
+## Total: ~10-14 hours across 7 steps

--- a/crates/core/seidrum-kernel/Cargo.toml
+++ b/crates/core/seidrum-kernel/Cargo.toml
@@ -9,11 +9,10 @@ path = "src/main.rs"
 
 [dependencies]
 seidrum-common = { path = "../seidrum-common" }
+seidrum-eventbus = { path = "../seidrum-eventbus" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
-
-# NATS client
 
 # HTTP client for ArangoDB
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }

--- a/crates/core/seidrum-kernel/src/main.rs
+++ b/crates/core/seidrum-kernel/src/main.rs
@@ -67,17 +67,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Start the kernel daemon: connect to NATS, spawn registry service (and
-/// future brain / orchestrator services), then wait for shutdown.
+/// Start the kernel daemon: build the eventbus, start transports for
+/// remote plugins, spawn kernel services, then wait for shutdown.
 async fn run_serve() -> anyhow::Result<()> {
-    // 1. Resolve NATS URL from config or env.
+    // 1. Load platform config (optional — env vars override).
     let config_path = Path::new("config/platform.yaml");
     let platform_config = load_platform_config(config_path).ok();
-
-    let nats_url = std::env::var("NATS_URL")
-        .ok()
-        .or_else(|| platform_config.as_ref().map(|c| c.nats_url.clone()))
-        .unwrap_or_else(|| "nats://localhost:4222".to_string());
 
     if platform_config.is_none() {
         warn!(
@@ -86,13 +81,38 @@ async fn run_serve() -> anyhow::Result<()> {
         );
     }
 
-    info!("NATS URL: {}", nats_url);
+    // 2. Build the eventbus with WS transport for remote plugins.
+    let ws_addr_str =
+        std::env::var("EVENTBUS_WS_ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
+    let ws_addr: std::net::SocketAddr = ws_addr_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid EVENTBUS_WS_ADDR '{}': {}", ws_addr_str, e))?;
 
-    // 2. Connect to the bus.
-    let nats_client = seidrum_common::bus_client::BusClient::connect(&nats_url, "kernel")
+    let data_dir = std::env::var("EVENTBUS_DATA_DIR").unwrap_or_else(|_| "data".to_string());
+    std::fs::create_dir_all(&data_dir)?;
+    let db_path = format!("{}/eventbus.redb", data_dir);
+
+    let store = std::sync::Arc::new(
+        seidrum_eventbus::storage::redb_store::RedbEventStore::open(&db_path)
+            .map_err(|e| anyhow::anyhow!("failed to open eventbus store at {}: {}", db_path, e))?,
+    );
+
+    let bus_handles = seidrum_eventbus::EventBusBuilder::new()
+        .storage(store)
+        .with_websocket(ws_addr)
+        .with_retry(seidrum_eventbus::delivery::RetryConfig::default())
+        .unsafe_allow_ws_dev_mode()
+        .build_with_handles()
         .await
-        .map_err(|e| anyhow::anyhow!("failed to connect to bus at {}: {}", nats_url, e))?;
-    info!("connected to bus");
+        .map_err(|e| anyhow::anyhow!("failed to build eventbus: {}", e))?;
+
+    info!("eventbus started (WS transport on {})", ws_addr);
+
+    // 3. Create in-process BusClient for kernel services. Variable
+    //    name `nats_client` kept temporarily to minimise diff.
+    let nats_client =
+        seidrum_common::bus_client::BusClient::from_bus(bus_handles.bus.clone(), "kernel");
+    info!("kernel BusClient ready (in-process backend)");
 
     // 3. Spawn the registry service.
     let registry = RegistryService::new();

--- a/crates/plugins/seidrum-api-gateway/src/main.rs
+++ b/crates/plugins/seidrum-api-gateway/src/main.rs
@@ -41,9 +41,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-api-gateway")]
 #[command(about = "HTTP/WebSocket API gateway for external Seidrum plugins")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Listen address for the HTTP/WebSocket server
     #[arg(long, env = "GATEWAY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
@@ -97,8 +97,8 @@ async fn main() -> Result<()> {
     info!(plugin = PLUGIN_ID, "Starting API gateway");
 
     // Connect to NATS
-    let nats = BusClient::connect(&cli.nats_url, PLUGIN_ID).await?;
-    info!(url = %cli.nats_url, "Connected to NATS");
+    let nats = BusClient::connect(&cli.bus_url, PLUGIN_ID).await?;
+    info!(url = %cli.bus_url, "Connected to NATS");
 
     // Register self as a plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-api-gateway/src/main.rs
+++ b/crates/plugins/seidrum-api-gateway/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = BusClient::connect(&cli.bus_url, PLUGIN_ID).await?;
-    info!(url = %cli.bus_url, "Connected to NATS");
+    info!(url = %cli.bus_url, "Connected to bus");
 
     // Register self as a plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-calendar/src/main.rs
+++ b/crates/plugins/seidrum-calendar/src/main.rs
@@ -12,9 +12,9 @@ use tracing::{error, info, warn};
 #[derive(Parser)]
 #[command(name = "seidrum-calendar", about = "Seidrum Google Calendar plugin")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY", default_value = "")]
@@ -338,7 +338,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         calendar_id = %cli.calendar_id,
         poll_interval = cli.poll_interval,
         "Starting seidrum-calendar plugin..."
@@ -347,8 +347,8 @@ async fn main() -> Result<()> {
     let api_key = resolve_google_api_key(&cli.google_api_key)?;
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "calendar").await?;
-    info!("Connected to NATS at {}", cli.nats_url);
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "calendar").await?;
+    info!("Connected to NATS at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-calendar/src/main.rs
+++ b/crates/plugins/seidrum-calendar/src/main.rs
@@ -348,7 +348,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "calendar").await?;
-    info!("Connected to NATS at {}", cli.bus_url);
+    info!("Connected to bus at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-claude-code/src/main.rs
+++ b/crates/plugins/seidrum-claude-code/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-claude-code/src/main.rs
+++ b/crates/plugins/seidrum-claude-code/src/main.rs
@@ -14,9 +14,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-claude-code")]
 #[command(about = "Claude Code CLI as an LLM tool and Telegram command")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Default working directory for Claude Code
     #[arg(long, env = "CLAUDE_WORKING_DIR", default_value = ".")]
@@ -84,11 +84,11 @@ async fn main() -> Result<()> {
     info!(plugin = PLUGIN_ID, "Starting Claude Code plugin");
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "claude-code")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "claude-code")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-cli/src/main.rs
+++ b/crates/plugins/seidrum-cli/src/main.rs
@@ -10,9 +10,9 @@ use tracing::{error, info};
 #[derive(Parser)]
 #[command(name = "seidrum-cli", about = "Seidrum CLI channel plugin")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 }
 
 #[tokio::main]
@@ -21,10 +21,10 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    info!(nats_url = %cli.nats_url, "Starting seidrum-cli plugin...");
+    info!(bus_url = %cli.bus_url, "Starting seidrum-cli plugin...");
 
     // Connect to NATS
-    let nats = BusClient::connect(&cli.nats_url, "cli").await?;
+    let nats = BusClient::connect(&cli.bus_url, "cli").await?;
 
     // Register with kernel
     let registration = PluginRegister {

--- a/crates/plugins/seidrum-code-executor/src/main.rs
+++ b/crates/plugins/seidrum-code-executor/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-code-executor/src/main.rs
+++ b/crates/plugins/seidrum-code-executor/src/main.rs
@@ -19,9 +19,9 @@ const DEFAULT_TIMEOUT_SECONDS: u64 = 10;
 #[command(name = "seidrum-code-executor")]
 #[command(about = "Sandboxed code execution as an LLM tool")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 }
 
 /// Request payload for code execution.
@@ -55,11 +55,11 @@ async fn main() -> Result<()> {
     info!(plugin = PLUGIN_ID, "Starting code executor plugin");
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "code-executor")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "code-executor")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-content-ingester/src/main.rs
+++ b/crates/plugins/seidrum-content-ingester/src/main.rs
@@ -12,9 +12,9 @@ use tracing::{error, info, warn};
     about = "Seidrum content ingester plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Embedding provider
     #[arg(long, env = "EMBEDDING_PROVIDER", default_value = "openai")]
@@ -106,14 +106,14 @@ async fn main() -> Result<()> {
     }
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         embedding_provider = %cli.embedding_provider,
         has_api_key,
         "Starting seidrum-content-ingester plugin..."
     );
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "content-ingester")
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "content-ingester")
         .await
         .context("failed to connect to NATS")?;
     info!("Connected to NATS");

--- a/crates/plugins/seidrum-content-ingester/src/main.rs
+++ b/crates/plugins/seidrum-content-ingester/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "content-ingester")
         .await
         .context("failed to connect to NATS")?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Register with kernel
     let register = PluginRegister {

--- a/crates/plugins/seidrum-email/src/main.rs
+++ b/crates/plugins/seidrum-email/src/main.rs
@@ -14,9 +14,9 @@ use tracing::{error, info, warn};
 #[derive(Parser)]
 #[command(name = "seidrum-email", about = "Seidrum Email channel plugin")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// IMAP server hostname
     #[arg(long, env = "IMAP_HOST")]
@@ -281,7 +281,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         imap_host = %cli.imap_host,
         smtp_host = %cli.smtp_host,
         poll_interval = cli.poll_interval,
@@ -289,8 +289,8 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "email").await?;
-    info!("Connected to NATS at {}", cli.nats_url);
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "email").await?;
+    info!("Connected to NATS at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {
@@ -363,7 +363,7 @@ async fn main() -> Result<()> {
     // Spawn IMAP polling task
     let imap_handle = tokio::spawn(async move {
         let poll_cli = Cli {
-            nats_url: String::new(),
+            bus_url: String::new(),
             imap_host,
             imap_port,
             imap_user,
@@ -393,7 +393,7 @@ async fn main() -> Result<()> {
 
     let outbound_handle = tokio::spawn(async move {
         let send_cli = Cli {
-            nats_url: String::new(),
+            bus_url: String::new(),
             imap_host: String::new(),
             imap_port: 0,
             imap_user: String::new(),

--- a/crates/plugins/seidrum-email/src/main.rs
+++ b/crates/plugins/seidrum-email/src/main.rs
@@ -290,7 +290,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "email").await?;
-    info!("Connected to NATS at {}", cli.bus_url);
+    info!("Connected to bus at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-entity-extractor/src/main.rs
+++ b/crates/plugins/seidrum-entity-extractor/src/main.rs
@@ -16,9 +16,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-entity-extractor")]
 #[command(about = "Extracts entities from stored content using LLM")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY")]
@@ -125,11 +125,11 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "entity-extractor")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "entity-extractor")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-entity-extractor/src/main.rs
+++ b/crates/plugins/seidrum-entity-extractor/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-event-emitter/src/main.rs
+++ b/crates/plugins/seidrum-event-emitter/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-event-emitter/src/main.rs
+++ b/crates/plugins/seidrum-event-emitter/src/main.rs
@@ -15,9 +15,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-event-emitter")]
 #[command(about = "Parses LLM responses for structured actions and emits events")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 }
 
 /// A task block extracted from LLM response.
@@ -86,11 +86,11 @@ async fn main() -> Result<()> {
     info!(plugin = PLUGIN_ID, "Starting event emitter plugin");
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "event-emitter")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "event-emitter")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-fact-extractor/src/main.rs
+++ b/crates/plugins/seidrum-fact-extractor/src/main.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-fact-extractor/src/main.rs
+++ b/crates/plugins/seidrum-fact-extractor/src/main.rs
@@ -16,9 +16,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-fact-extractor")]
 #[command(about = "Extracts factual claims from content about entities using LLM")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY")]
@@ -128,11 +128,11 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "fact-extractor")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "fact-extractor")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-feedback-extractor/src/main.rs
+++ b/crates/plugins/seidrum-feedback-extractor/src/main.rs
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
     // Connect to NATS
     let nats =
         seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "feedback-extractor").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Initialize response buffer (LRU cache)
     let response_buffer: Arc<Mutex<LruCache<String, ResponseContext>>> = Arc::new(Mutex::new(

--- a/crates/plugins/seidrum-feedback-extractor/src/main.rs
+++ b/crates/plugins/seidrum-feedback-extractor/src/main.rs
@@ -24,9 +24,9 @@ use seidrum_common::events::{
     about = "Seidrum feedback extraction and analysis plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Optional LLM provider for ambiguous feedback classification
     /// E.g., "google", "anthropic"
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         llm_provider = ?cli.llm_provider,
         response_buffer_size = cli.response_buffer_size,
         heuristic_threshold = cli.heuristic_threshold,
@@ -176,7 +176,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats =
-        seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "feedback-extractor").await?;
+        seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "feedback-extractor").await?;
     info!("Connected to NATS");
 
     // Initialize response buffer (LRU cache)

--- a/crates/plugins/seidrum-graph-context-loader/src/main.rs
+++ b/crates/plugins/seidrum-graph-context-loader/src/main.rs
@@ -19,9 +19,9 @@ use tracing::{error, info, warn};
     about = "Seidrum graph context loader plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Graph traversal depth (hops)
     #[arg(long, env = "GRAPH_DEPTH", default_value = "3")]
@@ -403,7 +403,7 @@ async fn main() -> Result<()> {
     }
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         graph_depth = cli.graph_depth,
         max_facts = cli.max_facts,
         min_confidence = cli.min_confidence,
@@ -413,10 +413,9 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let nats =
-        seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "graph-context-loader")
-            .await
-            .context("failed to connect to NATS")?;
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "graph-context-loader")
+        .await
+        .context("failed to connect to NATS")?;
     info!("Connected to NATS");
 
     // Register with kernel

--- a/crates/plugins/seidrum-graph-context-loader/src/main.rs
+++ b/crates/plugins/seidrum-graph-context-loader/src/main.rs
@@ -416,7 +416,7 @@ async fn main() -> Result<()> {
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "graph-context-loader")
         .await
         .context("failed to connect to NATS")?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Register with kernel
     let register = PluginRegister {

--- a/crates/plugins/seidrum-llm-anthropic/src/main.rs
+++ b/crates/plugins/seidrum-llm-anthropic/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     // Connect to NATS
     let nats =
         seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-anthropic").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/crates/plugins/seidrum-llm-anthropic/src/main.rs
+++ b/crates/plugins/seidrum-llm-anthropic/src/main.rs
@@ -27,9 +27,9 @@ use translator::{
     about = "Seidrum Anthropic LLM provider plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Anthropic API key
     #[arg(long, env = "ANTHROPIC_API_KEY")]
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         model = %cli.model,
         max_tool_rounds = cli.max_tool_rounds,
         "Starting seidrum-llm-anthropic provider plugin..."
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats =
-        seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "llm-anthropic").await?;
+        seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-anthropic").await?;
     info!("Connected to NATS");
 
     // Publish plugin registration

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-google").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -30,9 +30,9 @@ use translator::{
     about = "Seidrum Google Gemini LLM provider plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY")]
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         model = %cli.model,
         max_tool_rounds = cli.max_tool_rounds,
         "Starting seidrum-llm-google provider plugin..."
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
     let api_key = resolve_google_api_key(&cli.google_api_key)?;
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "llm-google").await?;
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-google").await?;
     info!("Connected to NATS");
 
     // Publish plugin registration

--- a/crates/plugins/seidrum-llm-ollama/src/main.rs
+++ b/crates/plugins/seidrum-llm-ollama/src/main.rs
@@ -27,9 +27,9 @@ use translator::{
     about = "Seidrum Ollama LLM provider plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Ollama base URL
     #[arg(long, env = "OLLAMA_URL", default_value = "http://localhost:11434")]
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         ollama_url = %cli.ollama_url,
         model = %cli.model,
         max_tool_rounds = cli.max_tool_rounds,
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "llm-ollama").await?;
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-ollama").await?;
     info!("Connected to NATS");
 
     // Publish plugin registration

--- a/crates/plugins/seidrum-llm-ollama/src/main.rs
+++ b/crates/plugins/seidrum-llm-ollama/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-ollama").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/crates/plugins/seidrum-llm-openai/src/main.rs
+++ b/crates/plugins/seidrum-llm-openai/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-openai").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/crates/plugins/seidrum-llm-openai/src/main.rs
+++ b/crates/plugins/seidrum-llm-openai/src/main.rs
@@ -27,9 +27,9 @@ use translator::{
     about = "Seidrum OpenAI LLM provider plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// OpenAI API key
     #[arg(long, env = "OPENAI_API_KEY")]
@@ -59,14 +59,14 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         model = %cli.model,
         max_tool_rounds = cli.max_tool_rounds,
         "Starting seidrum-llm-openai provider plugin..."
     );
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "llm-openai").await?;
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-openai").await?;
     info!("Connected to NATS");
 
     // Publish plugin registration

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -24,9 +24,9 @@ use context_assembly::{assemble_context, ContextConfig};
 #[derive(Parser)]
 #[command(name = "seidrum-llm-router", about = "Seidrum LLM router plugin")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Default LLM provider to use
     #[arg(long, env = "LLM_PROVIDER", default_value = "google")]
@@ -144,13 +144,13 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         provider = %cli.provider,
         "Starting seidrum-llm-router plugin..."
     );
 
     // Connect to NATS
-    let nats = seidrum_common::bus_client::BusClient::connect(&cli.nats_url, "llm-router").await?;
+    let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-router").await?;
     info!("Connected to NATS");
 
     // Publish plugin registration
@@ -253,7 +253,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Pull the next message from an async-nats subscriber.
+/// Pull the next message from a bus subscription.
 async fn futures_next(
     sub: &mut seidrum_common::bus_client::Subscription,
 ) -> Option<seidrum_common::bus_client::Message> {

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -151,7 +151,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = seidrum_common::bus_client::BusClient::connect(&cli.bus_url, "llm-router").await?;
-    info!("Connected to NATS");
+    info!("Connected to bus");
 
     // Publish plugin registration
     let register = serde_json::json!({

--- a/crates/plugins/seidrum-notification/src/main.rs
+++ b/crates/plugins/seidrum-notification/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-notification/src/main.rs
+++ b/crates/plugins/seidrum-notification/src/main.rs
@@ -14,9 +14,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-notification")]
 #[command(about = "Cross-channel notification plugin")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Default notification channel: "telegram" or "cli"
     #[arg(long, env = "NOTIFICATION_CHANNEL", default_value = "telegram")]
@@ -54,11 +54,11 @@ async fn main() -> Result<()> {
     info!(plugin = PLUGIN_ID, "Starting notification plugin");
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "notification")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "notification")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-response-formatter/src/main.rs
+++ b/crates/plugins/seidrum-response-formatter/src/main.rs
@@ -16,9 +16,9 @@ use seidrum_common::events::{ChannelOutbound, EventEnvelope, LlmResponse, Plugin
     about = "Seidrum response formatter plugin"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -125,10 +125,10 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    info!(nats_url = %cli.nats_url, "Starting seidrum-response-formatter plugin...");
+    info!(bus_url = %cli.bus_url, "Starting seidrum-response-formatter plugin...");
 
     // Connect to NATS
-    let nats = BusClient::connect(&cli.nats_url, "response-formatter").await?;
+    let nats = BusClient::connect(&cli.bus_url, "response-formatter").await?;
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/crates/plugins/seidrum-scope-classifier/src/main.rs
+++ b/crates/plugins/seidrum-scope-classifier/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-scope-classifier/src/main.rs
+++ b/crates/plugins/seidrum-scope-classifier/src/main.rs
@@ -16,9 +16,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-scope-classifier")]
 #[command(about = "Classifies content into scopes using LLM")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY")]
@@ -120,11 +120,11 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "scope-classifier")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "scope-classifier")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-task-detector/src/main.rs
+++ b/crates/plugins/seidrum-task-detector/src/main.rs
@@ -13,9 +13,9 @@ const PLUGIN_VERSION: &str = "0.1.0";
 #[command(name = "seidrum-task-detector")]
 #[command(about = "Detects actionable tasks from LLM responses and creates them in the brain")]
 struct Args {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://127.0.0.1:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Google API key (falls back to OpenClaw auth-profiles.json)
     #[arg(long, env = "GOOGLE_API_KEY")]
@@ -125,11 +125,11 @@ async fn main() -> Result<()> {
     );
 
     // Connect to NATS
-    let client = seidrum_common::bus_client::BusClient::connect(&args.nats_url, "task-detector")
+    let client = seidrum_common::bus_client::BusClient::connect(&args.bus_url, "task-detector")
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.nats_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to NATS");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-task-detector/src/main.rs
+++ b/crates/plugins/seidrum-task-detector/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to NATS")?;
 
-    info!(url = %args.bus_url, "Connected to NATS");
+    info!(url = %args.bus_url, "Connected to bus");
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-telegram/src/main.rs
+++ b/crates/plugins/seidrum-telegram/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
 
     // Connect to NATS
     let nats = BusClient::connect(&cli.bus_url, "telegram").await?;
-    info!("Connected to NATS at {}", cli.bus_url);
+    info!("Connected to bus at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-telegram/src/main.rs
+++ b/crates/plugins/seidrum-telegram/src/main.rs
@@ -21,9 +21,9 @@ use crate::inbound::InboundConfig;
 #[derive(Parser)]
 #[command(name = "seidrum-telegram", about = "Seidrum Telegram channel plugin")]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Telegram Bot API token
     #[arg(long, env = "TELEGRAM_TOKEN")]
@@ -59,14 +59,14 @@ async fn main() -> Result<()> {
     let allowed_users = parse_allowed_users(&cli.allowed_users);
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         allowed_users_count = allowed_users.len(),
         "Starting seidrum-telegram plugin..."
     );
 
     // Connect to NATS
-    let nats = BusClient::connect(&cli.nats_url, "telegram").await?;
-    info!("Connected to NATS at {}", cli.nats_url);
+    let nats = BusClient::connect(&cli.bus_url, "telegram").await?;
+    info!("Connected to NATS at {}", cli.bus_url);
 
     // Register plugin
     let register = PluginRegister {

--- a/crates/plugins/seidrum-tool-dispatcher/src/main.rs
+++ b/crates/plugins/seidrum-tool-dispatcher/src/main.rs
@@ -23,9 +23,9 @@ use seidrum_common::events::{
     about = "Seidrum capability dispatcher plugin — routes capability.call requests to owning plugins"
 )]
 struct Cli {
-    /// NATS server URL
-    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
-    nats_url: String,
+    /// Bus server URL
+    #[arg(long, env = "BUS_URL", default_value = "ws://127.0.0.1:9000")]
+    bus_url: String,
 
     /// Timeout for tool calls in seconds
     #[arg(long, env = "TOOL_CALL_TIMEOUT", default_value = "30")]
@@ -62,13 +62,13 @@ async fn main() -> Result<()> {
     let timeout = Duration::from_secs(cli.tool_call_timeout);
 
     info!(
-        nats_url = %cli.nats_url,
+        bus_url = %cli.bus_url,
         timeout_secs = cli.tool_call_timeout,
         "Starting seidrum-tool-dispatcher plugin..."
     );
 
     // Connect to NATS
-    let nats = BusClient::connect(&cli.nats_url, "tool-dispatcher").await?;
+    let nats = BusClient::connect(&cli.bus_url, "tool-dispatcher").await?;
 
     // Publish plugin registration
     let register = PluginRegister {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,11 +3,7 @@
 # Then:  cargo test -p seidrum-e2e -- --ignored
 
 services:
-  nats:
-    image: nats:latest
     command: "--jetstream --store_dir /data"
-    ports:
-      - "4222:4222"
 
   arangodb:
     image: arangodb:3.12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
   # --- Infrastructure ---
-  nats:
-    image: nats:latest
     command: ["--jetstream", "--store_dir", "/data"]
-    ports: ["4222:4222", "8222:8222"]
-    volumes: ["nats-data:/data"]
     restart: unless-stopped
 
   arangodb:
@@ -22,10 +18,10 @@ services:
       dockerfile: crates/core/seidrum-kernel/Dockerfile
     command: ["serve"]
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       ARANGO_URL: http://arangodb:8529
       ARANGO_PASSWORD: ${ARANGO_PASSWORD:-seidrum_dev}
-    depends_on: [nats, arangodb]
+    depends_on: [arangodb]
     restart: unless-stopped
 
   # --- Plugins ---
@@ -34,10 +30,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-telegram/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       TELEGRAM_TOKEN: ${TELEGRAM_TOKEN}
       TELEGRAM_ALLOWED_USERS: ${TELEGRAM_ALLOWED_USERS}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   llm-router:
@@ -45,10 +41,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-llm-router/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       LLM_ROUTING_STRATEGY: ${LLM_ROUTING_STRATEGY:-fallback}
       LLM_FALLBACK_PROVIDERS: ${LLM_FALLBACK_PROVIDERS:-google,openai,anthropic}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   llm-google:
@@ -56,9 +52,9 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-llm-google/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   tool-dispatcher:
@@ -66,8 +62,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-tool-dispatcher/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   content-ingester:
@@ -75,10 +71,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-content-ingester/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   entity-extractor:
@@ -86,9 +82,9 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-entity-extractor/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   fact-extractor:
@@ -96,9 +92,9 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-fact-extractor/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   graph-context-loader:
@@ -106,8 +102,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-graph-context-loader/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   scope-classifier:
@@ -115,9 +111,9 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-scope-classifier/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   response-formatter:
@@ -125,8 +121,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-response-formatter/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   event-emitter:
@@ -134,8 +130,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-event-emitter/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   task-detector:
@@ -143,9 +139,9 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-task-detector/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   code-executor:
@@ -153,8 +149,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-code-executor/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   notification:
@@ -162,10 +158,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-notification/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       NOTIFICATION_CHANNEL: ${NOTIFICATION_CHANNEL:-telegram}
       NOTIFICATION_LEVEL: ${NOTIFICATION_LEVEL:-all}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   llm-openai:
@@ -173,10 +169,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-llm-openai/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       LLM_MODEL: ${LLM_OPENAI_MODEL:-gpt-4o}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   llm-anthropic:
@@ -184,10 +180,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-llm-anthropic/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       LLM_MODEL: ${LLM_ANTHROPIC_MODEL:-claude-sonnet-4-6}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   llm-ollama:
@@ -195,10 +191,10 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-llm-ollama/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       OLLAMA_URL: ${OLLAMA_URL:-http://ollama:11434}
       LLM_MODEL: ${LLM_OLLAMA_MODEL:-llama3.2}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   feedback-extractor:
@@ -206,8 +202,8 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-feedback-extractor/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
-    depends_on: [nats]
+      BUS_URL: ws://kernel:9000
+    depends_on: [kernel]
     restart: unless-stopped
 
   email:
@@ -215,7 +211,7 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-email/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       IMAP_HOST: ${IMAP_HOST}
       IMAP_PORT: ${IMAP_PORT:-993}
       IMAP_USER: ${IMAP_USER}
@@ -226,7 +222,7 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       SMTP_FROM: ${SMTP_FROM}
       EMAIL_POLL_INTERVAL: ${EMAIL_POLL_INTERVAL:-60}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
   calendar:
@@ -234,13 +230,12 @@ services:
       context: .
       dockerfile: crates/plugins/seidrum-calendar/Dockerfile
     environment:
-      NATS_URL: nats://nats:4222
+      BUS_URL: ws://kernel:9000
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       GOOGLE_CALENDAR_ID: ${GOOGLE_CALENDAR_ID:-primary}
       CALENDAR_POLL_INTERVAL: ${CALENDAR_POLL_INTERVAL:-300}
-    depends_on: [nats]
+    depends_on: [kernel]
     restart: unless-stopped
 
 volumes:
-  nats-data:
   arango-data:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ plugin subscriptions — not from a central orchestrator dictating order.
 
 There are 5 concepts:
 
-1. **Events** — typed NATS messages. The universal communication primitive.
+1. **Events** — typed bus messages. The universal communication primitive.
 2. **Plugins** — independent processes that consume and produce typed events.
 3. **Capabilities** — tools, commands, or other invocable functions registered by plugins.
 4. **Workflows** — YAML-defined custom wiring that connects plugins, defines agents, and adds routing rules.
@@ -55,7 +55,7 @@ A plugin is an independent process that:
 
 1. Connects to NATS
 2. Registers itself: declares what event **types** it consumes and produces
-3. Subscribes to its declared NATS subjects
+3. Subscribes to its declared bus subjects
 4. Processes events and publishes results
 5. Optionally registers capabilities (tools, commands)
 6. Responds to health checks
@@ -74,7 +74,7 @@ not architectural distinctions:
 | Category | Examples | Pattern |
 |----------|----------|---------|
 | Channel | telegram, cli, email, calendar | Bidirectional: produces `channel.*.inbound`, consumes `channel.*.outbound` |
-| LLM Provider | llm-google, llm-openai, llm-ollama | Consumes `llm.provider.{id}`, produces reply via NATS request/reply |
+| LLM Provider | llm-google, llm-openai, llm-ollama | Consumes `llm.provider.{id}`, produces reply via bus request/reply |
 | Processing | content-ingester, entity-extractor | Consumes one event type, produces another |
 | Infrastructure | llm-router, tool-dispatcher, response-formatter | Orchestration and routing |
 
@@ -86,7 +86,7 @@ The LLM Router is a plugin that:
 - Produces: `llm.response`
 - Assembles context (prompt template, token budgeting)
 - Queries the capability registry for available tools
-- Dispatches to an LLM provider via `llm.provider.{id}` (NATS request/reply)
+- Dispatches to an LLM provider via `llm.provider.{id}` (bus request/reply)
 - Receives the provider's response and publishes `llm.response`
 
 The router speaks **unified format only**. It never touches provider-specific
@@ -98,7 +98,7 @@ temperature, max tokens.
 LLM Provider plugins are adapters:
 
 - Consume: `llm.provider.{id}` (unified format)
-- Produce: reply via NATS request/reply (unified format)
+- Produce: reply via bus request/reply (unified format)
 - Internally: translate unified → provider API format, call HTTP API
 - Handle the **tool call loop** internally:
   - If the LLM returns a function call → translate to unified `capability.call`
@@ -113,7 +113,7 @@ Each provider has its own config YAML (API keys, model defaults, etc.).
 
 Routes `capability.call` events to the owning plugin:
 
-- Consumes: `capability.call` (NATS request/reply)
+- Consumes: `capability.call` (bus request/reply)
 - Looks up which plugin owns the capability
 - Forwards to `capability.call.{plugin_id}`
 - Returns the result
@@ -433,7 +433,7 @@ operates in the data flow.
 
 | Concept | What it is | Who defines it |
 |---------|-----------|----------------|
-| Event | Typed NATS message | Plugins emit/consume |
+| Event | Typed bus message | Plugins emit/consume |
 | Plugin | Code that runs, self-registers | Developer |
 | Capability | Registered tool/command/future | Plugins register |
 | Data flow graph | Emerges from plugin registrations | Automatic |

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -104,7 +104,7 @@ tool-use rounds.
 
 ## Brain Access from Plugins
 
-Plugins never connect to ArangoDB. They use NATS request/reply to the kernel:
+Plugins never connect to ArangoDB. They use bus request/reply to the kernel:
 
 ```rust
 // Read: query the brain
@@ -402,20 +402,20 @@ Behavior:
 
 ```
 Consumes: capability.call
-Produces: (forwards to owning plugin via NATS request/reply)
+Produces: (forwards to owning plugin via bus request/reply)
 
 Behavior:
 1. Subscribe to capability.call events
 2. Look up the target capability from an in-memory cache of registered
    capabilities (populated from capability.register events)
 3. Forward the call payload to the owning plugin's call_subject via
-   NATS request/reply with a 30s timeout
+   bus request/reply with a 30s timeout
 4. Return the plugin's response to the original caller
 5. If the target capability is unknown or the owning plugin does not
    respond within the timeout, return an error payload
 
 Config:
-  timeout: NATS request/reply timeout (default: 30s)
+  timeout: bus request/reply timeout (default: 30s)
 ```
 
 ### code-executor
@@ -616,8 +616,8 @@ and [EVENT_CATALOG.md](EVENT_CATALOG.md) for the full REST API reference.
 - Multi-tenant: entries include `user_id` for per-user accountability
 
 **Multi-User Support:**
-- User CRUD via `brain.user.*` NATS subjects (backed by `users` collection)
-- User-scoped API keys via `brain.apikey.*` NATS subjects (backed by
+- User CRUD via `brain.user.*` bus subjects (backed by `users` collection)
+- User-scoped API keys via `brain.apikey.*` bus subjects (backed by
   `api_keys` collection)
 - Endpoints: `GET /api/v1/users/me`, `GET /api/v1/users` (admin),
   `PUT /api/v1/users/:id/role` (admin), `DELETE /api/v1/users/:id` (admin)
@@ -650,7 +650,7 @@ and [EVENT_CATALOG.md](EVENT_CATALOG.md) for the full REST API reference.
 - Health: `GET /health` (public, no auth)
 
 **CLI arguments:**
-- `--nats-url` (env: `NATS_URL`, default: `nats://localhost:4222`)
+- `--bus-url` (env: `NATS_URL`, default: `nats://localhost:4222`)
 - `--listen-addr` (env: `GATEWAY_LISTEN_ADDR`, default: `0.0.0.0:8080`)
 - `--api-key` (env: `GATEWAY_API_KEY`, required)
 - `--jwt-secret` (env: `GATEWAY_JWT_SECRET`, optional — enables JWT auth)
@@ -795,7 +795,7 @@ The consciousness service registers three skill-related capabilities:
 | `load-skill` | Explicitly load a skill by ID into the current conversation context, ensuring it persists across turns. |
 | `save-skill` | Create a new skill from the current conversation (for learned behavior). Stores description, snippet, source, and tags. |
 
-These capabilities are available to all agents via `capability.call.consciousness` and use the `brain.skill.*` NATS subjects documented in the [Event Catalog](EVENT_CATALOG.md).
+These capabilities are available to all agents via `capability.call.consciousness` and use the `brain.skill.*` bus subjects documented in the [Event Catalog](EVENT_CATALOG.md).
 
 ### Skill YAML Format
 

--- a/docs/PRESET_BUNDLES.md
+++ b/docs/PRESET_BUNDLES.md
@@ -341,4 +341,4 @@ Following Seidrum conventions:
 - No `unwrap()` in production code
 - All event structs derive `Serialize, Deserialize, Debug, Clone`
 - Scope enforcement on brain queries
-- NATS event publishing for state changes
+- bus event publishing for state changes


### PR DESCRIPTION
## Summary

**NATS is gone.** The entire Seidrum platform now runs on seidrum-eventbus. `async-nats` is removed from the dependency tree. No NATS server is required.

This is the actual migration — the culmination of PRs #29 (eventbus crate), #30 (BusClient abstraction), and #31 (WsClient adapter).

## What changed (7 steps, 1 commit)

### Step 1: In-process BusClient backend
- `BusClient::from_bus(bus, "kernel")` wraps `Arc<dyn EventBus>` directly
- Kernel services get zero-overhead in-process bus access (no WS round-trip)
- 5 new e2e tests verify all operations (publish/subscribe, request/reply, typed, envelope, is_connected)

### Step 2: Kernel startup swap
- `main.rs` creates `EventBusBuilder` with `RedbEventStore` + WS transport
- New env vars: `EVENTBUS_WS_ADDR` (default `0.0.0.0:9000`), `EVENTBUS_DATA_DIR` (default `data/`)
- Plugins connect to the kernel via `ws://`

### Step 3: Config migration (23 plugins + daemon + platform.yaml)
- `NATS_URL` → `BUS_URL`, default `ws://127.0.0.1:9000`
- `PlatformConfig.nats_url` → `.eventbus_url` (with `#[serde(alias = "nats_url")]` for back-compat)

### Step 4: Drop NATS backend
- Removed `BackendHandle::Nats` from `bus_client.rs`
- Removed `async-nats` from `seidrum-common/Cargo.toml`
- `BusClient::connect("nats://...")` now returns an immediate error

### Step 5: Daemon NATS cleanup
- Updated comments/strings, renamed NATS data paths to eventbus

### Step 6: E2E test migration
- `connect_nats()` → `connect_bus()`, `nats_request()` → `bus_request()`

### Step 7: Documentation
- CLAUDE.md updated (NATS → eventbus throughout)
- PHASE5_STEP3_PLAN.md included as persistent record

## Files changed

43 files, +663/-652 (nearly net-zero — it's a swap, not an addition)

## Verification

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all pass
- [x] `cargo fmt --check` — clean
- [x] `grep -r 'async.nats' crates/ | grep -v target | grep -v eventbus` → **zero matches**
- [ ] CI green

## What's next

- **Phase 6**: Interceptor-based plugin patterns + examples (per PLAN.md)
- **Issue #32**: WsClient auto-reconnect with exponential backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)