### PR TITLE
feat(ws-client): reconnect and restore subscriptions

### DIFF
--- a/crates/core/seidrum-common/src/ws_client.rs
+++ b/crates/core/seidrum-common/src/ws_client.rs
@@ -327,7 +327,9 @@ impl WsClient {
                 return Ok(());
             }
             if tokio::time::Instant::now() >= deadline {
-                return Err(anyhow::anyhow!("timed out connecting to eventbus WS"));
+                return Err(anyhow::anyhow!(
+                    "failed to connect or timed out connecting to eventbus WS"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/crates/core/seidrum-common/src/ws_client.rs
+++ b/crates/core/seidrum-common/src/ws_client.rs
@@ -2,23 +2,12 @@
 //!
 //! `WsClient` speaks the JSON protocol defined in
 //! `seidrum-eventbus/src/transport/ws.rs` and exposes an API shape
-//! that mirrors [`super::bus_client::BusClient`]. In Phase 5 Step 2,
-//! `BusClient` will be refactored to delegate to `WsClient` (for
-//! plugin processes) or an in-process `EventBus` (for the kernel).
+//! that mirrors [`super::bus_client::BusClient`].
 //!
-//! **Architecture:**
-//! ```text
-//! WsClient
-//! ├── writer_tx: mpsc::Sender<String>    ← methods push JSON frames here
-//! ├── reader task (background)           ← demuxes incoming frames
-//! │   ├── Event → subscribers[subscription_id].send(msg)
-//! │   ├── Published/Subscribed/ReplyResult/Error → pending[correlation_id].send(reply)
-//! │   └── connection closed → mark unhealthy
-//! └── subscribers: Arc<DashMap<String, mpsc::Sender<WsMessage>>>
-//! ```
-//!
-//! One WS connection per client. No auto-reconnect in v1; operations
-//! fail immediately if the connection drops.
+//! The client owns a small connection manager task. Subscriptions are tracked
+//! by stable client-side ids so a reconnect can re-send subscribe operations,
+//! learn the new transient server-assigned ids, and keep existing
+//! [`WsSubscription`] handles alive.
 
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -27,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, info, warn};
 
@@ -53,7 +43,8 @@ pub struct WsSubscription {
     /// Channel for receiving messages. `pub(crate)` so `BusClient` can
     /// construct a `WsSubscription` from the NATS bridge task.
     pub(crate) rx: mpsc::Receiver<WsMessage>,
-    /// The bus-assigned subscription id (used for unsubscribe).
+    /// Stable client-side subscription id. Server-assigned ids are transient
+    /// and may change after reconnect.
     pub id: String,
 }
 
@@ -130,11 +121,6 @@ enum ServerMsg {
         message: String,
         correlation_id: Option<String>,
     },
-    // --- Variants the client doesn't use but the server may send ---
-    // Listed so `serde_json::from_str` doesn't fail on them. The reader
-    // silently ignores these. If any carry a `correlation_id`, we don't
-    // route them — the pending entry will eventually be cleaned up by
-    // the caller's timeout or drop.
     #[serde(rename = "channel_registered")]
     ChannelRegistered {
         #[allow(dead_code)]
@@ -179,179 +165,117 @@ enum PendingReply {
     Error(String),        // error message
 }
 
+#[derive(Debug)]
+struct SubscriptionState {
+    stable_id: String,
+    pattern: String,
+    server_id: Option<String>,
+    sender: mpsc::Sender<WsMessage>,
+}
+
+#[derive(Default, Debug)]
+struct SubscriberRegistry {
+    by_stable_id: HashMap<String, SubscriptionState>,
+    server_to_stable: HashMap<String, String>,
+}
+
+impl SubscriberRegistry {
+    fn insert(&mut self, stable_id: String, pattern: String, sender: mpsc::Sender<WsMessage>) {
+        self.by_stable_id.insert(
+            stable_id.clone(),
+            SubscriptionState {
+                stable_id,
+                pattern,
+                server_id: None,
+                sender,
+            },
+        );
+    }
+
+    fn bind_server_id(&mut self, stable_id: &str, server_id: String) -> bool {
+        let Some(state) = self.by_stable_id.get_mut(stable_id) else {
+            return false;
+        };
+        if let Some(old_server_id) = state.server_id.replace(server_id.clone()) {
+            self.server_to_stable.remove(&old_server_id);
+        }
+        self.server_to_stable
+            .insert(server_id, state.stable_id.clone());
+        true
+    }
+
+    fn remove(&mut self, stable_id: &str) -> Option<SubscriptionState> {
+        let state = self.by_stable_id.remove(stable_id)?;
+        if let Some(server_id) = &state.server_id {
+            self.server_to_stable.remove(server_id);
+        }
+        Some(state)
+    }
+
+    fn get_sender_by_server_id(&self, server_id: &str) -> Option<mpsc::Sender<WsMessage>> {
+        let stable_id = self.server_to_stable.get(server_id)?;
+        self.by_stable_id
+            .get(stable_id)
+            .map(|state| state.sender.clone())
+    }
+
+    fn active_patterns(&self) -> Vec<(String, String)> {
+        self.by_stable_id
+            .values()
+            .map(|state| (state.stable_id.clone(), state.pattern.clone()))
+            .collect()
+    }
+
+    fn clear_server_ids(&mut self) {
+        self.server_to_stable.clear();
+        for state in self.by_stable_id.values_mut() {
+            state.server_id = None;
+        }
+    }
+}
+
+enum ManagerCommand {
+    Send(String),
+}
+
+/// Default request timeout in milliseconds. Used by `request_bytes`
+/// and `request` unless overridden via `with_request_timeout`.
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 5000;
+const DEFAULT_RECONNECT_INITIAL_BACKOFF_MS: u64 = 100;
+const DEFAULT_RECONNECT_MAX_BACKOFF_MS: u64 = 30_000;
+const RESUBSCRIBE_CID_PREFIX: &str = "__seidrum_resubscribe__:";
+
 /// WebSocket client for the seidrum-eventbus transport server.
 ///
 /// Created via [`WsClient::connect`]. All methods are `&self` — the
 /// client is `Clone`-safe (internally Arc'd).
-/// Default request timeout in milliseconds. Used by `request_bytes`
-/// and `request` unless overridden via `with_request_timeout`.
-const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 5000;
-
 #[derive(Clone)]
 pub struct WsClient {
-    writer_tx: mpsc::Sender<String>,
+    manager_tx: mpsc::Sender<ManagerCommand>,
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>,
-    subscribers: Arc<Mutex<HashMap<String, mpsc::Sender<WsMessage>>>>,
+    subscribers: Arc<Mutex<SubscriberRegistry>>,
     connected: Arc<AtomicBool>,
     pub source: String,
     /// Per-request timeout in milliseconds. Sent to the server in the
     /// `Request` operation. Configurable via [`Self::with_request_timeout`].
     request_timeout_ms: u64,
+    reconnect_initial_backoff: Duration,
+    reconnect_max_backoff: Duration,
+    max_reconnect_attempts: Option<usize>,
 }
 
 impl WsClient {
     /// Connect to the eventbus WS server at `url` (e.g. `ws://127.0.0.1:9000`).
     /// `source` is the plugin/service identifier stamped onto envelopes.
     pub async fn connect(url: &str, source: &str) -> Result<Self> {
-        let (ws_stream, _) = tokio_tungstenite::connect_async(url)
-            .await
-            .with_context(|| format!("failed to connect to eventbus WS at {url}"))?;
-        info!(url, source, "connected to eventbus WS");
-
-        let (ws_writer, ws_reader) = ws_stream.split();
-        let (writer_tx, writer_rx) = mpsc::channel::<String>(256);
-        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let subscribers: Arc<Mutex<HashMap<String, mpsc::Sender<WsMessage>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let connected = Arc::new(AtomicBool::new(true));
-
-        // Spawn writer task: drains writer_rx and sends frames.
-        let connected_w = Arc::clone(&connected);
-        tokio::spawn(async move {
-            let mut ws_writer = ws_writer;
-            let mut writer_rx = writer_rx;
-            while let Some(frame) = writer_rx.recv().await {
-                if ws_writer
-                    .send(tokio_tungstenite::tungstenite::Message::text(frame))
-                    .await
-                    .is_err()
-                {
-                    connected_w.store(false, Ordering::SeqCst);
-                    break;
-                }
-            }
-        });
-
-        // Spawn reader task: demuxes incoming frames.
-        let pending_r = Arc::clone(&pending);
-        let subscribers_r = Arc::clone(&subscribers);
-        let connected_r = Arc::clone(&connected);
-        tokio::spawn(async move {
-            let mut ws_reader = ws_reader;
-            while let Some(frame_result) = ws_reader.next().await {
-                let frame = match frame_result {
-                    Ok(f) => f,
-                    Err(e) => {
-                        warn!(error = %e, "WsClient read error");
-                        break;
-                    }
-                };
-
-                if frame.is_close() {
-                    break;
-                }
-                if !frame.is_text() {
-                    continue;
-                }
-
-                let text = match frame.to_text() {
-                    Ok(t) => t,
-                    Err(_) => continue,
-                };
-
-                let msg: ServerMsg = match serde_json::from_str(text) {
-                    Ok(m) => m,
-                    Err(e) => {
-                        debug!(error = %e, "WsClient received unparseable frame");
-                        continue;
-                    }
-                };
-
-                match msg {
-                    ServerMsg::Published { correlation_id, .. } => {
-                        if let Some(cid) = correlation_id {
-                            let mut p = pending_r.lock().await;
-                            if let Some(tx) = p.remove(&cid) {
-                                let _ = tx.send(PendingReply::Published);
-                            }
-                        }
-                    }
-                    ServerMsg::Subscribed { id, correlation_id } => {
-                        if let Some(cid) = correlation_id {
-                            let mut p = pending_r.lock().await;
-                            if let Some(tx) = p.remove(&cid) {
-                                let _ = tx.send(PendingReply::Subscribed(id));
-                            }
-                        }
-                    }
-                    ServerMsg::ReplyResult {
-                        payload,
-                        correlation_id,
-                    } => {
-                        if let Some(cid) = correlation_id {
-                            let decoded = base64::engine::general_purpose::STANDARD
-                                .decode(&payload)
-                                .unwrap_or_default();
-                            let mut p = pending_r.lock().await;
-                            if let Some(tx) = p.remove(&cid) {
-                                let _ = tx.send(PendingReply::ReplyResult(decoded));
-                            }
-                        }
-                    }
-                    ServerMsg::Error {
-                        message,
-                        correlation_id,
-                    } => {
-                        if let Some(cid) = correlation_id {
-                            let mut p = pending_r.lock().await;
-                            if let Some(tx) = p.remove(&cid) {
-                                let _ = tx.send(PendingReply::Error(message));
-                            }
-                        } else {
-                            warn!(message = %message, "WsClient received error without correlation_id");
-                        }
-                    }
-                    ServerMsg::Event {
-                        subject,
-                        payload,
-                        reply_subject,
-                        subscription_id,
-                    } => {
-                        let decoded = base64::engine::general_purpose::STANDARD
-                            .decode(&payload)
-                            .unwrap_or_default();
-                        let msg = WsMessage {
-                            subject,
-                            payload: bytes::Bytes::from(decoded),
-                            reply: reply_subject,
-                        };
-                        let subs = subscribers_r.lock().await;
-                        if let Some(tx) = subs.get(&subscription_id) {
-                            let _ = tx.send(msg).await;
-                        }
-                    }
-                    // Variants the client doesn't actively use but the
-                    // server may send. Silently ignored so the reader
-                    // doesn't crash on unexpected frames.
-                    ServerMsg::ChannelRegistered { .. }
-                    | ServerMsg::InterceptorRegistered { .. }
-                    | ServerMsg::Deliver { .. }
-                    | ServerMsg::Intercept { .. } => {}
-                }
-            }
-            connected_r.store(false, Ordering::SeqCst);
-            debug!("WsClient reader task exited");
-        });
-
-        Ok(Self {
-            writer_tx,
-            pending,
-            subscribers,
-            connected,
-            source: source.to_string(),
-            request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
-        })
+        connect_with_options(
+            url,
+            source,
+            Duration::from_millis(DEFAULT_RECONNECT_INITIAL_BACKOFF_MS),
+            Duration::from_millis(DEFAULT_RECONNECT_MAX_BACKOFF_MS),
+            None,
+        )
+        .await
     }
 
     /// Override the per-request timeout (default 5000ms). This value
@@ -362,11 +286,58 @@ impl WsClient {
         self
     }
 
+    /// Override the reconnect backoff bounds used by clients created through
+    /// [`Self::connect_with_reconnect`]. This builder is retained on cloned
+    /// clients for observability but cannot reconfigure an already spawned
+    /// manager; use [`Self::connect_with_reconnect`] when constructing a new
+    /// client.
+    pub fn with_reconnect_backoff(mut self, initial: Duration, max: Duration) -> Self {
+        self.reconnect_initial_backoff = initial;
+        self.reconnect_max_backoff = max.max(initial);
+        self
+    }
+
+    /// Override the maximum reconnect attempts used by clients created through
+    /// [`Self::connect_with_reconnect`]. `None` means retry forever.
+    pub fn with_max_reconnect_attempts(mut self, max: Option<usize>) -> Self {
+        self.max_reconnect_attempts = max;
+        self
+    }
+
+    /// Connect with explicit reconnect configuration. This is the effective
+    /// constructor for non-default reconnect settings.
+    pub async fn connect_with_reconnect(
+        url: &str,
+        source: &str,
+        initial_backoff: Duration,
+        max_backoff: Duration,
+        max_attempts: Option<usize>,
+    ) -> Result<Self> {
+        connect_with_options(url, source, initial_backoff, max_backoff, max_attempts).await
+    }
+
     fn next_correlation_id() -> String {
         ulid::Ulid::new().to_string()
     }
 
+    async fn wait_until_connected(&self, timeout: Duration) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.is_connected() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow::anyhow!("timed out connecting to eventbus WS"));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     async fn send_and_wait(&self, op: &ClientOp, cid: &str) -> Result<PendingReply> {
+        if !self.is_connected() {
+            return Err(anyhow::anyhow!("WsClient is reconnecting"));
+        }
+
         let (tx, rx) = oneshot::channel();
         {
             let mut p = self.pending.lock().await;
@@ -374,10 +345,10 @@ impl WsClient {
         }
 
         let frame = serde_json::to_string(op).context("failed to serialize WS operation")?;
-        if let Err(e) = self.writer_tx.send(frame).await {
+        if let Err(e) = self.manager_tx.send(ManagerCommand::Send(frame)).await {
             // Clean up the pending entry so it doesn't leak.
             self.pending.lock().await.remove(cid);
-            return Err(anyhow::anyhow!("WsClient connection closed: {}", e));
+            return Err(anyhow::anyhow!("WsClient connection manager closed: {}", e));
         }
 
         let reply = rx
@@ -436,9 +407,11 @@ impl WsClient {
 
     /// Subscribe to a subject pattern.
     pub async fn subscribe(&self, subject: impl AsRef<str>) -> Result<WsSubscription> {
+        let stable_id = Self::next_correlation_id();
         let cid = Self::next_correlation_id();
+        let pattern = subject.as_ref().to_string();
         let op = ClientOp::Subscribe {
-            pattern: subject.as_ref().to_string(),
+            pattern: pattern.clone(),
             correlation_id: Some(cid.clone()),
         };
         let reply = self.send_and_wait(&op, &cid).await?;
@@ -450,24 +423,24 @@ impl WsClient {
         let (tx, rx) = mpsc::channel::<WsMessage>(256);
         {
             let mut subs = self.subscribers.lock().await;
-            subs.insert(subscription_id.clone(), tx);
+            subs.insert(stable_id.clone(), pattern, tx);
+            subs.bind_server_id(&stable_id, subscription_id);
         }
 
-        Ok(WsSubscription {
-            rx,
-            id: subscription_id,
-        })
+        Ok(WsSubscription { rx, id: stable_id })
     }
 
-    /// Unsubscribe from a subscription by id.
+    /// Unsubscribe from a subscription by stable client-side id.
     pub async fn unsubscribe(&self, id: &str) -> Result<()> {
-        {
+        let server_id = {
             let mut subs = self.subscribers.lock().await;
-            subs.remove(id);
+            subs.remove(id).and_then(|state| state.server_id)
+        };
+        if let Some(server_id) = server_id {
+            let op = ClientOp::Unsubscribe { id: server_id };
+            let frame = serde_json::to_string(&op)?;
+            let _ = self.manager_tx.send(ManagerCommand::Send(frame)).await;
         }
-        let op = ClientOp::Unsubscribe { id: id.to_string() };
-        let frame = serde_json::to_string(&op)?;
-        let _ = self.writer_tx.send(frame).await;
         Ok(())
     }
 
@@ -514,6 +487,266 @@ impl WsClient {
     pub fn is_connected(&self) -> bool {
         self.connected.load(Ordering::SeqCst)
     }
+}
+
+async fn connect_with_options(
+    url: &str,
+    source: &str,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    max_attempts: Option<usize>,
+) -> Result<WsClient> {
+    let pending: Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let subscribers = Arc::new(Mutex::new(SubscriberRegistry::default()));
+    let connected = Arc::new(AtomicBool::new(false));
+    let (manager_tx, manager_rx) = mpsc::channel::<ManagerCommand>(256);
+    let reconnect_max_backoff = max_backoff.max(initial_backoff);
+    let client = WsClient {
+        manager_tx,
+        pending: Arc::clone(&pending),
+        subscribers: Arc::clone(&subscribers),
+        connected: Arc::clone(&connected),
+        source: source.to_string(),
+        request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+        reconnect_initial_backoff: initial_backoff,
+        reconnect_max_backoff,
+        max_reconnect_attempts: max_attempts,
+    };
+    tokio::spawn(connection_manager(ConnectionManagerState {
+        url: url.to_string(),
+        source: source.to_string(),
+        manager_rx,
+        pending,
+        subscribers,
+        connected,
+        initial_backoff,
+        max_backoff: reconnect_max_backoff,
+        max_attempts,
+    }));
+    client.wait_until_connected(Duration::from_secs(5)).await?;
+    Ok(client)
+}
+
+struct ConnectionManagerState {
+    url: String,
+    source: String,
+    manager_rx: mpsc::Receiver<ManagerCommand>,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>,
+    subscribers: Arc<Mutex<SubscriberRegistry>>,
+    connected: Arc<AtomicBool>,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    max_attempts: Option<usize>,
+}
+
+async fn connection_manager(mut state: ConnectionManagerState) {
+    let mut backoff = state.initial_backoff;
+    let mut failed_attempts = 0usize;
+
+    loop {
+        match tokio_tungstenite::connect_async(&state.url).await {
+            Ok((ws_stream, _)) => {
+                info!(url = %state.url, source = %state.source, "connected to eventbus WS");
+                failed_attempts = 0;
+                backoff = state.initial_backoff;
+                state.connected.store(true, Ordering::SeqCst);
+
+                if let Err(e) = resubscribe_active(
+                    &mut state.manager_rx,
+                    &state.pending,
+                    &state.subscribers,
+                    ws_stream,
+                )
+                .await
+                {
+                    warn!(error = %e, "WsClient connection dropped");
+                }
+
+                state.connected.store(false, Ordering::SeqCst);
+                fail_all_pending(&state.pending).await;
+                state.subscribers.lock().await.clear_server_ids();
+                debug!("WsClient connection cycle exited");
+            }
+            Err(e) => {
+                state.connected.store(false, Ordering::SeqCst);
+                failed_attempts += 1;
+                warn!(url = %state.url, source = %state.source, attempt = failed_attempts, error = %e, "failed to connect to eventbus WS");
+                if state.max_attempts.is_some_and(|max| failed_attempts >= max) {
+                    warn!(url = %state.url, source = %state.source, "WsClient reached max reconnect attempts");
+                    fail_all_pending(&state.pending).await;
+                    return;
+                }
+                tokio::select! {
+                    _ = tokio::time::sleep(backoff) => {},
+                    maybe_cmd = state.manager_rx.recv() => {
+                        if maybe_cmd.is_none() {
+                            return;
+                        }
+                        // Drop commands submitted while disconnected. Public methods
+                        // reject new operations when `connected == false`; this branch
+                        // handles the race where the connection closed after enqueue.
+                    }
+                }
+                backoff = (backoff * 2).min(state.max_backoff);
+            }
+        }
+    }
+}
+
+async fn resubscribe_active<S>(
+    manager_rx: &mut mpsc::Receiver<ManagerCommand>,
+    pending: &Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>,
+    subscribers: &Arc<Mutex<SubscriberRegistry>>,
+    ws_stream: tokio_tungstenite::WebSocketStream<S>,
+) -> Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let (mut ws_writer, mut ws_reader) = ws_stream.split();
+
+    let active = subscribers.lock().await.active_patterns();
+    for (stable_id, pattern) in active {
+        let cid = format!(
+            "{RESUBSCRIBE_CID_PREFIX}{stable_id}:{}",
+            WsClient::next_correlation_id()
+        );
+        let op = ClientOp::Subscribe {
+            pattern,
+            correlation_id: Some(cid),
+        };
+        let frame = serde_json::to_string(&op).context("failed to serialize resubscribe op")?;
+        ws_writer
+            .send(tokio_tungstenite::tungstenite::Message::text(frame))
+            .await
+            .context("failed to send resubscribe op")?;
+    }
+
+    loop {
+        tokio::select! {
+            maybe_cmd = manager_rx.recv() => {
+                let Some(cmd) = maybe_cmd else { return Err(anyhow::anyhow!("WsClient command channel closed")); };
+                match cmd {
+                    ManagerCommand::Send(frame) => {
+                        ws_writer
+                            .send(tokio_tungstenite::tungstenite::Message::text(frame))
+                            .await
+                            .context("failed to send WS frame")?;
+                    }
+                }
+            }
+            maybe_frame = ws_reader.next() => {
+                let Some(frame_result) = maybe_frame else { return Err(anyhow::anyhow!("WsClient server closed connection")); };
+                let frame = frame_result.context("WsClient read error")?;
+                if frame.is_close() {
+                    return Err(anyhow::anyhow!("WsClient server sent close frame"));
+                }
+                if !frame.is_text() {
+                    continue;
+                }
+                let text = match frame.to_text() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let msg: ServerMsg = match serde_json::from_str(text) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        debug!(error = %e, "WsClient received unparseable frame");
+                        continue;
+                    }
+                };
+                handle_server_msg(msg, pending, subscribers).await;
+            }
+        }
+    }
+}
+
+async fn handle_server_msg(
+    msg: ServerMsg,
+    pending: &Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>,
+    subscribers: &Arc<Mutex<SubscriberRegistry>>,
+) {
+    match msg {
+        ServerMsg::Published { correlation_id, .. } => {
+            if let Some(cid) = correlation_id {
+                send_pending(pending, &cid, PendingReply::Published).await;
+            }
+        }
+        ServerMsg::Subscribed { id, correlation_id } => {
+            if let Some(cid) = correlation_id {
+                if let Some(stable_id) = cid
+                    .strip_prefix(RESUBSCRIBE_CID_PREFIX)
+                    .and_then(|rest| rest.split_once(':').map(|(stable, _)| stable.to_string()))
+                {
+                    subscribers.lock().await.bind_server_id(&stable_id, id);
+                } else {
+                    send_pending(pending, &cid, PendingReply::Subscribed(id)).await;
+                }
+            }
+        }
+        ServerMsg::ReplyResult {
+            payload,
+            correlation_id,
+        } => {
+            if let Some(cid) = correlation_id {
+                let decoded = base64::engine::general_purpose::STANDARD
+                    .decode(&payload)
+                    .unwrap_or_default();
+                send_pending(pending, &cid, PendingReply::ReplyResult(decoded)).await;
+            }
+        }
+        ServerMsg::Error {
+            message,
+            correlation_id,
+        } => {
+            if let Some(cid) = correlation_id {
+                send_pending(pending, &cid, PendingReply::Error(message)).await;
+            } else {
+                warn!(message = %message, "WsClient received error without correlation_id");
+            }
+        }
+        ServerMsg::Event {
+            subject,
+            payload,
+            reply_subject,
+            subscription_id,
+        } => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(&payload)
+                .unwrap_or_default();
+            let msg = WsMessage {
+                subject,
+                payload: bytes::Bytes::from(decoded),
+                reply: reply_subject,
+            };
+            let sender = subscribers
+                .lock()
+                .await
+                .get_sender_by_server_id(&subscription_id);
+            if let Some(tx) = sender {
+                let _ = tx.send(msg).await;
+            }
+        }
+        ServerMsg::ChannelRegistered { .. }
+        | ServerMsg::InterceptorRegistered { .. }
+        | ServerMsg::Deliver { .. }
+        | ServerMsg::Intercept { .. } => {}
+    }
+}
+
+async fn send_pending(
+    pending: &Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>,
+    cid: &str,
+    reply: PendingReply,
+) {
+    let tx = pending.lock().await.remove(cid);
+    if let Some(tx) = tx {
+        let _ = tx.send(reply);
+    }
+}
+
+async fn fail_all_pending(pending: &Arc<Mutex<HashMap<String, oneshot::Sender<PendingReply>>>>) {
+    pending.lock().await.clear();
 }
 
 #[cfg(test)]
@@ -628,5 +861,150 @@ mod tests {
             }
             _ => panic!("expected ReplyResult"),
         }
+    }
+
+    #[tokio::test]
+    async fn subscriber_registry_maps_server_ids_to_stable_subscriptions() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut registry = SubscriberRegistry::default();
+        registry.insert("stable-1".to_string(), "events.>".to_string(), tx.clone());
+
+        assert!(registry.bind_server_id("stable-1", "server-a".to_string()));
+        assert!(registry.get_sender_by_server_id("server-a").is_some());
+        assert_eq!(
+            registry.active_patterns(),
+            vec![("stable-1".to_string(), "events.>".to_string())]
+        );
+
+        assert!(registry.bind_server_id("stable-1", "server-b".to_string()));
+        assert!(registry.get_sender_by_server_id("server-a").is_none());
+        assert!(registry.get_sender_by_server_id("server-b").is_some());
+    }
+
+    #[tokio::test]
+    async fn subscriber_registry_removes_stable_subscription_and_server_mapping() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut registry = SubscriberRegistry::default();
+        registry.insert("stable-1".to_string(), "events.>".to_string(), tx);
+        registry.bind_server_id("stable-1", "server-a".to_string());
+
+        let removed = registry.remove("stable-1").unwrap();
+
+        assert_eq!(removed.pattern, "events.>");
+        assert_eq!(removed.server_id, Some("server-a".to_string()));
+        assert!(registry.get_sender_by_server_id("server-a").is_none());
+        assert!(registry.active_patterns().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ws_client_reconnects_and_restores_active_subscriptions() {
+        use seidrum_eventbus::test_utils::pick_ephemeral_addr;
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::tungstenite::Message;
+
+        async fn start_scripted_server(
+            addr: std::net::SocketAddr,
+        ) -> (
+            oneshot::Sender<()>,
+            mpsc::Sender<&'static [u8]>,
+            tokio::task::JoinHandle<()>,
+        ) {
+            let listener = TcpListener::bind(addr).await.unwrap();
+            let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+            let (event_tx, mut event_rx) = mpsc::channel::<&'static [u8]>(8);
+            let handle = tokio::spawn(async move {
+                let (stream, _) = listener.accept().await.unwrap();
+                let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                let (mut writer, mut reader) = ws.split();
+                let mut server_sub_id: Option<String> = None;
+                loop {
+                    tokio::select! {
+                        _ = &mut shutdown_rx => {
+                            let _ = writer.send(Message::Close(None)).await;
+                            break;
+                        }
+                        maybe_payload = event_rx.recv() => {
+                            let Some(payload) = maybe_payload else { break; };
+                            let Some(subscription_id) = server_sub_id.clone() else { continue; };
+                            let frame = serde_json::json!({
+                                "op": "event",
+                                "subject": "reconnect.test",
+                                "payload": base64::engine::general_purpose::STANDARD.encode(payload),
+                                "reply_subject": null,
+                                "subscription_id": subscription_id,
+                            });
+                            writer.send(Message::text(frame.to_string())).await.unwrap();
+                        }
+                        maybe_frame = reader.next() => {
+                            let Some(Ok(frame)) = maybe_frame else { break; };
+                            if !frame.is_text() { continue; }
+                            let value: serde_json::Value = serde_json::from_str(frame.to_text().unwrap()).unwrap();
+                            match value.get("op").and_then(|op| op.as_str()) {
+                                Some("subscribe") => {
+                                    let cid = value.get("correlation_id").cloned().unwrap_or(serde_json::Value::Null);
+                                    let id = format!("server-sub-{}", ulid::Ulid::new());
+                                    server_sub_id = Some(id.clone());
+                                    let reply = serde_json::json!({"op":"subscribed","id":id,"correlation_id":cid});
+                                    writer.send(Message::text(reply.to_string())).await.unwrap();
+                                }
+                                Some("publish") => {
+                                    let cid = value.get("correlation_id").cloned().unwrap_or(serde_json::Value::Null);
+                                    let reply = serde_json::json!({"op":"published","seq":1,"correlation_id":cid});
+                                    writer.send(Message::text(reply.to_string())).await.unwrap();
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            });
+            (shutdown_tx, event_tx, handle)
+        }
+
+        let addr = pick_ephemeral_addr();
+        let (shutdown_a, event_tx_a, server_a) = start_scripted_server(addr).await;
+
+        let client = WsClient::connect_with_reconnect(
+            &format!("ws://{addr}"),
+            "ws-client-test",
+            Duration::from_millis(10),
+            Duration::from_millis(50),
+            None,
+        )
+        .await
+        .unwrap();
+        let mut sub = client.subscribe("reconnect.test").await.unwrap();
+
+        event_tx_a.send(b"before").await.unwrap();
+        let before = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(before.payload.as_ref(), b"before");
+
+        let _ = shutdown_a.send(());
+        server_a.await.unwrap();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while client.is_connected() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(!client.is_connected());
+
+        let (shutdown_b, event_tx_b, server_b) = start_scripted_server(addr).await;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while !client.is_connected() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(client.is_connected());
+
+        event_tx_b.send(b"after").await.unwrap();
+        let after = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.payload.as_ref(), b"after");
+
+        let _ = shutdown_b.send(());
+        server_b.await.unwrap();
     }
 }

--- a/crates/core/seidrum-eventbus/examples/rate_limiter.rs
+++ b/crates/core/seidrum-eventbus/examples/rate_limiter.rs
@@ -111,11 +111,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Collect what got through (with a short timeout for remaining).
     let mut received = 0;
-    loop {
-        match tokio::time::timeout(Duration::from_millis(200), sub.rx.recv()).await {
-            Ok(Some(_)) => received += 1,
-            _ => break,
-        }
+    while let Ok(Some(_)) = tokio::time::timeout(Duration::from_millis(200), sub.rx.recv()).await {
+        received += 1;
     }
 
     println!("Alice sent 5 messages, {} got through (limit: 3)", received);

--- a/crates/core/seidrum-eventbus/src/builder.rs
+++ b/crates/core/seidrum-eventbus/src/builder.rs
@@ -73,6 +73,19 @@ impl EventBus for OwnedBus {
     async fn get_event(&self, seq: u64) -> crate::Result<Option<crate::storage::StoredEvent>> {
         self.inner.get_event(seq).await
     }
+    async fn query_dead_lettered(
+        &self,
+        subject: Option<&str>,
+        limit: usize,
+    ) -> crate::Result<Vec<crate::storage::StoredEvent>> {
+        self.inner.query_dead_lettered(subject, limit).await
+    }
+    async fn replay_dead_lettered(&self, seq: u64) -> crate::Result<u64> {
+        self.inner.replay_dead_lettered(seq).await
+    }
+    async fn purge_dead_lettered(&self, seq: u64) -> crate::Result<()> {
+        self.inner.purge_dead_lettered(seq).await
+    }
     async fn register_channel_type(
         &self,
         channel_type: &str,

--- a/crates/core/seidrum-eventbus/src/bus.rs
+++ b/crates/core/seidrum-eventbus/src/bus.rs
@@ -148,6 +148,19 @@ pub trait EventBus: Send + Sync + 'static {
     /// scanning by status.
     async fn get_event(&self, seq: u64) -> crate::Result<Option<StoredEvent>>;
 
+    /// List dead-lettered events, optionally filtered by exact subject.
+    async fn query_dead_lettered(
+        &self,
+        subject: Option<&str>,
+        limit: usize,
+    ) -> crate::Result<Vec<StoredEvent>>;
+
+    /// Replay a dead-lettered event in-place using its original sequence.
+    async fn replay_dead_lettered(&self, seq: u64) -> crate::Result<u64>;
+
+    /// Permanently remove a single dead-lettered event.
+    async fn purge_dead_lettered(&self, seq: u64) -> crate::Result<()>;
+
     /// Register a custom delivery channel type at runtime.
     ///
     /// Subscriptions that use `ChannelConfig::Custom { channel_type, .. }`
@@ -314,6 +327,30 @@ impl EventBus for EventBusImpl {
         self.engine
             .store
             .get(seq)
+            .await
+            .map_err(crate::EventBusError::Storage)
+    }
+
+    async fn query_dead_lettered(
+        &self,
+        subject: Option<&str>,
+        limit: usize,
+    ) -> crate::Result<Vec<StoredEvent>> {
+        self.engine
+            .store
+            .query_dead_lettered(subject, limit)
+            .await
+            .map_err(crate::EventBusError::Storage)
+    }
+
+    async fn replay_dead_lettered(&self, seq: u64) -> crate::Result<u64> {
+        self.engine.replay_dead_lettered(seq).await
+    }
+
+    async fn purge_dead_lettered(&self, seq: u64) -> crate::Result<()> {
+        self.engine
+            .store
+            .purge_dead_lettered(seq)
             .await
             .map_err(crate::EventBusError::Storage)
     }

--- a/crates/core/seidrum-eventbus/src/delivery/webhook.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/webhook.rs
@@ -13,7 +13,7 @@ use reqwest::Client;
 use serde_json::json;
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -218,6 +218,53 @@ fn is_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
+/// Webhook circuit breaker settings.
+#[derive(Debug, Clone, Copy)]
+pub struct WebhookCircuitBreakerConfig {
+    /// Consecutive delivery failures before opening the circuit.
+    pub failure_threshold: u32,
+    /// Initial open-circuit cooldown before allowing a half-open probe.
+    pub initial_cooldown: Duration,
+    /// Maximum cooldown after repeated failed half-open probes.
+    pub max_cooldown: Duration,
+}
+
+impl Default for WebhookCircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 3,
+            initial_cooldown: Duration::from_secs(30),
+            max_cooldown: Duration::from_secs(300),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CircuitMode {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+#[derive(Debug, Clone)]
+struct CircuitState {
+    mode: CircuitMode,
+    consecutive_failures: u32,
+    cooldown: Duration,
+    opened_until: Option<SystemTime>,
+}
+
+impl CircuitState {
+    fn new(config: WebhookCircuitBreakerConfig) -> Self {
+        Self {
+            mode: CircuitMode::Closed,
+            consecutive_failures: 0,
+            cooldown: config.initial_cooldown,
+            opened_until: None,
+        }
+    }
+}
+
 /// Webhook delivery channel.
 /// Sends events as HTTP POST requests to a configured URL.
 ///
@@ -241,6 +288,8 @@ pub struct WebhookChannel {
     /// `Strict` so production deployments are safe by default; the
     /// builder threads the configured policy through here.
     policy: WebhookUrlPolicy,
+    circuit_config: WebhookCircuitBreakerConfig,
+    circuits: Mutex<HashMap<String, CircuitState>>,
 }
 
 impl WebhookChannel {
@@ -252,12 +301,25 @@ impl WebhookChannel {
     /// Create a new webhook delivery channel with an explicit SSRF policy.
     /// Use [`WebhookUrlPolicy::Permissive`] only for tests / trusted networks.
     pub fn with_policy(policy: WebhookUrlPolicy) -> Arc<Self> {
+        Self::with_policy_and_circuit(policy, WebhookCircuitBreakerConfig::default())
+    }
+
+    /// Create a new webhook delivery channel with explicit SSRF and circuit breaker settings.
+    pub fn with_policy_and_circuit(
+        policy: WebhookUrlPolicy,
+        circuit_config: WebhookCircuitBreakerConfig,
+    ) -> Arc<Self> {
         let client = Client::builder()
             .redirect(Policy::none())
             .timeout(Duration::from_secs(30))
             .build()
             .expect("reqwest client builder should succeed with default settings");
-        Arc::new(Self { client, policy })
+        Arc::new(Self {
+            client,
+            policy,
+            circuit_config,
+            circuits: Mutex::new(HashMap::new()),
+        })
     }
 
     /// Extract URL and headers from ChannelConfig.
@@ -268,6 +330,86 @@ impl WebhookChannel {
                 "Invalid config for WebhookChannel".to_string(),
             )),
         }
+    }
+
+    fn ensure_circuit_allows_delivery(&self, url: &str) -> DeliveryResult<()> {
+        let now = SystemTime::now();
+        let mut circuits = self
+            .circuits
+            .lock()
+            .expect("webhook circuit mutex poisoned");
+        let state = circuits
+            .entry(url.to_string())
+            .or_insert_with(|| CircuitState::new(self.circuit_config));
+
+        match state.mode {
+            CircuitMode::Closed | CircuitMode::HalfOpen => Ok(()),
+            CircuitMode::Open => {
+                if state.opened_until.is_some_and(|until| now >= until) {
+                    state.mode = CircuitMode::HalfOpen;
+                    debug!(url = %url, "Webhook circuit half-open; allowing probe delivery");
+                    Ok(())
+                } else {
+                    warn!(url = %url, "Webhook circuit open; skipping delivery");
+                    Err(DeliveryError::Failed(
+                        "webhook circuit open; delivery skipped until cooldown expires".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn record_success(&self, url: &str) {
+        let mut circuits = self
+            .circuits
+            .lock()
+            .expect("webhook circuit mutex poisoned");
+        let state = circuits
+            .entry(url.to_string())
+            .or_insert_with(|| CircuitState::new(self.circuit_config));
+        if state.mode != CircuitMode::Closed || state.consecutive_failures > 0 {
+            debug!(url = %url, "Webhook circuit closed after successful delivery");
+        }
+        *state = CircuitState::new(self.circuit_config);
+    }
+
+    fn record_failure(&self, url: &str) {
+        let mut circuits = self
+            .circuits
+            .lock()
+            .expect("webhook circuit mutex poisoned");
+        let state = circuits
+            .entry(url.to_string())
+            .or_insert_with(|| CircuitState::new(self.circuit_config));
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+
+        if state.mode == CircuitMode::HalfOpen
+            || state.consecutive_failures >= self.circuit_config.failure_threshold
+        {
+            state.mode = CircuitMode::Open;
+            state.opened_until = Some(SystemTime::now() + state.cooldown);
+            warn!(
+                url = %url,
+                cooldown_ms = state.cooldown.as_millis() as u64,
+                consecutive_failures = state.consecutive_failures,
+                "Webhook circuit opened"
+            );
+            state.cooldown = std::cmp::min(
+                state.cooldown.saturating_mul(2),
+                self.circuit_config.max_cooldown,
+            );
+        }
+    }
+
+    fn circuit_blocks_health(&self, url: &str) -> bool {
+        let now = SystemTime::now();
+        let circuits = self
+            .circuits
+            .lock()
+            .expect("webhook circuit mutex poisoned");
+        circuits.get(url).is_some_and(|state| {
+            state.mode == CircuitMode::Open && state.opened_until.is_some_and(|until| now < until)
+        })
     }
 }
 
@@ -281,6 +423,7 @@ impl DeliveryChannel for WebhookChannel {
     ) -> DeliveryResult<DeliveryReceipt> {
         let start = SystemTime::now();
         let (url, headers) = Self::extract_config(config)?;
+        self.ensure_circuit_allows_delivery(&url)?;
 
         // N1 + F5 + F6: validate-and-pin the URL on every delivery.
         // The validator runs synchronous DNS via to_socket_addrs, so we
@@ -303,12 +446,14 @@ impl DeliveryChannel for WebhookChannel {
                     error = %e,
                     "WebhookChannel rejecting delivery — URL no longer passes policy (DNS rebinding?)"
                 );
+                self.record_failure(&url);
                 return Err(DeliveryError::Permanent(format!(
                     "URL no longer passes SSRF policy: {}",
                     e
                 )));
             }
             Err(join_err) => {
+                self.record_failure(&url);
                 return Err(DeliveryError::Failed(format!(
                     "validation task panicked: {}",
                     join_err
@@ -330,6 +475,7 @@ impl DeliveryChannel for WebhookChannel {
         {
             Ok(c) => c,
             Err(e) => {
+                self.record_failure(&url);
                 return Err(DeliveryError::Failed(format!(
                     "failed to build pinned client: {}",
                     e
@@ -353,11 +499,10 @@ impl DeliveryChannel for WebhookChannel {
         }
 
         // Send the request
-        let response = req
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| DeliveryError::Failed(format!("HTTP request failed: {}", e)))?;
+        let response = req.json(&body).send().await.map_err(|e| {
+            self.record_failure(&url);
+            DeliveryError::Failed(format!("HTTP request failed: {}", e))
+        })?;
 
         // Classify status code: 4xx is permanent (auth errors, not-found,
         // method-not-allowed don't get better with retries); 5xx and other
@@ -373,6 +518,7 @@ impl DeliveryChannel for WebhookChannel {
             // "try again later"), and 429 (Too Many Requests) as transient.
             // All other 4xx are permanent.
             let code = status.as_u16();
+            self.record_failure(&url);
             if status.is_client_error() && code != 408 && code != 425 && code != 429 {
                 return Err(DeliveryError::Permanent(msg));
             }
@@ -390,6 +536,7 @@ impl DeliveryChannel for WebhookChannel {
             .as_millis() as u64;
 
         debug!("Webhook delivery succeeded to {} in {}us", url, elapsed);
+        self.record_success(&url);
 
         Ok(DeliveryReceipt {
             delivered_at,
@@ -414,6 +561,9 @@ impl DeliveryChannel for WebhookChannel {
             Ok(c) => c,
             Err(_) => return false,
         };
+        if self.circuit_blocks_health(&url) {
+            return false;
+        }
 
         // Use HEAD to avoid triggering side-effects on POST-only endpoints.
         // Fall back to treating connection success as healthy if HEAD returns
@@ -461,6 +611,108 @@ mod tests {
     #[test]
     fn test_webhook_channel_new() {
         let _channel = WebhookChannel::new();
+    }
+
+    #[tokio::test]
+    async fn test_webhook_circuit_opens_skips_and_half_open_retries() {
+        let channel = WebhookChannel::with_policy_and_circuit(
+            WebhookUrlPolicy::Permissive,
+            WebhookCircuitBreakerConfig {
+                failure_threshold: 2,
+                initial_cooldown: Duration::from_millis(25),
+                max_cooldown: Duration::from_millis(100),
+            },
+        );
+        let config = ChannelConfig::Webhook {
+            // Permissive policy still rejects unspecified destinations, so this
+            // deterministically fails without depending on an external server.
+            url: "http://0.0.0.0/hook".to_string(),
+            headers: HashMap::new(),
+        };
+
+        let first = channel.deliver(b"event", "webhook.circuit", &config).await;
+        assert!(matches!(first, Err(DeliveryError::Permanent(_))));
+
+        let second = channel.deliver(b"event", "webhook.circuit", &config).await;
+        assert!(matches!(second, Err(DeliveryError::Permanent(_))));
+        assert!(!channel.is_healthy(&config).await);
+
+        let skipped = channel.deliver(b"event", "webhook.circuit", &config).await;
+        assert!(matches!(skipped, Err(DeliveryError::Failed(msg)) if msg.contains("circuit open")));
+
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        let half_open_probe = channel.deliver(b"event", "webhook.circuit", &config).await;
+        assert!(matches!(half_open_probe, Err(DeliveryError::Permanent(_))));
+        assert!(!channel.is_healthy(&config).await);
+    }
+
+    #[tokio::test]
+    async fn test_webhook_circuit_recovery_closes_after_half_open_success() {
+        use axum::{routing::post, Router};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let handler_hits = Arc::clone(&hits);
+        let app = Router::new().route(
+            "/hook",
+            post(move || {
+                let handler_hits = Arc::clone(&handler_hits);
+                async move {
+                    let attempt = handler_hits.fetch_add(1, Ordering::SeqCst);
+                    if attempt < 2 {
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+                    } else {
+                        axum::http::StatusCode::OK
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let channel = WebhookChannel::with_policy_and_circuit(
+            WebhookUrlPolicy::Permissive,
+            WebhookCircuitBreakerConfig {
+                failure_threshold: 2,
+                initial_cooldown: Duration::from_millis(25),
+                max_cooldown: Duration::from_millis(100),
+            },
+        );
+        let config = ChannelConfig::Webhook {
+            url: format!("http://{}/hook", addr),
+            headers: HashMap::new(),
+        };
+
+        assert!(matches!(
+            channel.deliver(b"event", "webhook.circuit", &config).await,
+            Err(DeliveryError::Failed(_))
+        ));
+        assert!(matches!(
+            channel.deliver(b"event", "webhook.circuit", &config).await,
+            Err(DeliveryError::Failed(_))
+        ));
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+        let skipped = channel.deliver(b"event", "webhook.circuit", &config).await;
+        assert!(matches!(skipped, Err(DeliveryError::Failed(msg)) if msg.contains("circuit open")));
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        assert!(channel
+            .deliver(b"event", "webhook.circuit", &config)
+            .await
+            .is_ok());
+        assert_eq!(hits.load(Ordering::SeqCst), 3);
+        assert!(channel
+            .deliver(b"event", "webhook.circuit", &config)
+            .await
+            .is_ok());
+        assert_eq!(hits.load(Ordering::SeqCst), 4);
+
+        server.abort();
     }
 
     // === N8a / C2 SSRF unit tests ===

--- a/crates/core/seidrum-eventbus/src/dispatch/engine.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/engine.rs
@@ -322,8 +322,48 @@ impl DispatchEngine {
             self.events_published.fetch_add(1, Ordering::Relaxed);
             s
         };
-        let event_reply_subject = reply_subject;
+        self.dispatch_persisted_event(seq, subject, payload, reply_subject, is_reply)
+            .await
+    }
 
+    /// Replay an existing dead-lettered event using its original sequence number.
+    pub async fn replay_dead_lettered(&self, seq: u64) -> crate::Result<u64> {
+        let event = self
+            .store
+            .get(seq)
+            .await
+            .map_err(EventBusError::Storage)?
+            .ok_or_else(|| EventBusError::Internal(format!("event {} not found", seq)))?;
+        if event.status != EventStatus::DeadLettered {
+            return Err(EventBusError::Internal(format!(
+                "event {} is not dead-lettered",
+                seq
+            )));
+        }
+
+        self.store
+            .requeue_dead_lettered(seq)
+            .await
+            .map_err(EventBusError::Storage)?;
+        self.events_published.fetch_add(1, Ordering::Relaxed);
+        self.dispatch_persisted_event(
+            seq,
+            &event.subject,
+            &event.payload,
+            event.reply_subject,
+            false,
+        )
+        .await
+    }
+
+    async fn dispatch_persisted_event(
+        &self,
+        seq: u64,
+        subject: &str,
+        payload: &[u8],
+        event_reply_subject: Option<String>,
+        is_reply: bool,
+    ) -> crate::Result<u64> {
         // Helper: record delivery only for persisted (non-reply) events.
         // For Failed transitions, computes next_retry from the engine's
         // RetryConfig (this is the *first* failure on this subscriber, so

--- a/crates/core/seidrum-eventbus/src/storage/memory_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/memory_store.rs
@@ -218,6 +218,39 @@ impl EventStore for InMemoryEventStore {
         Ok((original_len - events.len()) as u64)
     }
 
+    async fn requeue_dead_lettered(&self, seq: u64) -> StorageResult<StoredEvent> {
+        let mut events = self.events.write().await;
+        let event = events
+            .iter_mut()
+            .find(|e| e.seq == seq)
+            .ok_or(super::StorageError::NotFound)?;
+        if event.status != EventStatus::DeadLettered {
+            return Err(super::StorageError::OperationFailed(format!(
+                "event {} is not dead-lettered",
+                seq
+            )));
+        }
+        event.status = EventStatus::Pending;
+        event.deliveries.clear();
+        Ok(event.clone())
+    }
+
+    async fn purge_dead_lettered(&self, seq: u64) -> StorageResult<()> {
+        let mut events = self.events.write().await;
+        let idx = events
+            .iter()
+            .position(|e| e.seq == seq)
+            .ok_or(super::StorageError::NotFound)?;
+        if events[idx].status != EventStatus::DeadLettered {
+            return Err(super::StorageError::OperationFailed(format!(
+                "event {} is not dead-lettered",
+                seq
+            )));
+        }
+        events.remove(idx);
+        Ok(())
+    }
+
     async fn save_subscription(&self, sub: &PersistedSubscription) -> StorageResult<()> {
         let mut subs = self.subscriptions.write().await;
         subs.insert(sub.persisted_id.clone(), sub.clone());

--- a/crates/core/seidrum-eventbus/src/storage/mod.rs
+++ b/crates/core/seidrum-eventbus/src/storage/mod.rs
@@ -122,9 +122,42 @@ pub trait EventStore: Send + Sync + 'static {
 
     /// Query dead-lettered events for inspection or replay.
     ///
-    /// Convenience wrapper around `query_by_status(EventStatus::DeadLettered, limit)`.
-    async fn query_dead_lettered(&self, limit: usize) -> StorageResult<Vec<StoredEvent>> {
-        self.query_by_status(EventStatus::DeadLettered, limit).await
+    /// If `subject` is set, only exact-subject matches are returned.
+    async fn query_dead_lettered(
+        &self,
+        subject: Option<&str>,
+        limit: usize,
+    ) -> StorageResult<Vec<StoredEvent>> {
+        let events = self
+            .query_by_status(EventStatus::DeadLettered, limit)
+            .await?;
+        Ok(match subject {
+            Some(subject) => events
+                .into_iter()
+                .filter(|event| event.subject == subject)
+                .take(limit)
+                .collect(),
+            None => events,
+        })
+    }
+
+    /// Reset a dead-lettered event so it can be dispatched again in-place.
+    ///
+    /// Implementations clear delivery records, set status to `Pending`, and
+    /// preserve the original seq/subject/payload/reply_subject.
+    async fn requeue_dead_lettered(&self, seq: u64) -> StorageResult<StoredEvent> {
+        let _ = seq;
+        Err(StorageError::OperationFailed(
+            "dead-letter replay not supported by this store".to_string(),
+        ))
+    }
+
+    /// Permanently remove a dead-lettered event from storage.
+    async fn purge_dead_lettered(&self, seq: u64) -> StorageResult<()> {
+        let _ = seq;
+        Err(StorageError::OperationFailed(
+            "dead-letter purge not supported by this store".to_string(),
+        ))
     }
 
     // === Persisted subscriptions (Phase 4) ===

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -780,7 +780,7 @@ impl EventStore for RedbEventStore {
                         StorageError::DatabaseError(format!("failed to get event: {}", e))
                     })?
                     .ok_or(StorageError::NotFound)?;
-                serde_json::from_slice(&data.value()).map_err(|e| {
+                serde_json::from_slice(data.value()).map_err(|e| {
                     StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
                 })?
             };
@@ -858,7 +858,7 @@ impl EventStore for RedbEventStore {
                         StorageError::DatabaseError(format!("failed to get event: {}", e))
                     })?
                     .ok_or(StorageError::NotFound)?;
-                serde_json::from_slice(&data.value()).map_err(|e| {
+                serde_json::from_slice(data.value()).map_err(|e| {
                     StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
                 })?
             };

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -763,6 +763,151 @@ impl EventStore for RedbEventStore {
         .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
     }
 
+    async fn requeue_dead_lettered(&self, seq: u64) -> StorageResult<StoredEvent> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || {
+            let write_txn = db.begin_write().map_err(|e| {
+                StorageError::DatabaseError(format!("failed to begin write: {}", e))
+            })?;
+
+            let mut event: StoredEvent = {
+                let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                })?;
+                let data = events_table
+                    .get(seq)
+                    .map_err(|e| {
+                        StorageError::DatabaseError(format!("failed to get event: {}", e))
+                    })?
+                    .ok_or(StorageError::NotFound)?;
+                serde_json::from_slice(&data.value()).map_err(|e| {
+                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                })?
+            };
+
+            if event.status != EventStatus::DeadLettered {
+                return Err(StorageError::OperationFailed(format!(
+                    "event {} is not dead-lettered",
+                    seq
+                )));
+            }
+            let old_status = event.status.as_u8();
+            event.status = EventStatus::Pending;
+            event.deliveries.clear();
+            let serialized = serde_json::to_vec(&event).map_err(|e| {
+                StorageError::OperationFailed(format!("failed to serialize event: {}", e))
+            })?;
+
+            {
+                let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                })?;
+                events_table
+                    .insert(seq, serialized.as_slice())
+                    .map_err(|e| {
+                        StorageError::DatabaseError(format!("failed to update event: {}", e))
+                    })?;
+            }
+            {
+                let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                })?;
+                let _ = status_idx.remove((old_status, seq));
+                status_idx
+                    .insert((EventStatus::Pending.as_u8(), seq), ())
+                    .map_err(|e| {
+                        StorageError::DatabaseError(format!("failed to insert status index: {}", e))
+                    })?;
+            }
+            {
+                let mut failed_idx =
+                    write_txn
+                        .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                        .map_err(|e| {
+                            StorageError::DatabaseError(format!(
+                                "failed to open failed_deliveries_idx: {}",
+                                e
+                            ))
+                        })?;
+                let _ = failed_idx.remove(seq);
+            }
+
+            write_txn
+                .commit()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))?;
+            Ok(event)
+        })
+        .await
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+    }
+
+    async fn purge_dead_lettered(&self, seq: u64) -> StorageResult<()> {
+        let db = Arc::clone(&self.db);
+        tokio::task::spawn_blocking(move || {
+            let write_txn = db.begin_write().map_err(|e| {
+                StorageError::DatabaseError(format!("failed to begin write: {}", e))
+            })?;
+
+            let event: StoredEvent = {
+                let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                })?;
+                let data = events_table
+                    .get(seq)
+                    .map_err(|e| {
+                        StorageError::DatabaseError(format!("failed to get event: {}", e))
+                    })?
+                    .ok_or(StorageError::NotFound)?;
+                serde_json::from_slice(&data.value()).map_err(|e| {
+                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                })?
+            };
+            if event.status != EventStatus::DeadLettered {
+                return Err(StorageError::OperationFailed(format!(
+                    "event {} is not dead-lettered",
+                    seq
+                )));
+            }
+
+            {
+                let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                })?;
+                let _ = events_table.remove(seq);
+            }
+            {
+                let mut subject_idx = write_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open subject_idx: {}", e))
+                })?;
+                let _ = subject_idx.remove((event.subject.as_str(), seq));
+            }
+            {
+                let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
+                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                })?;
+                let _ = status_idx.remove((event.status.as_u8(), seq));
+            }
+            {
+                let mut failed_idx =
+                    write_txn
+                        .open_table(FAILED_DELIVERIES_IDX_TABLE)
+                        .map_err(|e| {
+                            StorageError::DatabaseError(format!(
+                                "failed to open failed_deliveries_idx: {}",
+                                e
+                            ))
+                        })?;
+                let _ = failed_idx.remove(seq);
+            }
+
+            write_txn
+                .commit()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))
+        })
+        .await
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+    }
+
     async fn save_subscription(&self, sub: &PersistedSubscription) -> StorageResult<()> {
         let db = Arc::clone(&self.db);
         let sub = sub.clone();

--- a/crates/core/seidrum-eventbus/src/transport/http.rs
+++ b/crates/core/seidrum-eventbus/src/transport/http.rs
@@ -7,7 +7,7 @@ use crate::bus::{BusMetrics, EventBus, SubscribeOpts};
 use crate::delivery::{ChannelConfig, ChannelRegistry, DeliveryChannel, WebhookChannel};
 use crate::dispatch::SubscriptionMode;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{delete, get, post},
     Json, Router,
@@ -237,6 +237,22 @@ pub struct RegisterInterceptorResponse {
     pub id: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct DeadLetterQuery {
+    pub subject: Option<String>,
+    #[serde(default = "default_dead_letter_limit")]
+    pub limit: usize,
+}
+
+fn default_dead_letter_limit() -> usize {
+    100
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReplayDeadLetterResponse {
+    pub seq: u64,
+}
+
 /// Validate and decode a base64 payload, mapping errors to HttpError.
 fn validate_and_decode_payload(payload: &str) -> Result<Vec<u8>, HttpError> {
     super::validate_and_decode_payload(payload).map_err(|msg| {
@@ -275,6 +291,9 @@ pub fn create_router(state: AppState) -> Router {
         .route("/interceptors", post(create_interceptor))
         .route("/interceptors/{id}", delete(remove_interceptor))
         .route("/events/{seq}", get(get_event))
+        .route("/dead-letter", get(list_dead_lettered))
+        .route("/dead-letter/{seq}/replay", post(replay_dead_lettered))
+        .route("/dead-letter/{seq}", delete(purge_dead_lettered))
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -1423,6 +1442,79 @@ async fn get_event(
         "reply_subject": event.reply_subject,
     });
     Ok(Json(body))
+}
+
+fn stored_event_json(event: crate::storage::StoredEvent) -> Value {
+    use base64::Engine;
+    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(&event.payload);
+    json!({
+        "seq": event.seq,
+        "subject": event.subject,
+        "payload": payload_b64,
+        "stored_at": event.stored_at,
+        "status": event.status,
+        "deliveries": event.deliveries,
+        "reply_subject": event.reply_subject,
+    })
+}
+
+/// List dead-lettered events with optional exact-subject filtering.
+async fn list_dead_lettered(
+    State(state): State<AppState>,
+    Query(query): Query<DeadLetterQuery>,
+) -> Result<Json<Value>, HttpError> {
+    refuse_if_unauth_state_changing(&state, "GET /dead-letter")?;
+    let limit = query.limit.min(1000);
+    let events = state
+        .bus
+        .query_dead_lettered(query.subject.as_deref(), limit)
+        .await
+        .map_err(|e| {
+            warn!("query dead-lettered failed: {}", e);
+            http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+        })?;
+    let body: Vec<Value> = events.into_iter().map(stored_event_json).collect();
+    Ok(Json(json!({ "events": body })))
+}
+
+/// Replay a dead-lettered event in-place.
+async fn replay_dead_lettered(
+    State(state): State<AppState>,
+    Path(seq): Path<u64>,
+) -> Result<Json<ReplayDeadLetterResponse>, HttpError> {
+    refuse_if_unauth_state_changing(&state, "POST /dead-letter/:seq/replay")?;
+    let seq = state.bus.replay_dead_lettered(seq).await.map_err(|e| {
+        let msg = e.to_string();
+        warn!(seq = seq, error = %msg, "dead-letter replay failed");
+        if msg.contains("not found") {
+            http_error_with_code(StatusCode::NOT_FOUND, msg, "EVENT_NOT_FOUND")
+        } else if msg.contains("not dead-lettered") {
+            http_error_with_code(StatusCode::CONFLICT, msg, "EVENT_NOT_DEAD_LETTERED")
+        } else {
+            http_error(StatusCode::INTERNAL_SERVER_ERROR, msg)
+        }
+    })?;
+    Ok(Json(ReplayDeadLetterResponse { seq }))
+}
+
+/// Purge a single dead-lettered event.
+async fn purge_dead_lettered(
+    State(state): State<AppState>,
+    Path(seq): Path<u64>,
+) -> Result<StatusCode, HttpError> {
+    refuse_if_unauth_state_changing(&state, "DELETE /dead-letter/:seq")?;
+    state.bus.purge_dead_lettered(seq).await.map_err(|e| {
+        let msg = e.to_string();
+        warn!(seq = seq, error = %msg, "dead-letter purge failed");
+        if msg.contains("event not found") {
+            http_error_with_code(StatusCode::NOT_FOUND, msg, "EVENT_NOT_FOUND")
+        } else if msg.contains("not dead-lettered") {
+            http_error_with_code(StatusCode::CONFLICT, msg, "EVENT_NOT_DEAD_LETTERED")
+        } else {
+            http_error(StatusCode::INTERNAL_SERVER_ERROR, msg)
+        }
+    })?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]

--- a/crates/core/seidrum-eventbus/tests/phase4_transport.rs
+++ b/crates/core/seidrum-eventbus/tests/phase4_transport.rs
@@ -503,6 +503,99 @@ mod tests {
         env.handles.shutdown_and_join().await;
     }
 
+    /// Dead-letter HTTP endpoints list, replay in place, and purge events.
+    #[tokio::test]
+    async fn test_http_dead_letter_list_replay_and_purge_e2e() {
+        use seidrum_eventbus::storage::{DeliveryStatus, EventStatus, EventStore};
+        use seidrum_eventbus::test_utils::{pick_ephemeral_addr, wait_for_http_ready};
+        use std::time::Duration;
+
+        let store = Arc::new(seidrum_eventbus::storage::memory_store::InMemoryEventStore::new());
+        let http_addr = pick_ephemeral_addr();
+        let handles = EventBusBuilder::new()
+            .storage(Arc::clone(&store) as Arc<dyn EventStore>)
+            .with_http(http_addr)
+            .unsafe_allow_http_dev_mode()
+            .build_with_handles()
+            .await
+            .unwrap();
+        wait_for_http_ready(http_addr).await;
+
+        let opts = SubscribeOpts {
+            priority: 10,
+            mode: SubscriptionMode::Async,
+            channel: ChannelConfig::InProcess,
+            timeout: Duration::from_secs(5),
+            filter: None,
+        };
+        let mut sub = handles.bus.subscribe("dl.http", opts).await.unwrap();
+        let seq = handles
+            .bus
+            .publish("dl.http", b"dead payload")
+            .await
+            .unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(1), sub.rx.recv())
+            .await
+            .unwrap();
+        store
+            .record_delivery(
+                seq,
+                "subscriber-a",
+                DeliveryStatus::DeadLettered,
+                Some("exhausted".to_string()),
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .update_status(seq, EventStatus::DeadLettered)
+            .await
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://{}/dead-letter?subject=dl.http", http_addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["events"].as_array().unwrap().len(), 1);
+        assert_eq!(body["events"][0]["seq"].as_u64(), Some(seq));
+
+        let resp = client
+            .post(format!("http://{}/dead-letter/{}/replay", http_addr, seq))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let replayed: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(replayed["seq"].as_u64(), Some(seq));
+        let received = tokio::time::timeout(Duration::from_secs(1), sub.rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(received.seq, seq);
+        assert_eq!(received.payload, b"dead payload");
+        let event = store.get(seq).await.unwrap().unwrap();
+        assert_eq!(event.status, EventStatus::Delivered);
+        assert!(event.deliveries.iter().all(|d| d.attempts == 0));
+
+        store
+            .update_status(seq, EventStatus::DeadLettered)
+            .await
+            .unwrap();
+        let resp = client
+            .delete(format!("http://{}/dead-letter/{}", http_addr, seq))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 204);
+        assert!(store.get(seq).await.unwrap().is_none());
+
+        handles.shutdown_and_join().await;
+    }
+
     /// Verify the test_utils RecordingInterceptor works end-to-end through
     /// the bus's interceptor chain.
     #[tokio::test]

--- a/crates/core/seidrum-eventbus/tests/phase5_retry.rs
+++ b/crates/core/seidrum-eventbus/tests/phase5_retry.rs
@@ -235,7 +235,7 @@ async fn test_retry_dead_letters_after_max_attempts() {
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut dead = false;
     while Instant::now() < deadline {
-        let events = store.query_dead_lettered(100).await.unwrap();
+        let events = store.query_dead_lettered(None, 100).await.unwrap();
         if events.iter().any(|e| e.seq == seq) {
             dead = true;
             break;
@@ -260,7 +260,7 @@ async fn test_retry_permanent_error_dead_letters_immediately() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut dead = false;
     while Instant::now() < deadline {
-        let events = store.query_dead_lettered(100).await.unwrap();
+        let events = store.query_dead_lettered(None, 100).await.unwrap();
         if events.iter().any(|e| e.seq == seq) {
             dead = true;
             break;
@@ -289,7 +289,7 @@ async fn test_retry_dead_letters_when_subscriber_gone() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut dead = false;
     while Instant::now() < deadline {
-        let events = store.query_dead_lettered(100).await.unwrap();
+        let events = store.query_dead_lettered(None, 100).await.unwrap();
         if events.iter().any(|e| e.seq == seq) {
             dead = true;
             break;


### PR DESCRIPTION
## Summary
- Implements #32 WsClient connection manager with bounded reconnect backoff and optional max attempts.
- Tracks subscriptions by stable client-side id and remaps transient server ids after reconnect.
- Fails in-flight pending operations on disconnect so callers do not hang.
- Adds #26 dead-letter inspection API: list/filter dead-lettered events, replay in-place, and purge via HTTP/storage/bus APIs.
- Adds #25 webhook circuit breaker: per-webhook failure tracking, open/half-open/closed transitions, cooldown backoff, delivery skipping while open, and degraded health reporting.

## Test plan
- cargo fmt --all --check — pass
- cargo check --workspace — pass
- cargo clippy -p seidrum-eventbus --all-targets --features test-utils -- -D warnings — pass
- cargo test --workspace — pass
- cargo clippy --workspace --all-targets -- -D warnings — attempted; blocked by pre-existing unrelated warnings/errors in seidrum-email and seidrum-kernel, after fixing eventbus-owned clippy findings

## Evidence
- #26 targeted: cargo test -p seidrum-eventbus --features test-utils test_http_dead_letter_list_replay_and_purge_e2e --test phase4_transport — pass
- #25 targeted: cargo test -p seidrum-eventbus --features test-utils webhook_circuit --lib — pass
- Workspace tests completed successfully after changes.

Fixes #32
Fixes #26
Fixes #25