### PR TITLE
Milestone 0: pin Rust toolchain and clean clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
 
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
         with:
           targets: ${{ matrix.target }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,14 @@ Thank you for your interest in contributing to Seidrum.
 2. Clone your fork
 3. Create a feature branch (`git checkout -b feature/my-feature`)
 4. Make your changes
-5. Run checks: `cargo build --workspace && cargo clippy --workspace && cargo test --workspace`
+5. Run checks: `cargo check --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
 6. Commit and push to your fork
 7. Open a pull request
 
 ## Development setup
 
 ```bash
-# Prerequisites: Rust stable, NATS Server, ArangoDB 3.12+
+# Prerequisites: Rust 1.88 or newer, NATS Server, ArangoDB 3.12+
 
 # Start infrastructure
 docker compose up -d nats arangodb
@@ -57,7 +57,7 @@ See [docs/PLUGIN_SPEC.md](docs/PLUGIN_SPEC.md) for the full specification.
 
 - Keep PRs focused on a single change
 - Include tests for new functionality
-- Make sure `cargo clippy --workspace` passes with no new warnings
+- Make sure `cargo clippy --workspace --all-targets -- -D warnings` passes
 - Write a clear description of what changed and why
 
 ## Reporting issues

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ members = [
     "crates/plugins/seidrum-feedback-extractor",
 ]
 resolver = "2"
+
+[workspace.package]
+rust-version = "1.88"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There is no architectural distinction between a Telegram adapter, an LLM provide
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) (stable)
+- [Rust](https://rustup.rs/) 1.88 or newer. The repository includes `rust-toolchain.toml`, so `rustup` will select the pinned toolchain automatically.
 - [Docker](https://docker.com/get-started) (for ArangoDB)
 
 ### Quick start

--- a/crates/core/seidrum-common/src/bus_client.rs
+++ b/crates/core/seidrum-common/src/bus_client.rs
@@ -91,8 +91,7 @@ impl BusClient {
                 Err(e) => {
                     if attempt >= Self::CONNECT_MAX_ATTEMPTS {
                         return Err(e.context(format!(
-                            "failed to connect to bus at {} after {} attempts",
-                            url, attempt
+                            "failed to connect to bus at {url} after {attempt} attempts"
                         )));
                     }
                     debug!(
@@ -140,7 +139,7 @@ impl BusClient {
             BackendHandle::InProcess(bus) => {
                 bus.publish(subject_str, &bytes)
                     .await
-                    .map_err(|e| anyhow::anyhow!("publish failed: {}", e))?;
+                    .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
                 debug!(subject = subject_str, "published message (in-process)");
             }
         }
@@ -188,7 +187,7 @@ impl BusClient {
                 let reply = bus
                     .request(subject_str, &bytes, Duration::from_secs(5))
                     .await
-                    .map_err(|e| anyhow::anyhow!("request failed: {}", e))?;
+                    .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
                 Ok(reply)
             }
         }
@@ -210,7 +209,7 @@ impl BusClient {
                 let sub = bus
                     .subscribe(subject_str, opts)
                     .await
-                    .map_err(|e| anyhow::anyhow!("subscribe failed: {}", e))?;
+                    .map_err(|e| anyhow::anyhow!("subscribe failed: {e}"))?;
                 let sub_id = sub.id.clone();
 
                 // Bridge: DispatchedEvent → WsMessage

--- a/crates/core/seidrum-common/src/ws_client.rs
+++ b/crates/core/seidrum-common/src/ws_client.rs
@@ -350,7 +350,7 @@ impl WsClient {
         if let Err(e) = self.manager_tx.send(ManagerCommand::Send(frame)).await {
             // Clean up the pending entry so it doesn't leak.
             self.pending.lock().await.remove(cid);
-            return Err(anyhow::anyhow!("WsClient connection manager closed: {}", e));
+            return Err(anyhow::anyhow!("WsClient connection manager closed: {e}"));
         }
 
         let reply = rx
@@ -358,7 +358,7 @@ impl WsClient {
             .map_err(|_| anyhow::anyhow!("WsClient pending reply dropped (connection lost)"))?;
 
         if let PendingReply::Error(msg) = &reply {
-            return Err(anyhow::anyhow!("bus error: {}", msg));
+            return Err(anyhow::anyhow!("bus error: {msg}"));
         }
 
         Ok(reply)

--- a/crates/core/seidrum-common/tests/ws_client_e2e.rs
+++ b/crates/core/seidrum-common/tests/ws_client_e2e.rs
@@ -28,7 +28,7 @@ async fn start_bus_with_ws() -> (seidrum_eventbus::BusHandles, std::net::SocketA
 #[tokio::test]
 async fn test_ws_client_publish_and_subscribe() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
 
     let client = WsClient::connect(&url, "test-plugin").await.unwrap();
     assert!(client.is_connected());
@@ -62,7 +62,7 @@ async fn test_ws_client_publish_and_subscribe() {
 #[tokio::test]
 async fn test_ws_client_request_reply() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
 
     // Set up a request handler on the bus directly (in-process).
     let req_sub = handles
@@ -90,7 +90,7 @@ async fn test_ws_client_request_reply() {
 #[tokio::test]
 async fn test_ws_client_publish_envelope() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
 
     let client = WsClient::connect(&url, "envelope-test").await.unwrap();
     let mut sub = client.subscribe("envelope.subject").await.unwrap();
@@ -136,7 +136,7 @@ async fn test_ws_client_typed_request() {
     }
 
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
 
     // Echo handler that wraps the payload.
     let req_sub = handles
@@ -171,7 +171,7 @@ async fn test_ws_client_typed_request() {
 #[tokio::test]
 async fn test_ws_client_multiple_subscriptions() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
     let client = WsClient::connect(&url, "multi-sub").await.unwrap();
 
     let mut sub_a = client.subscribe("multi.a").await.unwrap();
@@ -212,7 +212,7 @@ async fn test_ws_client_multiple_subscriptions() {
 #[tokio::test]
 async fn test_ws_client_unsubscribe_stops_delivery() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
     let client = WsClient::connect(&url, "unsub-test").await.unwrap();
 
     let mut sub = client.subscribe("unsub.subject").await.unwrap();
@@ -258,8 +258,7 @@ async fn test_ws_client_connect_refused() {
     let err = format!("{}", result.err().unwrap());
     assert!(
         err.contains("failed to connect"),
-        "error should mention connection failure, got: {}",
-        err
+        "error should mention connection failure, got: {err}"
     );
 }
 
@@ -272,7 +271,7 @@ async fn test_ws_client_connect_refused() {
 #[tokio::test]
 async fn test_ws_client_operations_after_server_shutdown_do_not_hang() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
     let client = WsClient::connect(&url, "disconnect-test").await.unwrap();
     assert!(client.is_connected());
 
@@ -306,7 +305,7 @@ async fn test_bus_client_connect_retries_until_server_ready() {
     use seidrum_eventbus::test_utils::pick_ephemeral_addr;
 
     let ws_addr = pick_ephemeral_addr();
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
 
     // Start the connect in a background task BEFORE the server is up.
     let url_clone = url.clone();
@@ -344,7 +343,7 @@ async fn test_bus_client_connect_retries_until_server_ready() {
 #[tokio::test]
 async fn test_ws_client_request_timeout_configurable() {
     let (handles, ws_addr) = start_bus_with_ws().await;
-    let url = format!("ws://{}", ws_addr);
+    let url = format!("ws://{ws_addr}");
     let client = WsClient::connect(&url, "timeout-test")
         .await
         .unwrap()
@@ -360,8 +359,7 @@ async fn test_ws_client_request_timeout_configurable() {
     assert!(result.is_err(), "request with no handler should time out");
     assert!(
         elapsed < Duration::from_secs(2),
-        "should time out in ~200ms, not wait 5s (elapsed: {:?})",
-        elapsed
+        "should time out in ~200ms, not wait 5s (elapsed: {elapsed:?})"
     );
 
     handles.shutdown_and_join().await;

--- a/crates/core/seidrum-daemon/src/config.rs
+++ b/crates/core/seidrum-daemon/src/config.rs
@@ -249,11 +249,11 @@ pub fn set_enabled(paths: &SeidrumPaths, name: &str, enabled: bool) -> Result<()
             entry.enabled = enabled;
             save_plugins_config(&yaml_path, &config)?;
             let state = if enabled { "enabled" } else { "disabled" };
-            println!("Plugin '{}' {}", name, state);
+            println!("Plugin '{name}' {state}");
             Ok(())
         }
         None => {
-            anyhow::bail!("Plugin '{}' not found in plugins.yaml", name);
+            anyhow::bail!("Plugin '{name}' not found in plugins.yaml");
         }
     }
 }

--- a/crates/core/seidrum-daemon/src/daemon.rs
+++ b/crates/core/seidrum-daemon/src/daemon.rs
@@ -209,10 +209,7 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
     if let Ok(pid_str) = std::fs::read_to_string(&pid_file) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
             if is_process_alive(pid) {
-                anyhow::bail!(
-                    "Daemon is already running (PID {}). Use 'seidrum stop' first.",
-                    pid
-                );
+                anyhow::bail!("Daemon is already running (PID {pid}). Use 'seidrum stop' first.");
             }
         }
         // Stale PID file — remove it
@@ -368,7 +365,7 @@ pub async fn start(paths: &SeidrumPaths) -> Result<()> {
 }
 
 /// Monitor processes and restart crashed ones.
-async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
+async fn check_processes(processes: &mut [ManagedProcess], paths: &SeidrumPaths) {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     for proc in processes.iter_mut() {
@@ -423,7 +420,7 @@ async fn check_processes(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPat
 }
 
 /// Gracefully shut down all processes: SIGTERM plugins first, then kernel.
-async fn shutdown(processes: &mut Vec<ManagedProcess>, paths: &SeidrumPaths) {
+async fn shutdown(processes: &mut [ManagedProcess], paths: &SeidrumPaths) {
     info!("Shutting down all processes...");
 
     // Send SIGTERM to plugins first (not kernel)
@@ -541,7 +538,7 @@ async fn handle_plugin_start(
             if let Some(reply) = &msg.reply {
                 let response = PluginCommandResponse {
                     success: false,
-                    message: format!("Failed to parse command: {}", e),
+                    message: format!("Failed to parse command: {e}"),
                 };
                 let _ = client
                     .reply_to(reply, serde_json::to_vec(&response).unwrap_or_default())
@@ -575,7 +572,7 @@ async fn handle_plugin_start(
         None => {
             let response = PluginCommandResponse {
                 success: false,
-                message: format!("Plugin '{}' not found in plugins.yaml", plugin_name),
+                message: format!("Plugin '{plugin_name}' not found in plugins.yaml"),
             };
             if let Some(reply) = &msg.reply {
                 let _ = client
@@ -592,7 +589,7 @@ async fn handle_plugin_start(
             if is_process_alive(pid) {
                 let response = PluginCommandResponse {
                     success: false,
-                    message: format!("Plugin '{}' is already running (PID {})", plugin_name, pid),
+                    message: format!("Plugin '{plugin_name}' is already running (PID {pid})"),
                 };
                 if let Some(reply) = &msg.reply {
                     let _ = client
@@ -611,7 +608,7 @@ async fn handle_plugin_start(
     if let Err(e) = sync_runtime_env_file() {
         let response = PluginCommandResponse {
             success: false,
-            message: format!("Failed to load .env: {}", e),
+            message: format!("Failed to load .env: {e}"),
         };
         if let Some(reply) = &msg.reply {
             let _ = client
@@ -636,7 +633,7 @@ async fn handle_plugin_start(
             }
             let response = PluginCommandResponse {
                 success: true,
-                message: format!("Plugin '{}' started", plugin_name),
+                message: format!("Plugin '{plugin_name}' started"),
             };
             if let Some(reply) = &msg.reply {
                 let _ = client
@@ -648,7 +645,7 @@ async fn handle_plugin_start(
             error!(name = %plugin_name, error = %e, "Failed to start plugin via bus");
             let response = PluginCommandResponse {
                 success: false,
-                message: format!("Failed to start plugin: {}", e),
+                message: format!("Failed to start plugin: {e}"),
             };
             if let Some(reply) = &msg.reply {
                 let _ = client
@@ -674,7 +671,7 @@ async fn handle_plugin_stop(
             if let Some(reply) = &msg.reply {
                 let response = PluginCommandResponse {
                     success: false,
-                    message: format!("Failed to parse command: {}", e),
+                    message: format!("Failed to parse command: {e}"),
                 };
                 let _ = client
                     .reply_to(reply, serde_json::to_vec(&response).unwrap_or_default())
@@ -693,7 +690,7 @@ async fn handle_plugin_stop(
         Err(_) => {
             let response = PluginCommandResponse {
                 success: false,
-                message: format!("Plugin '{}' does not appear to be running", plugin_name),
+                message: format!("Plugin '{plugin_name}' does not appear to be running"),
             };
             if let Some(reply) = &msg.reply {
                 let _ = client
@@ -724,10 +721,7 @@ async fn handle_plugin_stop(
         let _ = std::fs::remove_file(&pid_file);
         let response = PluginCommandResponse {
             success: false,
-            message: format!(
-                "Plugin '{}' is not running (stale PID file cleaned up)",
-                plugin_name
-            ),
+            message: format!("Plugin '{plugin_name}' is not running (stale PID file cleaned up)"),
         };
         if let Some(reply) = &msg.reply {
             let _ = client
@@ -752,7 +746,7 @@ async fn handle_plugin_stop(
             let _ = std::fs::remove_file(&pid_file);
             let response = PluginCommandResponse {
                 success: true,
-                message: format!("Plugin '{}' stopped", plugin_name),
+                message: format!("Plugin '{plugin_name}' stopped"),
             };
             if let Some(reply) = &msg.reply {
                 let _ = client
@@ -773,7 +767,7 @@ async fn handle_plugin_stop(
 
     let response = PluginCommandResponse {
         success: true,
-        message: format!("Plugin '{}' killed", plugin_name),
+        message: format!("Plugin '{plugin_name}' killed"),
     };
     if let Some(reply) = &msg.reply {
         let _ = client
@@ -813,7 +807,7 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     let entry = config
         .plugins
         .get(name)
-        .ok_or_else(|| anyhow::anyhow!("Plugin '{}' not found in plugins.yaml", name))?;
+        .ok_or_else(|| anyhow::anyhow!("Plugin '{name}' not found in plugins.yaml"))?;
 
     sync_runtime_env_file()?;
 
@@ -824,7 +818,7 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     if let Ok(pid_str) = std::fs::read_to_string(paths.plugin_pid_file(name)) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
             if is_process_alive(pid) {
-                println!("Plugin '{}' is already running (PID {})", name, pid);
+                println!("Plugin '{name}' is already running (PID {pid})");
                 return Ok(());
             }
         }
@@ -844,7 +838,7 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
         });
     }
 
-    println!("Plugin '{}' started", name);
+    println!("Plugin '{name}' started");
     Ok(())
 }
 
@@ -852,15 +846,12 @@ pub async fn start_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
 pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     let pid_file = paths.plugin_pid_file(name);
     let pid_str = std::fs::read_to_string(&pid_file)
-        .with_context(|| format!("Plugin '{}' does not appear to be running", name))?;
+        .with_context(|| format!("Plugin '{name}' does not appear to be running"))?;
     let pid: i32 = pid_str.trim().parse().context("Invalid PID file")?;
 
     if !is_process_alive(pid) {
         let _ = std::fs::remove_file(&pid_file);
-        println!(
-            "Plugin '{}' is not running (stale PID file cleaned up)",
-            name
-        );
+        println!("Plugin '{name}' is not running (stale PID file cleaned up)");
         return Ok(());
     }
 
@@ -876,7 +867,7 @@ pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
         tokio::time::sleep(Duration::from_millis(500)).await;
         if !is_process_alive(pid) {
             let _ = std::fs::remove_file(&pid_file);
-            println!("Plugin '{}' stopped", name);
+            println!("Plugin '{name}' stopped");
             return Ok(());
         }
     }
@@ -887,7 +878,7 @@ pub async fn stop_plugin(paths: &SeidrumPaths, name: &str) -> Result<()> {
     }
     let _ = std::fs::remove_file(&pid_file);
 
-    println!("Plugin '{}' killed", name);
+    println!("Plugin '{name}' killed");
     Ok(())
 }
 

--- a/crates/core/seidrum-daemon/src/infra.rs
+++ b/crates/core/seidrum-daemon/src/infra.rs
@@ -185,7 +185,7 @@ impl InfraManager {
 
     /// Check if a TCP port is in use by attempting to connect.
     pub fn is_port_in_use(port: u16) -> bool {
-        std::net::TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok()
+        std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok()
     }
 
     // -----------------------------------------------------------------------
@@ -213,12 +213,12 @@ impl InfraManager {
                 .template("{spinner:.green} {msg}")
                 .expect("invalid template"),
         );
-        pb.set_message(format!("Downloading NATS v{}...", version));
+        pb.set_message(format!("Downloading NATS v{version}..."));
         pb.enable_steady_tick(Duration::from_millis(120));
 
         let response = reqwest::get(&url)
             .await
-            .with_context(|| format!("Failed to download NATS from {}", url))?;
+            .with_context(|| format!("Failed to download NATS from {url}"))?;
 
         if !response.status().is_success() {
             anyhow::bail!(
@@ -371,7 +371,7 @@ impl InfraManager {
         let status = std::process::Command::new(runtime)
             .args(["pull", &self.config.arango.image])
             .status()
-            .with_context(|| format!("Failed to run '{} pull'", runtime))?;
+            .with_context(|| format!("Failed to run '{runtime} pull'"))?;
 
         if !status.success() {
             anyhow::bail!("Failed to pull ArangoDB image");
@@ -418,7 +418,7 @@ impl InfraManager {
                 &self.config.arango.image,
             ])
             .output()
-            .with_context(|| format!("Failed to run '{} run'", runtime))?;
+            .with_context(|| format!("Failed to run '{runtime} run'"))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -532,13 +532,13 @@ fn platform_pair() -> Result<(&'static str, &'static str)> {
     let os = match std::env::consts::OS {
         "macos" => "darwin",
         "linux" => "linux",
-        other => anyhow::bail!("Unsupported OS for NATS download: {}", other),
+        other => anyhow::bail!("Unsupported OS for NATS download: {other}"),
     };
 
     let arch = match std::env::consts::ARCH {
         "x86_64" => "amd64",
         "aarch64" => "arm64",
-        other => anyhow::bail!("Unsupported architecture for NATS download: {}", other),
+        other => anyhow::bail!("Unsupported architecture for NATS download: {other}"),
     };
 
     Ok((os, arch))
@@ -572,9 +572,7 @@ async fn wait_for_http(url: &str, name: &str, max_retries: u32, interval: Durati
     }
 
     anyhow::bail!(
-        "{} did not become healthy after {} attempts. Check logs in ~/.seidrum/logs/",
-        name,
-        max_retries
+        "{name} did not become healthy after {max_retries} attempts. Check logs in ~/.seidrum/logs/"
     )
 }
 

--- a/crates/core/seidrum-daemon/src/install.rs
+++ b/crates/core/seidrum-daemon/src/install.rs
@@ -41,7 +41,7 @@ fn systemd_unit_path() -> std::path::PathBuf {
         std::path::PathBuf::from("/etc/systemd/system/seidrum.service")
     } else {
         let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        std::path::PathBuf::from(format!("{}/.config/systemd/user/seidrum.service", home))
+        std::path::PathBuf::from(format!("{home}/.config/systemd/user/seidrum.service"))
     }
 }
 
@@ -162,8 +162,7 @@ fn uninstall_systemd() -> Result<()> {
 fn launchd_plist_path() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     std::path::PathBuf::from(format!(
-        "{}/Library/LaunchAgents/com.seidrum.daemon.plist",
-        home
+        "{home}/Library/LaunchAgents/com.seidrum.daemon.plist"
     ))
 }
 

--- a/crates/core/seidrum-daemon/src/main.rs
+++ b/crates/core/seidrum-daemon/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
                 } else {
                     "not running".to_string()
                 };
-                println!("  ArangoDB: {}", arango_status);
+                println!("  ArangoDB: {arango_status}");
                 println!();
             }
             status::show(&paths).await
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
             PkgAction::Info { name } => pkg::list::show_package_info(&name, &paths),
             PkgAction::Update { name } => {
                 if let Some(n) = name {
-                    println!("Updating package: {}", n);
+                    println!("Updating package: {n}");
                     println!("Update functionality not yet implemented");
                 } else {
                     println!("Updating all packages...");

--- a/crates/core/seidrum-daemon/src/paths.rs
+++ b/crates/core/seidrum-daemon/src/paths.rs
@@ -87,22 +87,22 @@ impl SeidrumPaths {
 
     /// Path to a plugin's PID file.
     pub fn plugin_pid_file(&self, name: &str) -> PathBuf {
-        self.pid_dir.join(format!("{}.pid", name))
+        self.pid_dir.join(format!("{name}.pid"))
     }
 
     /// Path to a plugin's metadata file.
     pub fn plugin_meta_file(&self, name: &str) -> PathBuf {
-        self.pid_dir.join(format!("{}.meta", name))
+        self.pid_dir.join(format!("{name}.meta"))
     }
 
     /// Path to a plugin's stopped marker file.
     pub fn plugin_stopped_file(&self, name: &str) -> PathBuf {
-        self.pid_dir.join(format!("{}.stopped", name))
+        self.pid_dir.join(format!("{name}.stopped"))
     }
 
     /// Path to a plugin's log file.
     pub fn plugin_log_file(&self, name: &str) -> PathBuf {
-        self.log_dir.join(format!("{}.log", name))
+        self.log_dir.join(format!("{name}.log"))
     }
 
     /// Resolve a plugin binary path. Checks the daemon's own directory first

--- a/crates/core/seidrum-daemon/src/pkg/download.rs
+++ b/crates/core/seidrum-daemon/src/pkg/download.rs
@@ -15,10 +15,7 @@ fn validate_artifact_url(url: &str) -> Result<()> {
         && !url.starts_with("http://localhost")
         && !url.starts_with("http://127.0.0.1")
     {
-        anyhow::bail!(
-            "Artifact URL must use https:// or be localhost for development: {}",
-            url
-        );
+        anyhow::bail!("Artifact URL must use https:// or be localhost for development: {url}");
     }
 
     // Check for private/internal IP ranges (basic string-based check)
@@ -34,8 +31,7 @@ fn validate_artifact_url(url: &str) -> Result<()> {
     for range in &private_ranges {
         if url.contains(range) && !url.contains("localhost") && !url.contains("127.0.0.1") {
             anyhow::bail!(
-                "Artifact URL uses private/internal IP range, which is not allowed: {}",
-                url
+                "Artifact URL uses private/internal IP range, which is not allowed: {url}"
             );
         }
     }
@@ -105,7 +101,11 @@ pub async fn download_artifact(artifacts: &[PackageArtifact], dest_dir: &Path) -
     };
 
     let mut stream = response.bytes_stream();
-    let filename = artifact.url.split('/').last().unwrap_or("package.tar.gz");
+    let filename = artifact
+        .url
+        .split('/')
+        .next_back()
+        .unwrap_or("package.tar.gz");
     let dest_path = dest_dir.join(filename);
 
     let mut file = File::create(&dest_path)?;

--- a/crates/core/seidrum-daemon/src/pkg/install.rs
+++ b/crates/core/seidrum-daemon/src/pkg/install.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::PermissionsExt;
 
 /// Main install command
 pub async fn install(package_str: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
-    println!("Resolving package: {}", package_str);
+    println!("Resolving package: {package_str}");
 
     // Step 1: Resolve package
     let resolved = resolve::resolve_package(package_str, paths)?;
@@ -22,14 +22,14 @@ pub async fn install(package_str: &str, yes: bool, paths: &SeidrumPaths) -> Resu
     println!("  Name:        {}", manifest.name);
     println!("  Version:     {}", manifest.version);
     if let Some(desc) = &manifest.description {
-        println!("  Description: {}", desc);
+        println!("  Description: {desc}");
     }
     println!("  Kind:        {:?}", manifest.kind);
     println!("  Events:      {:?}", manifest.events);
     if !manifest.env_vars.is_empty() {
         println!("  Environment Variables:");
         for (k, v) in &manifest.env_vars {
-            println!("    {} = {}", k, v);
+            println!("    {k} = {v}");
         }
     }
 
@@ -62,8 +62,6 @@ pub async fn install(package_str: &str, yes: bool, paths: &SeidrumPaths) -> Resu
         kind: manifest.kind.clone(),
         installed_at: Utc::now().to_rfc3339(),
         source: match &resolved.source {
-            super::PackageSource::Registry { name, .. } => name.clone(),
-            super::PackageSource::Url(url) => url.clone(),
             super::PackageSource::Local(path) => path.to_string_lossy().to_string(),
         },
     };
@@ -103,7 +101,7 @@ async fn install_plugin(resolved: &super::ResolvedPackage, paths: &SeidrumPaths)
         .artifacts
         .iter()
         .find(|a| a.target == target)
-        .ok_or_else(|| anyhow::anyhow!("No artifact for target {}", target))?;
+        .ok_or_else(|| anyhow::anyhow!("No artifact for target {target}"))?;
 
     // Verify against the SPECIFIC artifact that was downloaded
     if !verify::verify_sha256(&artifact_path, &artifact.sha256)? {
@@ -281,5 +279,5 @@ fn find_executable(dir: &Path, name: &str) -> Result<PathBuf> {
         }
     }
 
-    anyhow::bail!("Could not find executable for plugin {}", name)
+    anyhow::bail!("Could not find executable for plugin {name}")
 }

--- a/crates/core/seidrum-daemon/src/pkg/list.rs
+++ b/crates/core/seidrum-daemon/src/pkg/list.rs
@@ -43,7 +43,7 @@ pub fn list_packages(paths: &SeidrumPaths) -> Result<()> {
         .collect();
 
     let table = Table::new(&rows);
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }
@@ -69,7 +69,7 @@ pub fn show_package_info(name: &str, paths: &SeidrumPaths) -> Result<()> {
             println!("  Installed At: {}", pkg.installed_at);
         }
         None => {
-            println!("Package '{}' not found.", name);
+            println!("Package '{name}' not found.");
         }
     }
 

--- a/crates/core/seidrum-daemon/src/pkg/mod.rs
+++ b/crates/core/seidrum-daemon/src/pkg/mod.rs
@@ -58,13 +58,10 @@ pub struct PackageDependency {
 pub struct ResolvedPackage {
     pub manifest: PackageManifest,
     pub source: PackageSource,
-    pub manifest_url: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum PackageSource {
-    Registry { name: String, version: String },
-    Url(String),
     Local(PathBuf),
 }
 

--- a/crates/core/seidrum-daemon/src/pkg/publish.rs
+++ b/crates/core/seidrum-daemon/src/pkg/publish.rs
@@ -33,7 +33,7 @@ pub fn publish(registry_name: &str, paths: &SeidrumPaths) -> Result<()> {
         let content = fs::read_to_string(&registries_yaml)?;
         serde_yaml::from_str(&content).map_err(|e| {
             tracing::warn!("Failed to parse registries config: {}", e);
-            anyhow::anyhow!("Failed to parse registries config: {}", e)
+            anyhow::anyhow!("Failed to parse registries config: {e}")
         })?
     } else {
         RegistriesConfig::default()
@@ -41,7 +41,7 @@ pub fn publish(registry_name: &str, paths: &SeidrumPaths) -> Result<()> {
 
     let registry = registries_config
         .find(registry_name)
-        .ok_or_else(|| anyhow::anyhow!("Registry '{}' not configured", registry_name))?;
+        .ok_or_else(|| anyhow::anyhow!("Registry '{registry_name}' not configured"))?;
 
     println!("  Registry: {} ({})", registry.name, registry.url);
 

--- a/crates/core/seidrum-daemon/src/pkg/registry.rs
+++ b/crates/core/seidrum-daemon/src/pkg/registry.rs
@@ -15,14 +15,14 @@ struct RegistryRow {
 
 /// Add a custom registry
 pub fn add_registry(name: &str, url: &str, paths: &SeidrumPaths) -> Result<()> {
-    println!("Adding registry: {}", name);
+    println!("Adding registry: {name}");
 
     let registries_yaml = paths.seidrum_home.join("registries.yaml");
     let mut registries: RegistriesConfig = if registries_yaml.exists() {
         let content = fs::read_to_string(&registries_yaml)?;
         serde_yaml::from_str(&content).map_err(|e| {
             tracing::warn!("Failed to parse registries config: {}", e);
-            anyhow::anyhow!("Failed to parse registries config: {}", e)
+            anyhow::anyhow!("Failed to parse registries config: {e}")
         })?
     } else {
         RegistriesConfig::default()
@@ -31,22 +31,22 @@ pub fn add_registry(name: &str, url: &str, paths: &SeidrumPaths) -> Result<()> {
     // Clone the registry git repo
     let registry_path = paths.registries_dir().join(name);
     if registry_path.exists() {
-        anyhow::bail!("Registry '{}' already exists", name);
+        anyhow::bail!("Registry '{name}' already exists");
     }
 
-    println!("Cloning registry from: {}", url);
+    println!("Cloning registry from: {url}");
     fs::create_dir_all(paths.registries_dir())?;
 
     let registry_str = registry_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("Invalid registry path: contains non-UTF8 characters"))?;
     let output = Command::new("git")
-        .args(&["clone", url, registry_str])
+        .args(["clone", url, registry_str])
         .output()?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to clone registry: {}", stderr);
+        anyhow::bail!("Failed to clone registry: {stderr}");
     }
 
     // Add to registries config
@@ -61,7 +61,7 @@ pub fn add_registry(name: &str, url: &str, paths: &SeidrumPaths) -> Result<()> {
     fs::write(&registries_yaml, yaml_content)?;
 
     info!("Added registry {}", name);
-    println!("Successfully added registry '{}'", name);
+    println!("Successfully added registry '{name}'");
 
     Ok(())
 }
@@ -95,14 +95,14 @@ pub fn list_registries(paths: &SeidrumPaths) -> Result<()> {
         .collect();
 
     let table = Table::new(&rows);
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }
 
 /// Remove a custom registry
 pub fn remove_registry(name: &str, paths: &SeidrumPaths) -> Result<()> {
-    println!("Removing registry: {}", name);
+    println!("Removing registry: {name}");
 
     let registries_yaml = paths.seidrum_home.join("registries.yaml");
     if !registries_yaml.exists() {
@@ -113,7 +113,7 @@ pub fn remove_registry(name: &str, paths: &SeidrumPaths) -> Result<()> {
     let mut registries: RegistriesConfig = serde_yaml::from_str(&content)?;
 
     if registries.find(name).is_none() {
-        anyhow::bail!("Registry '{}' not found", name);
+        anyhow::bail!("Registry '{name}' not found");
     }
 
     registries.remove(name);
@@ -127,7 +127,7 @@ pub fn remove_registry(name: &str, paths: &SeidrumPaths) -> Result<()> {
     }
 
     info!("Removed registry {}", name);
-    println!("Successfully removed registry '{}'", name);
+    println!("Successfully removed registry '{name}'");
 
     Ok(())
 }
@@ -142,7 +142,7 @@ pub fn sync_registry(name: Option<&str>, paths: &SeidrumPaths) -> Result<()> {
     let content = fs::read_to_string(&registries_yaml)?;
     let mut registries: RegistriesConfig = serde_yaml::from_str(&content).map_err(|e| {
         tracing::warn!("Failed to parse registries config: {}", e);
-        anyhow::anyhow!("Failed to parse registries config: {}", e)
+        anyhow::anyhow!("Failed to parse registries config: {e}")
     })?;
 
     let registries_to_sync = if let Some(n) = name {
@@ -156,7 +156,7 @@ pub fn sync_registry(name: Option<&str>, paths: &SeidrumPaths) -> Result<()> {
     };
 
     for reg_name in registries_to_sync {
-        println!("Syncing registry: {}", reg_name);
+        println!("Syncing registry: {reg_name}");
 
         let registry_path = paths.registries_dir().join(&reg_name);
         if !registry_path.exists() {
@@ -166,12 +166,12 @@ pub fn sync_registry(name: Option<&str>, paths: &SeidrumPaths) -> Result<()> {
 
         let output = Command::new("git")
             .current_dir(&registry_path)
-            .args(&["pull"])
+            .args(["pull"])
             .output()?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            println!("  Warning: git pull failed: {}", stderr);
+            println!("  Warning: git pull failed: {stderr}");
         } else {
             // Update sync timestamp
             if let Some(reg) = registries

--- a/crates/core/seidrum-daemon/src/pkg/resolve.rs
+++ b/crates/core/seidrum-daemon/src/pkg/resolve.rs
@@ -1,7 +1,7 @@
 use super::{PackageManifest, PackageSource, ResolvedPackage};
 use crate::paths::SeidrumPaths;
 use anyhow::{anyhow, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 /// Resolve a package reference: name, name@version, or URL
@@ -45,13 +45,12 @@ fn resolve_from_url(url: &str) -> Result<ResolvedPackage> {
     // This is a placeholder - in real implementation, would fetch from HTTP
     // For now, return an error indicating we need to implement HTTP fetching
     Err(anyhow!(
-        "HTTP package resolution not yet implemented. URL: {}",
-        url
+        "HTTP package resolution not yet implemented. URL: {url}"
     ))
 }
 
 /// Resolve from a local directory
-fn resolve_from_local(path: &PathBuf) -> Result<ResolvedPackage> {
+fn resolve_from_local(path: &Path) -> Result<ResolvedPackage> {
     info!("Resolving package from local directory: {}", path.display());
 
     let manifest_path = path.join("seidrum-pkg.yaml");
@@ -59,8 +58,7 @@ fn resolve_from_local(path: &PathBuf) -> Result<ResolvedPackage> {
     let manifest: PackageManifest = serde_yaml::from_str(&manifest_content)?;
 
     Ok(ResolvedPackage {
-        source: PackageSource::Local(path.clone()),
-        manifest_url: manifest_path.to_string_lossy().to_string(),
+        source: PackageSource::Local(path.to_path_buf()),
         manifest,
     })
 }

--- a/crates/core/seidrum-daemon/src/pkg/search.rs
+++ b/crates/core/seidrum-daemon/src/pkg/search.rs
@@ -17,12 +17,12 @@ pub fn search(query: &str, _paths: &SeidrumPaths) -> Result<()> {
 
     // This is a placeholder - in real implementation would search registry index
     // For now, show helpful message
-    println!("Searching registry for: {}", query);
+    println!("Searching registry for: {query}");
     println!();
     println!("Registry search functionality requires a configured registry.");
     println!("Run 'seidrum pkg registry add <name> <url>' to add a registry.");
     println!();
-    println!("No packages found matching: {}", query);
+    println!("No packages found matching: {query}");
 
     Ok(())
 }

--- a/crates/core/seidrum-daemon/src/pkg/uninstall.rs
+++ b/crates/core/seidrum-daemon/src/pkg/uninstall.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 /// Uninstall a package
 pub fn uninstall(name: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
-    println!("Looking up installed package: {}", name);
+    println!("Looking up installed package: {name}");
 
     // Load installed packages
     let installed_yaml = paths.installed_yaml();
@@ -21,7 +21,7 @@ pub fn uninstall(name: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
     let pkg = registry
         .find(name)
         .cloned()
-        .ok_or_else(|| anyhow!("Package {} not installed", name))?;
+        .ok_or_else(|| anyhow!("Package {name} not installed"))?;
 
     println!("\nPackage Details:");
     println!("  Name:        {}", pkg.name);
@@ -42,7 +42,7 @@ pub fn uninstall(name: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
         }
     }
 
-    println!("\nUninstalling {}...", name);
+    println!("\nUninstalling {name}...");
 
     // Remove binary if it's a plugin
     let bin_path = paths.managed_bin_dir().join(name);
@@ -57,7 +57,7 @@ pub fn uninstall(name: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
     // Remove agent files if present
     let agents_dir = paths.config_dir.join("agents");
     if agents_dir.exists() {
-        let agent_file = agents_dir.join(format!("{}.yaml", name));
+        let agent_file = agents_dir.join(format!("{name}.yaml"));
         if agent_file.exists() {
             fs::remove_file(&agent_file)?;
             println!("  Removed agent config: {}", agent_file.display());
@@ -70,7 +70,7 @@ pub fn uninstall(name: &str, yes: bool, paths: &SeidrumPaths) -> Result<()> {
     fs::write(&installed_yaml, yaml_content)?;
 
     info!("Uninstalled package {}", name);
-    println!("\nSuccessfully uninstalled {}", name);
+    println!("\nSuccessfully uninstalled {name}");
 
     Ok(())
 }
@@ -87,7 +87,7 @@ fn remove_plugin_from_config(plugin_name: &str, paths: &SeidrumPaths) -> Result<
     if let Some(root) = doc.as_mapping_mut() {
         let plugins_key = serde_yaml::Value::String("plugins".to_string());
         if let Some(plugins_map) = root.get_mut(&plugins_key).and_then(|v| v.as_mapping_mut()) {
-            plugins_map.remove(&serde_yaml::Value::String(plugin_name.to_string()));
+            plugins_map.remove(serde_yaml::Value::String(plugin_name.to_string()));
         }
     }
 

--- a/crates/core/seidrum-daemon/src/status.rs
+++ b/crates/core/seidrum-daemon/src/status.rs
@@ -21,7 +21,7 @@ pub struct ProcessMeta {
 pub async fn show(paths: &SeidrumPaths) -> Result<()> {
     let daemon_pid = check_pid_file(&paths.daemon_pid_file());
     match daemon_pid {
-        Some(pid) => println!("Seidrum daemon: running (PID {})\n", pid),
+        Some(pid) => println!("Seidrum daemon: running (PID {pid})\n"),
         None => println!("Seidrum daemon: not running\n"),
     }
 
@@ -137,16 +137,16 @@ fn format_uptime(started_at: DateTime<Utc>) -> String {
     let total_secs = duration.num_seconds().max(0) as u64;
 
     if total_secs < 60 {
-        format!("{}s", total_secs)
+        format!("{total_secs}s")
     } else if total_secs < 3600 {
         format!("{}m", total_secs / 60)
     } else if total_secs < 86400 {
         let hours = total_secs / 3600;
         let mins = (total_secs % 3600) / 60;
-        format!("{}h {}m", hours, mins)
+        format!("{hours}h {mins}m")
     } else {
         let days = total_secs / 86400;
         let hours = (total_secs % 86400) / 3600;
-        format!("{}d {}h", days, hours)
+        format!("{days}d {hours}h")
     }
 }

--- a/crates/core/seidrum-e2e/tests/capability.rs
+++ b/crates/core/seidrum-e2e/tests/capability.rs
@@ -29,7 +29,7 @@ async fn test_capability_register_and_search() {
                 "input": { "type": "string" }
             }
         }),
-        call_subject: format!("capability.call.{}", plugin_id),
+        call_subject: format!("capability.call.{plugin_id}"),
         kind: "tool".into(),
     };
 
@@ -50,8 +50,7 @@ async fn test_capability_register_and_search() {
         common::bus_request(&bus, "capability.search", &search_req).await;
     assert!(
         search_resp.tools.iter().any(|t| t.tool_id == tool_id),
-        "Tool {} should appear in search results",
-        tool_id
+        "Tool {tool_id} should appear in search results"
     );
 
     // Describe it

--- a/crates/core/seidrum-e2e/tests/conversation_crud.rs
+++ b/crates/core/seidrum-e2e/tests/conversation_crud.rs
@@ -132,7 +132,7 @@ async fn test_conversation_get_with_max_messages() {
             conversation_id: conv_id.clone(),
             message: ConversationMessage {
                 role: "user".into(),
-                content: Some(format!("Message {}", i)),
+                content: Some(format!("Message {i}")),
                 tool_calls: vec![],
                 tool_results: vec![],
                 media: vec![],

--- a/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
+++ b/crates/core/seidrum-e2e/tests/plugin_lifecycle.rs
@@ -39,7 +39,7 @@ async fn test_plugin_register_and_query() {
         description: "Plugin created by E2E tests".into(),
         consumes: vec![],
         produces: vec![],
-        health_subject: format!("plugin.{}.health", plugin_id),
+        health_subject: format!("plugin.{plugin_id}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,

--- a/crates/core/seidrum-e2e/tests/skill_crud.rs
+++ b/crates/core/seidrum-e2e/tests/skill_crud.rs
@@ -78,8 +78,7 @@ async fn test_skill_search() {
         common::bus_request(&bus, "brain.skill.search", &search_req).await;
     assert!(
         search_resp.skills.iter().any(|s| s.id == skill_id),
-        "Expected to find skill {} in search results",
-        skill_id
+        "Expected to find skill {skill_id} in search results"
     );
 
     // Cleanup

--- a/crates/core/seidrum-eventbus/examples/encryption_interceptor.rs
+++ b/crates/core/seidrum-eventbus/examples/encryption_interceptor.rs
@@ -91,14 +91,14 @@ async fn main() -> anyhow::Result<()> {
     // Simulate: publish an "encrypted" inbound message
     let plaintext = b"Hello from Telegram!";
     let encrypted = xor_cipher(plaintext, key);
-    println!("Publishing encrypted payload: {:?}", encrypted);
+    println!("Publishing encrypted payload: {encrypted:?}");
 
     bus.publish("channel.telegram.inbound", &encrypted).await?;
 
     // The subscriber should receive the decrypted plaintext
     if let Some(event) = sub.rx.recv().await {
         let decrypted = String::from_utf8_lossy(&event.payload);
-        println!("Subscriber received (decrypted): {}", decrypted);
+        println!("Subscriber received (decrypted): {decrypted}");
         assert_eq!(event.payload, plaintext);
         println!("✓ Encryption interceptor works!");
     }

--- a/crates/core/seidrum-eventbus/examples/rate_limiter.rs
+++ b/crates/core/seidrum-eventbus/examples/rate_limiter.rs
@@ -106,7 +106,7 @@ async fn main() -> anyhow::Result<()> {
         });
         let bytes = serde_json::to_vec(&payload)?;
         bus.publish("channel.telegram.inbound", &bytes).await?;
-        println!("Published message {} from alice", i);
+        println!("Published message {i} from alice");
     }
 
     // Collect what got through (with a short timeout for remaining).
@@ -115,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
         received += 1;
     }
 
-    println!("Alice sent 5 messages, {} got through (limit: 3)", received);
+    println!("Alice sent 5 messages, {received} got through (limit: 3)");
     assert_eq!(received, 3, "rate limiter should have dropped 2");
     println!("✓ Rate limiter works!");
 

--- a/crates/core/seidrum-eventbus/src/delivery/in_process.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/in_process.rs
@@ -85,7 +85,7 @@ mod tests {
         let (channel, mut rx) = InProcessChannel::new();
 
         for i in 0..5 {
-            let payload = format!("message {}", i).into_bytes();
+            let payload = format!("message {i}").into_bytes();
             channel
                 .deliver(&payload, "test", &ChannelConfig::InProcess)
                 .await
@@ -94,7 +94,7 @@ mod tests {
 
         for i in 0..5 {
             let received = rx.recv().await.unwrap();
-            assert_eq!(received, format!("message {}", i).into_bytes());
+            assert_eq!(received, format!("message {i}").into_bytes());
         }
     }
 

--- a/crates/core/seidrum-eventbus/src/delivery/retry.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/retry.rs
@@ -267,7 +267,7 @@ impl RetryTask {
     async fn dead_letter(&self, delivery: &RetryableDelivery, reason: &str) {
         // Use a single canonical reason format so log/error parsing is
         // consistent across all dead-letter sources.
-        let formatted = format!("dead-lettered: {}", reason);
+        let formatted = format!("dead-lettered: {reason}");
         if let Err(e) = self
             .store
             .record_delivery(

--- a/crates/core/seidrum-eventbus/src/delivery/webhook.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/webhook.rs
@@ -448,15 +448,13 @@ impl DeliveryChannel for WebhookChannel {
                 );
                 self.record_failure(&url);
                 return Err(DeliveryError::Permanent(format!(
-                    "URL no longer passes SSRF policy: {}",
-                    e
+                    "URL no longer passes SSRF policy: {e}"
                 )));
             }
             Err(join_err) => {
                 self.record_failure(&url);
                 return Err(DeliveryError::Failed(format!(
-                    "validation task panicked: {}",
-                    join_err
+                    "validation task panicked: {join_err}"
                 )));
             }
         };
@@ -477,8 +475,7 @@ impl DeliveryChannel for WebhookChannel {
             Err(e) => {
                 self.record_failure(&url);
                 return Err(DeliveryError::Failed(format!(
-                    "failed to build pinned client: {}",
-                    e
+                    "failed to build pinned client: {e}"
                 )));
             }
         };
@@ -501,7 +498,7 @@ impl DeliveryChannel for WebhookChannel {
         // Send the request
         let response = req.json(&body).send().await.map_err(|e| {
             self.record_failure(&url);
-            DeliveryError::Failed(format!("HTTP request failed: {}", e))
+            DeliveryError::Failed(format!("HTTP request failed: {e}"))
         })?;
 
         // Classify status code: 4xx is permanent (auth errors, not-found,
@@ -682,7 +679,7 @@ mod tests {
             },
         );
         let config = ChannelConfig::Webhook {
-            url: format!("http://{}/hook", addr),
+            url: format!("http://{addr}/hook"),
             headers: HashMap::new(),
         };
 
@@ -730,7 +727,7 @@ mod tests {
         match r {
             Ok(_) => {}
             Err(WebhookUrlError::DnsError(_, _)) => {}
-            Err(e) => panic!("unexpected error for example.com: {}", e),
+            Err(e) => panic!("unexpected error for example.com: {e}"),
         }
     }
 
@@ -763,8 +760,7 @@ mod tests {
         let r = validate_webhook_url("https://169.254.169.254/latest/meta-data/");
         assert!(
             matches!(r, Err(WebhookUrlError::PrivateAddress(_, _))),
-            "AWS metadata IP must be rejected, got {:?}",
-            r
+            "AWS metadata IP must be rejected, got {r:?}"
         );
     }
 
@@ -778,9 +774,7 @@ mod tests {
             let r = validate_webhook_url(url);
             assert!(
                 matches!(r, Err(WebhookUrlError::PrivateAddress(_, _))),
-                "{} must be rejected, got {:?}",
-                url,
-                r
+                "{url} must be rejected, got {r:?}"
             );
         }
     }
@@ -820,8 +814,7 @@ mod tests {
             matches!(r, Err(WebhookUrlError::PrivateAddress(_, _)))
                 || matches!(r, Err(WebhookUrlError::DnsError(_, _)))
                 || matches!(r, Err(WebhookUrlError::Parse(_))),
-            "127.1 short-form must NOT be accepted, got {:?}",
-            r
+            "127.1 short-form must NOT be accepted, got {r:?}"
         );
     }
 
@@ -833,8 +826,7 @@ mod tests {
             matches!(r, Err(WebhookUrlError::PrivateAddress(_, _)))
                 || matches!(r, Err(WebhookUrlError::DnsError(_, _)))
                 || matches!(r, Err(WebhookUrlError::Parse(_))),
-            "decimal-encoded loopback must NOT be accepted, got {:?}",
-            r
+            "decimal-encoded loopback must NOT be accepted, got {r:?}"
         );
     }
 
@@ -863,14 +855,13 @@ mod tests {
     fn test_ssrf_permissive_accepts_loopback_but_rejects_unspecified() {
         let r =
             validate_webhook_url_with_policy("http://127.0.0.1/hook", WebhookUrlPolicy::Permissive);
-        assert!(r.is_ok(), "Permissive should accept loopback, got {:?}", r);
+        assert!(r.is_ok(), "Permissive should accept loopback, got {r:?}");
 
         let r =
             validate_webhook_url_with_policy("http://0.0.0.0/hook", WebhookUrlPolicy::Permissive);
         assert!(
             matches!(r, Err(WebhookUrlError::PrivateAddress(_, _))),
-            "Permissive must still reject 0.0.0.0, got {:?}",
-            r
+            "Permissive must still reject 0.0.0.0, got {r:?}"
         );
     }
 

--- a/crates/core/seidrum-eventbus/src/delivery/websocket.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/websocket.rs
@@ -53,7 +53,7 @@ impl DeliveryChannel for WebSocketChannel {
         });
 
         let msg_bytes = serde_json::to_vec(&message)
-            .map_err(|e| DeliveryError::Failed(format!("JSON encode error: {}", e)))?;
+            .map_err(|e| DeliveryError::Failed(format!("JSON encode error: {e}")))?;
 
         self.tx
             .send(WebSocketMessage { payload: msg_bytes })

--- a/crates/core/seidrum-eventbus/src/delivery/ws_remote.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/ws_remote.rs
@@ -145,10 +145,7 @@ impl DeliveryChannel for WsRemoteChannel {
             Ok(s) => s,
             Err(e) => {
                 self.pending_replies.lock().await.remove(&request_id);
-                return Err(DeliveryError::Failed(format!(
-                    "encode deliver frame: {}",
-                    e
-                )));
+                return Err(DeliveryError::Failed(format!("encode deliver frame: {e}")));
             }
         };
 
@@ -246,7 +243,7 @@ mod tests {
         let result = channel
             .deliver(b"hello", "test.subject", &ChannelConfig::InProcess)
             .await;
-        assert!(result.is_ok(), "deliver should succeed: {:?}", result);
+        assert!(result.is_ok(), "deliver should succeed: {result:?}");
     }
 
     #[tokio::test]
@@ -274,7 +271,7 @@ mod tests {
             .await;
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("client rejected"), "got: {}", err);
+        assert!(err.contains("client rejected"), "got: {err}");
     }
 
     #[tokio::test]
@@ -289,7 +286,7 @@ mod tests {
             .await;
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("timed out"), "got: {}", err);
+        assert!(err.contains("timed out"), "got: {err}");
     }
 
     #[tokio::test]
@@ -314,7 +311,7 @@ mod tests {
         let result = deliver_task.await.unwrap();
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("disconnect"), "got: {}", err);
+        assert!(err.contains("disconnect"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/core/seidrum-eventbus/src/delivery/ws_remote_interceptor.rs
+++ b/crates/core/seidrum-eventbus/src/delivery/ws_remote_interceptor.rs
@@ -434,7 +434,7 @@ mod tests {
             let mut guard = pending.lock().await;
             for i in 0..MAX_PENDING_INTERCEPTS {
                 let (tx, _rx) = oneshot::channel::<WsInterceptReply>();
-                guard.insert(format!("dummy-{}", i), tx);
+                guard.insert(format!("dummy-{i}"), tx);
             }
         }
 

--- a/crates/core/seidrum-eventbus/src/dispatch/engine.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/engine.rs
@@ -216,8 +216,7 @@ impl DispatchEngine {
         }
         if subject.len() > MAX_SUBJECT_LENGTH {
             return Err(EventBusError::InvalidSubject(format!(
-                "subject exceeds maximum length of {} bytes",
-                MAX_SUBJECT_LENGTH
+                "subject exceeds maximum length of {MAX_SUBJECT_LENGTH} bytes"
             )));
         }
         if subject.contains('\0') {
@@ -232,8 +231,7 @@ impl DispatchEngine {
     fn validate_payload(payload: &[u8]) -> crate::Result<()> {
         if payload.len() > MAX_PAYLOAD_SIZE {
             return Err(EventBusError::PayloadTooLarge(format!(
-                "payload exceeds maximum size of {} bytes",
-                MAX_PAYLOAD_SIZE
+                "payload exceeds maximum size of {MAX_PAYLOAD_SIZE} bytes"
             )));
         }
         Ok(())
@@ -292,10 +290,9 @@ impl DispatchEngine {
         if let Ok(intercepting) = INTERCEPTING_SUBJECT.try_with(|s| s.clone()) {
             if intercepting == subject {
                 return Err(EventBusError::Internal(format!(
-                    "re-entrant publish from sync interceptor on subject '{}' \
+                    "re-entrant publish from sync interceptor on subject '{subject}' \
                      would loop; sync interceptors must not publish to \
-                     subjects they intercept",
-                    subject
+                     subjects they intercept"
                 )));
             }
         }
@@ -333,11 +330,10 @@ impl DispatchEngine {
             .get(seq)
             .await
             .map_err(EventBusError::Storage)?
-            .ok_or_else(|| EventBusError::Internal(format!("event {} not found", seq)))?;
+            .ok_or_else(|| EventBusError::Internal(format!("event {seq} not found")))?;
         if event.status != EventStatus::DeadLettered {
             return Err(EventBusError::Internal(format!(
-                "event {} is not dead-lettered",
-                seq
+                "event {seq} is not dead-lettered"
             )));
         }
 
@@ -631,7 +627,7 @@ impl DispatchEngine {
                                 seq,
                                 entry_id,
                                 DeliveryStatus::Failed,
-                                Some(format!("sync channel delivery failed: {}", e)),
+                                Some(format!("sync channel delivery failed: {e}")),
                             )
                             .await;
                         }
@@ -822,8 +818,7 @@ impl DispatchEngine {
             .count();
         if existing_for_pattern >= MAX_INTERCEPTORS_PER_SUBJECT {
             return Err(EventBusError::Internal(format!(
-                "too many interceptors registered for pattern '{}' (max: {})",
-                subject_pattern, MAX_INTERCEPTORS_PER_SUBJECT
+                "too many interceptors registered for pattern '{subject_pattern}' (max: {MAX_INTERCEPTORS_PER_SUBJECT})"
             )));
         }
 
@@ -893,8 +888,7 @@ impl DispatchEngine {
             Some(e) => e,
             None => {
                 return Err(RetryOutcome::Permanent(format!(
-                    "subscriber {} no longer exists",
-                    subscriber_id
+                    "subscriber {subscriber_id} no longer exists"
                 )));
             }
         };
@@ -909,7 +903,7 @@ impl DispatchEngine {
                 {
                     Ok(_) => Ok(()),
                     Err(DeliveryError::Permanent(msg)) => Err(RetryOutcome::Permanent(msg)),
-                    Err(e) => Err(RetryOutcome::Transient(format!("{}", e))),
+                    Err(e) => Err(RetryOutcome::Transient(format!("{e}"))),
                 }
             }
             ChannelConfig::Custom { channel_type, .. } => {
@@ -919,15 +913,14 @@ impl DispatchEngine {
                     Some(c) => c,
                     None => {
                         return Err(RetryOutcome::Permanent(format!(
-                            "no channel registered for type '{}'",
-                            channel_type
+                            "no channel registered for type '{channel_type}'"
                         )));
                     }
                 };
                 match channel.deliver(payload, subject, &entry.channel).await {
                     Ok(_) => Ok(()),
                     Err(DeliveryError::Permanent(msg)) => Err(RetryOutcome::Permanent(msg)),
-                    Err(e) => Err(RetryOutcome::Transient(format!("{}", e))),
+                    Err(e) => Err(RetryOutcome::Transient(format!("{e}"))),
                 }
             }
             ChannelConfig::InProcess => {
@@ -947,7 +940,7 @@ impl DispatchEngine {
                     seq,
                 };
                 tx.try_send(event)
-                    .map_err(|e| RetryOutcome::Transient(format!("{}", e)))
+                    .map_err(|e| RetryOutcome::Transient(format!("{e}")))
             }
             ChannelConfig::WebSocket => {
                 // WebSocket connections are per-session and cannot survive

--- a/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
+++ b/crates/core/seidrum-eventbus/src/dispatch/subject_index.rs
@@ -94,8 +94,7 @@ impl SubjectIndex {
 
         if tokens.len() > MAX_SUBJECT_DEPTH {
             return Err(EventBusError::InvalidSubject(format!(
-                "subject pattern exceeds maximum depth of {} tokens",
-                MAX_SUBJECT_DEPTH
+                "subject pattern exceeds maximum depth of {MAX_SUBJECT_DEPTH} tokens"
             )));
         }
 
@@ -513,7 +512,7 @@ mod tests {
     fn test_subject_depth_limit() {
         let mut index = SubjectIndex::new();
         let deep_pattern = (0..257)
-            .map(|i| format!("level{}", i))
+            .map(|i| format!("level{i}"))
             .collect::<Vec<_>>()
             .join(".");
         let result = index.subscribe(make_entry("sub1", &deep_pattern, 10));

--- a/crates/core/seidrum-eventbus/src/lib.rs
+++ b/crates/core/seidrum-eventbus/src/lib.rs
@@ -242,7 +242,7 @@ pub mod test_utils {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
             if tokio::time::Instant::now() >= deadline {
-                panic!("TCP server at {} did not become ready in time", addr);
+                panic!("TCP server at {addr} did not become ready in time");
             }
             match tokio::time::timeout(
                 Duration::from_millis(200),
@@ -270,10 +270,10 @@ pub mod test_utils {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
             if tokio::time::Instant::now() >= deadline {
-                panic!("HTTP server at {} did not become ready in time", addr);
+                panic!("HTTP server at {addr} did not become ready in time");
             }
             if let Ok(resp) = client
-                .get(format!("http://{}/health", addr))
+                .get(format!("http://{addr}/health"))
                 .timeout(Duration::from_millis(200))
                 .send()
                 .await
@@ -292,11 +292,11 @@ pub mod test_utils {
     /// throwaway connection — the only signal that the listener is up.
     /// Use after starting a bus configured with `with_websocket(...)`.
     pub async fn wait_for_ws_ready(addr: SocketAddr) {
-        let url = format!("ws://{}", addr);
+        let url = format!("ws://{addr}");
         let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
             if tokio::time::Instant::now() >= deadline {
-                panic!("WebSocket server at {} did not become ready in time", addr);
+                panic!("WebSocket server at {addr} did not become ready in time");
             }
             match tokio::time::timeout(
                 Duration::from_millis(200),

--- a/crates/core/seidrum-eventbus/src/storage/memory_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/memory_store.rs
@@ -226,8 +226,7 @@ impl EventStore for InMemoryEventStore {
             .ok_or(super::StorageError::NotFound)?;
         if event.status != EventStatus::DeadLettered {
             return Err(super::StorageError::OperationFailed(format!(
-                "event {} is not dead-lettered",
-                seq
+                "event {seq} is not dead-lettered"
             )));
         }
         event.status = EventStatus::Pending;
@@ -243,8 +242,7 @@ impl EventStore for InMemoryEventStore {
             .ok_or(super::StorageError::NotFound)?;
         if events[idx].status != EventStatus::DeadLettered {
             return Err(super::StorageError::OperationFailed(format!(
-                "event {} is not dead-lettered",
-                seq
+                "event {seq} is not dead-lettered"
             )));
         }
         events.remove(idx);
@@ -300,7 +298,7 @@ mod tests {
             let handle = tokio::spawn(async move {
                 let event = StoredEvent {
                     seq: 0,
-                    subject: format!("test.{}", i),
+                    subject: format!("test.{i}"),
                     payload: vec![i as u8],
                     stored_at: 1000 + i as u64,
                     status: EventStatus::Pending,

--- a/crates/core/seidrum-eventbus/src/storage/redb_store.rs
+++ b/crates/core/seidrum-eventbus/src/storage/redb_store.rs
@@ -41,7 +41,7 @@ impl RedbEventStore {
     pub fn open<P: AsRef<Path>>(path: P) -> StorageResult<Self> {
         let path_ref = path.as_ref();
         let db = Database::create(path_ref)
-            .map_err(|e| StorageError::DatabaseError(format!("failed to open redb: {}", e)))?;
+            .map_err(|e| StorageError::DatabaseError(format!("failed to open redb: {e}")))?;
 
         // Tighten file mode on Unix. No-op on other platforms.
         #[cfg(unix)]
@@ -61,35 +61,31 @@ impl RedbEventStore {
         // Ensure tables exist
         {
             let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin transaction: {}", e))
+                StorageError::DatabaseError(format!("failed to begin transaction: {e}"))
             })?;
             {
                 let _t1 = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let _t2 = write_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open subject_idx table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open subject_idx table: {e}"))
                 })?;
                 let _t3 = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open status_idx table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open status_idx table: {e}"))
                 })?;
                 let _t4 = write_txn
                     .open_table(FAILED_DELIVERIES_IDX_TABLE)
                     .map_err(|e| {
                         StorageError::DatabaseError(format!(
-                            "failed to open failed_deliveries_idx table: {}",
-                            e
+                            "failed to open failed_deliveries_idx table: {e}"
                         ))
                     })?;
                 let _t5 = write_txn.open_table(SUBSCRIPTIONS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!(
-                        "failed to open subscriptions table: {}",
-                        e
-                    ))
+                    StorageError::DatabaseError(format!("failed to open subscriptions table: {e}"))
                 })?;
             }
             write_txn.commit().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to commit transaction: {}", e))
+                StorageError::DatabaseError(format!("failed to commit transaction: {e}"))
             })?;
         }
 
@@ -114,18 +110,18 @@ impl EventStore for RedbEventStore {
             // Use a single write transaction for atomic seq generation + insert.
             // This prevents race conditions where two concurrent appends could
             // read the same last_seq from separate read transactions.
-            let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
-            })?;
+            let write_txn = db
+                .begin_write()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin write: {e}")))?;
 
             // Get next seq inside the write transaction (serialized by redb)
             let next_seq = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let last_seq: u64 = events_table
                     .last()
-                    .map_err(|e| StorageError::DatabaseError(format!("failed to get last: {}", e)))?
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get last: {e}")))?
                     .map(|(k, _)| k.value())
                     .unwrap_or(0);
                 last_seq + 1
@@ -136,50 +132,47 @@ impl EventStore for RedbEventStore {
             stored.stored_at = RedbEventStore::current_time_ms();
 
             let serialized = serde_json::to_vec(&stored).map_err(|e| {
-                StorageError::OperationFailed(format!("failed to serialize event: {}", e))
+                StorageError::OperationFailed(format!("failed to serialize event: {e}"))
             })?;
 
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 events_table
                     .insert(next_seq, serialized.as_slice())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to insert event: {}", e))
+                        StorageError::DatabaseError(format!("failed to insert event: {e}"))
                     })?;
             }
             {
                 let mut subject_idx = write_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open subject_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open subject_idx: {e}"))
                 })?;
                 subject_idx
                     .insert((stored.subject.as_str(), next_seq), ())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!(
-                            "failed to insert subject index: {}",
-                            e
-                        ))
+                        StorageError::DatabaseError(format!("failed to insert subject index: {e}"))
                     })?;
             }
             {
                 let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
                 })?;
                 status_idx
                     .insert((stored.status.as_u8(), next_seq), ())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to insert status index: {}", e))
+                        StorageError::DatabaseError(format!("failed to insert status index: {e}"))
                     })?;
             }
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))?;
 
             Ok(next_seq)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn get(&self, seq: u64) -> StorageResult<Option<StoredEvent>> {
@@ -187,18 +180,18 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {e}")))?;
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
             match events_table
                 .get(seq)
-                .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {}", e)))?
+                .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
             {
                 Some(data) => {
                     let bytes = data.value().to_vec();
                     let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                        StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                        StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                     })?;
                     Ok(Some(event))
                 }
@@ -206,60 +199,58 @@ impl EventStore for RedbEventStore {
             }
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn update_status(&self, seq: u64, status: EventStatus) -> StorageResult<()> {
         let db = Arc::clone(&self.db);
 
         tokio::task::spawn_blocking(move || {
-            let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
-            })?;
+            let write_txn = db
+                .begin_write()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin write: {e}")))?;
 
             // Read the event
             let old_status_u8;
             let serialized = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let data = events_table
                     .get(seq)
-                    .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to get event: {}", e))
-                    })?
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
                     .ok_or(StorageError::NotFound)?;
                 let bytes = data.value().to_vec();
                 let mut event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize event: {e}"))
                 })?;
                 old_status_u8 = event.status.as_u8();
                 event.status = status;
                 serde_json::to_vec(&event).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to serialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to serialize event: {e}"))
                 })?
             };
 
             // Write back
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 events_table
                     .insert(seq, serialized.as_slice())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to update event: {}", e))
+                        StorageError::DatabaseError(format!("failed to update event: {e}"))
                     })?;
             }
 
             // Update status index: remove old, insert new
             {
                 let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
                 })?;
                 let _ = status_idx.remove((old_status_u8, seq));
                 status_idx.insert((status.as_u8(), seq), ()).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to insert new status index: {}", e))
+                    StorageError::DatabaseError(format!("failed to insert new status index: {e}"))
                 })?;
             }
 
@@ -278,10 +269,10 @@ impl EventStore for RedbEventStore {
 
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn record_delivery(
@@ -296,25 +287,23 @@ impl EventStore for RedbEventStore {
         let subscriber_id = subscriber_id.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
-            })?;
+            let write_txn = db
+                .begin_write()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin write: {e}")))?;
 
             // Read the event, mutate the delivery record, and capture the
             // post-update state of the failed-deliveries index.
             let (serialized, has_failed_deliveries) = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let data = events_table
                     .get(seq)
-                    .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to get event: {}", e))
-                    })?
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
                     .ok_or(StorageError::NotFound)?;
                 let bytes = data.value().to_vec();
                 let mut event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize event: {e}"))
                 })?;
 
                 // Update or insert delivery record
@@ -367,7 +356,7 @@ impl EventStore for RedbEventStore {
                     .any(|d| d.status == DeliveryStatus::Failed);
 
                 let serialized = serde_json::to_vec(&event).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to serialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to serialize event: {e}"))
                 })?;
                 (serialized, has_failed)
             };
@@ -375,12 +364,12 @@ impl EventStore for RedbEventStore {
             // Write back the event
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 events_table
                     .insert(seq, serialized.as_slice())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to update event: {}", e))
+                        StorageError::DatabaseError(format!("failed to update event: {e}"))
                     })?;
             }
 
@@ -392,15 +381,13 @@ impl EventStore for RedbEventStore {
                         .open_table(FAILED_DELIVERIES_IDX_TABLE)
                         .map_err(|e| {
                             StorageError::DatabaseError(format!(
-                                "failed to open failed_deliveries_idx: {}",
-                                e
+                                "failed to open failed_deliveries_idx: {e}"
                             ))
                         })?;
                 if has_failed_deliveries {
                     failed_idx.insert(seq, ()).map_err(|e| {
                         StorageError::DatabaseError(format!(
-                            "failed to insert failed_deliveries_idx: {}",
-                            e
+                            "failed to insert failed_deliveries_idx: {e}"
                         ))
                     })?;
                 } else {
@@ -410,10 +397,10 @@ impl EventStore for RedbEventStore {
 
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn query_by_status(
@@ -427,23 +414,22 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {e}")))?;
             let status_idx = read_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
             })?;
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
 
             let mut results = Vec::new();
-            let iter = status_idx.range((status_u8, u64::MIN)..).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to range query: {}", e))
-            })?;
+            let iter = status_idx
+                .range((status_u8, u64::MIN)..)
+                .map_err(|e| StorageError::DatabaseError(format!("failed to range query: {e}")))?;
 
             for item in iter {
-                let (key, _) = item.map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
-                })?;
+                let (key, _) = item
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
                 let (key_status, seq): (u8, u64) = key.value();
                 if key_status != status_u8 {
                     break;
@@ -452,12 +438,13 @@ impl EventStore for RedbEventStore {
                     break;
                 }
 
-                if let Some(data) = events_table.get(seq).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to get event: {}", e))
-                })? {
+                if let Some(data) = events_table
+                    .get(seq)
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
+                {
                     let bytes = data.value().to_vec();
                     let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                        StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                        StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                     })?;
                     // Verify actual status matches index (guards against stale entries).
                     if event.status == status {
@@ -469,7 +456,7 @@ impl EventStore for RedbEventStore {
             Ok(results)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn query_by_subject(
@@ -484,26 +471,23 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {e}")))?;
             let subject_idx = read_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open subject_idx: {}", e))
+                StorageError::DatabaseError(format!("failed to open subject_idx: {e}"))
             })?;
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
 
             let mut results = Vec::new();
             let start_seq = since.unwrap_or(0);
             let iter = subject_idx
                 .range((subject.as_str(), start_seq)..)
-                .map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to range query: {}", e))
-                })?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to range query: {e}")))?;
 
             for item in iter {
-                let (key, _) = item.map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
-                })?;
+                let (key, _) = item
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
                 let (key_subject, seq): (&str, u64) = key.value();
                 if key_subject != subject.as_str() {
                     break;
@@ -512,12 +496,13 @@ impl EventStore for RedbEventStore {
                     break;
                 }
 
-                if let Some(data) = events_table.get(seq).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to get event: {}", e))
-                })? {
+                if let Some(data) = events_table
+                    .get(seq)
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
+                {
                     let bytes = data.value().to_vec();
                     let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                        StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                        StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                     })?;
                     results.push(event);
                 }
@@ -526,7 +511,7 @@ impl EventStore for RedbEventStore {
             Ok(results)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn query_retryable(
@@ -539,16 +524,15 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {e}")))?;
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
             let failed_idx = read_txn
                 .open_table(FAILED_DELIVERIES_IDX_TABLE)
                 .map_err(|e| {
                     StorageError::DatabaseError(format!(
-                        "failed to open failed_deliveries_idx: {}",
-                        e
+                        "failed to open failed_deliveries_idx: {e}"
                     ))
                 })?;
 
@@ -556,18 +540,18 @@ impl EventStore for RedbEventStore {
             // Iterate only events known to have at least one Failed delivery.
             let iter = failed_idx
                 .iter()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
 
             let now = RedbEventStore::current_time_ms();
             for item in iter {
-                let (key, _) = item.map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
-                })?;
+                let (key, _) = item
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
                 let seq: u64 = key.value();
 
-                let data = match events_table.get(seq).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to get event: {}", e))
-                })? {
+                let data = match events_table
+                    .get(seq)
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
+                {
                     Some(d) => d,
                     None => {
                         tracing::warn!(
@@ -579,7 +563,7 @@ impl EventStore for RedbEventStore {
                 };
                 let bytes = data.value().to_vec();
                 let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                 })?;
 
                 for delivery in &event.deliveries {
@@ -609,7 +593,7 @@ impl EventStore for RedbEventStore {
             Ok(results)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn count_retryable(&self, max_attempts: u32) -> StorageResult<u64> {
@@ -617,16 +601,15 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin read: {e}")))?;
             let events_table = read_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
             let failed_idx = read_txn
                 .open_table(FAILED_DELIVERIES_IDX_TABLE)
                 .map_err(|e| {
                     StorageError::DatabaseError(format!(
-                        "failed to open failed_deliveries_idx: {}",
-                        e
+                        "failed to open failed_deliveries_idx: {e}"
                     ))
                 })?;
 
@@ -634,15 +617,15 @@ impl EventStore for RedbEventStore {
             let mut count = 0u64;
             let iter = failed_idx
                 .iter()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
             for item in iter {
-                let (key, _) = item.map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
-                })?;
+                let (key, _) = item
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to iterate: {e}")))?;
                 let seq: u64 = key.value();
-                let data = match events_table.get(seq).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to get event: {}", e))
-                })? {
+                let data = match events_table
+                    .get(seq)
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
+                {
                     Some(d) => d,
                     None => {
                         tracing::warn!(
@@ -654,7 +637,7 @@ impl EventStore for RedbEventStore {
                 };
                 let bytes = data.value().to_vec();
                 let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                 })?;
                 for delivery in &event.deliveries {
                     if delivery.is_retryable(max_attempts, now) {
@@ -665,7 +648,7 @@ impl EventStore for RedbEventStore {
             Ok(count)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn compact(&self, older_than: Duration) -> StorageResult<u64> {
@@ -678,27 +661,27 @@ impl EventStore for RedbEventStore {
             // This prevents TOCTOU races where an event's status could change
             // between identification and deletion.
             let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
+                StorageError::DatabaseError(format!("failed to begin write: {e}"))
             })?;
 
             let to_delete: Vec<(u64, String, u8)> = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
 
                 let mut items = Vec::new();
                 let iter = events_table.iter().map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to iterate: {}", e))
+                    StorageError::DatabaseError(format!("failed to iterate: {e}"))
                 })?;
 
                 for item in iter {
                     let (key, data) = item.map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to iterate: {}", e))
+                        StorageError::DatabaseError(format!("failed to iterate: {e}"))
                     })?;
                     let seq: u64 = key.value();
                     let bytes = data.value().to_vec();
                     let event: StoredEvent = serde_json::from_slice(&bytes).map_err(|e| {
-                        StorageError::OperationFailed(format!("failed to deserialize: {}", e))
+                        StorageError::OperationFailed(format!("failed to deserialize: {e}"))
                     })?;
 
                     let terminal = matches!(
@@ -722,16 +705,16 @@ impl EventStore for RedbEventStore {
 
             // Open tables once outside the loop to avoid repeated handle setup.
             let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                StorageError::DatabaseError(format!("failed to open events table: {e}"))
             })?;
             let mut subject_idx = write_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open subject_idx: {}", e))
+                StorageError::DatabaseError(format!("failed to open subject_idx: {e}"))
             })?;
             let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
             })?;
             let mut failed_idx = write_txn.open_table(FAILED_DELIVERIES_IDX_TABLE).map_err(|e| {
-                StorageError::DatabaseError(format!("failed to open failed_deliveries_idx: {}", e))
+                StorageError::DatabaseError(format!("failed to open failed_deliveries_idx: {e}"))
             })?;
 
             for (seq, subject, status_u8) in &to_delete {
@@ -755,68 +738,65 @@ impl EventStore for RedbEventStore {
 
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))?;
 
             Ok(removed)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn requeue_dead_lettered(&self, seq: u64) -> StorageResult<StoredEvent> {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || {
-            let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
-            })?;
+            let write_txn = db
+                .begin_write()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin write: {e}")))?;
 
             let mut event: StoredEvent = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let data = events_table
                     .get(seq)
-                    .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to get event: {}", e))
-                    })?
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
                     .ok_or(StorageError::NotFound)?;
                 serde_json::from_slice(data.value()).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize event: {e}"))
                 })?
             };
 
             if event.status != EventStatus::DeadLettered {
                 return Err(StorageError::OperationFailed(format!(
-                    "event {} is not dead-lettered",
-                    seq
+                    "event {seq} is not dead-lettered"
                 )));
             }
             let old_status = event.status.as_u8();
             event.status = EventStatus::Pending;
             event.deliveries.clear();
             let serialized = serde_json::to_vec(&event).map_err(|e| {
-                StorageError::OperationFailed(format!("failed to serialize event: {}", e))
+                StorageError::OperationFailed(format!("failed to serialize event: {e}"))
             })?;
 
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 events_table
                     .insert(seq, serialized.as_slice())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to update event: {}", e))
+                        StorageError::DatabaseError(format!("failed to update event: {e}"))
                     })?;
             }
             {
                 let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
                 })?;
                 let _ = status_idx.remove((old_status, seq));
                 status_idx
                     .insert((EventStatus::Pending.as_u8(), seq), ())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to insert status index: {}", e))
+                        StorageError::DatabaseError(format!("failed to insert status index: {e}"))
                     })?;
             }
             {
@@ -825,8 +805,7 @@ impl EventStore for RedbEventStore {
                         .open_table(FAILED_DELIVERIES_IDX_TABLE)
                         .map_err(|e| {
                             StorageError::DatabaseError(format!(
-                                "failed to open failed_deliveries_idx: {}",
-                                e
+                                "failed to open failed_deliveries_idx: {e}"
                             ))
                         })?;
                 let _ = failed_idx.remove(seq);
@@ -834,56 +813,53 @@ impl EventStore for RedbEventStore {
 
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))?;
             Ok(event)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn purge_dead_lettered(&self, seq: u64) -> StorageResult<()> {
         let db = Arc::clone(&self.db);
         tokio::task::spawn_blocking(move || {
-            let write_txn = db.begin_write().map_err(|e| {
-                StorageError::DatabaseError(format!("failed to begin write: {}", e))
-            })?;
+            let write_txn = db
+                .begin_write()
+                .map_err(|e| StorageError::DatabaseError(format!("failed to begin write: {e}")))?;
 
             let event: StoredEvent = {
                 let events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let data = events_table
                     .get(seq)
-                    .map_err(|e| {
-                        StorageError::DatabaseError(format!("failed to get event: {}", e))
-                    })?
+                    .map_err(|e| StorageError::DatabaseError(format!("failed to get event: {e}")))?
                     .ok_or(StorageError::NotFound)?;
                 serde_json::from_slice(data.value()).map_err(|e| {
-                    StorageError::OperationFailed(format!("failed to deserialize event: {}", e))
+                    StorageError::OperationFailed(format!("failed to deserialize event: {e}"))
                 })?
             };
             if event.status != EventStatus::DeadLettered {
                 return Err(StorageError::OperationFailed(format!(
-                    "event {} is not dead-lettered",
-                    seq
+                    "event {seq} is not dead-lettered"
                 )));
             }
 
             {
                 let mut events_table = write_txn.open_table(EVENTS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open events table: {}", e))
+                    StorageError::DatabaseError(format!("failed to open events table: {e}"))
                 })?;
                 let _ = events_table.remove(seq);
             }
             {
                 let mut subject_idx = write_txn.open_table(SUBJECT_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open subject_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open subject_idx: {e}"))
                 })?;
                 let _ = subject_idx.remove((event.subject.as_str(), seq));
             }
             {
                 let mut status_idx = write_txn.open_table(STATUS_IDX_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("failed to open status_idx: {}", e))
+                    StorageError::DatabaseError(format!("failed to open status_idx: {e}"))
                 })?;
                 let _ = status_idx.remove((event.status.as_u8(), seq));
             }
@@ -893,8 +869,7 @@ impl EventStore for RedbEventStore {
                         .open_table(FAILED_DELIVERIES_IDX_TABLE)
                         .map_err(|e| {
                             StorageError::DatabaseError(format!(
-                                "failed to open failed_deliveries_idx: {}",
-                                e
+                                "failed to open failed_deliveries_idx: {e}"
                             ))
                         })?;
                 let _ = failed_idx.remove(seq);
@@ -902,10 +877,10 @@ impl EventStore for RedbEventStore {
 
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {}", e)))
+                .map_err(|e| StorageError::DatabaseError(format!("failed to commit: {e}")))
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking error: {e}")))?
     }
 
     async fn save_subscription(&self, sub: &PersistedSubscription) -> StorageResult<()> {
@@ -913,26 +888,26 @@ impl EventStore for RedbEventStore {
         let sub = sub.clone();
         tokio::task::spawn_blocking(move || {
             let serialized = serde_json::to_vec(&sub).map_err(|e| {
-                StorageError::OperationFailed(format!("serialize subscription: {}", e))
+                StorageError::OperationFailed(format!("serialize subscription: {e}"))
             })?;
             let write_txn = db
                 .begin_write()
-                .map_err(|e| StorageError::DatabaseError(format!("begin write: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("begin write: {e}")))?;
             {
                 let mut t = write_txn.open_table(SUBSCRIPTIONS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("open subscriptions table: {}", e))
+                    StorageError::DatabaseError(format!("open subscriptions table: {e}"))
                 })?;
                 t.insert(sub.persisted_id.as_str(), serialized.as_slice())
                     .map_err(|e| {
-                        StorageError::DatabaseError(format!("insert subscription: {}", e))
+                        StorageError::DatabaseError(format!("insert subscription: {e}"))
                     })?;
             }
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("commit: {}", e)))
+                .map_err(|e| StorageError::DatabaseError(format!("commit: {e}")))
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {e}")))?
     }
 
     async fn list_subscriptions(&self) -> StorageResult<Vec<PersistedSubscription>> {
@@ -940,27 +915,27 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let read_txn = db
                 .begin_read()
-                .map_err(|e| StorageError::DatabaseError(format!("begin read: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("begin read: {e}")))?;
             let table = read_txn
                 .open_table(SUBSCRIPTIONS_TABLE)
-                .map_err(|e| StorageError::DatabaseError(format!("open subscriptions: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("open subscriptions: {e}")))?;
             let mut results = Vec::new();
             let iter = table
                 .iter()
-                .map_err(|e| StorageError::DatabaseError(format!("iterate: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("iterate: {e}")))?;
             for item in iter {
                 let (_, value) =
-                    item.map_err(|e| StorageError::DatabaseError(format!("iterate row: {}", e)))?;
+                    item.map_err(|e| StorageError::DatabaseError(format!("iterate row: {e}")))?;
                 let bytes = value.value().to_vec();
                 let sub: PersistedSubscription = serde_json::from_slice(&bytes).map_err(|e| {
-                    StorageError::OperationFailed(format!("deserialize subscription: {}", e))
+                    StorageError::OperationFailed(format!("deserialize subscription: {e}"))
                 })?;
                 results.push(sub);
             }
             Ok(results)
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {e}")))?
     }
 
     async fn delete_subscription(&self, persisted_id: &str) -> StorageResult<()> {
@@ -969,19 +944,19 @@ impl EventStore for RedbEventStore {
         tokio::task::spawn_blocking(move || {
             let write_txn = db
                 .begin_write()
-                .map_err(|e| StorageError::DatabaseError(format!("begin write: {}", e)))?;
+                .map_err(|e| StorageError::DatabaseError(format!("begin write: {e}")))?;
             {
                 let mut t = write_txn.open_table(SUBSCRIPTIONS_TABLE).map_err(|e| {
-                    StorageError::DatabaseError(format!("open subscriptions table: {}", e))
+                    StorageError::DatabaseError(format!("open subscriptions table: {e}"))
                 })?;
                 let _ = t.remove(persisted_id.as_str());
             }
             write_txn
                 .commit()
-                .map_err(|e| StorageError::DatabaseError(format!("commit: {}", e)))
+                .map_err(|e| StorageError::DatabaseError(format!("commit: {e}")))
         })
         .await
-        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {}", e)))?
+        .map_err(|e| StorageError::OperationFailed(format!("spawn_blocking: {e}")))?
     }
 }
 
@@ -1141,8 +1116,8 @@ mod tests {
                 for i in 0..5 {
                     let event = StoredEvent {
                         seq: 0,
-                        subject: format!("test.task.{}", task_id),
-                        payload: format!("event-{}-{}", task_id, i).into_bytes(),
+                        subject: format!("test.task.{task_id}"),
+                        payload: format!("event-{task_id}-{i}").into_bytes(),
                         stored_at: 0,
                         status: EventStatus::Pending,
                         deliveries: vec![],
@@ -1170,7 +1145,7 @@ mod tests {
         // Every event is readable via get(seq).
         for seq in &all_seqs {
             let event = store.get(*seq).await.unwrap();
-            assert!(event.is_some(), "event seq={} should be readable", seq);
+            assert!(event.is_some(), "event seq={seq} should be readable");
         }
     }
 
@@ -1352,9 +1327,9 @@ mod tests {
         for i in 0..5 {
             store
                 .save_subscription(&PersistedSubscription {
-                    persisted_id: format!("id-{}", i),
-                    pattern: format!("subject.{}", i),
-                    url: format!("https://hook{}.example.com", i),
+                    persisted_id: format!("id-{i}"),
+                    pattern: format!("subject.{i}"),
+                    url: format!("https://hook{i}.example.com"),
                     headers: std::collections::HashMap::new(),
                     priority: i as u32,
                     created_at: 1000 + i as u64,

--- a/crates/core/seidrum-eventbus/src/transport/http.rs
+++ b/crates/core/seidrum-eventbus/src/transport/http.rs
@@ -552,7 +552,7 @@ impl HttpServer {
 
         let listener = tokio::net::TcpListener::bind(addr)
             .await
-            .map_err(|e| crate::EventBusError::Internal(format!("Failed to bind: {}", e)))?;
+            .map_err(|e| crate::EventBusError::Internal(format!("Failed to bind: {e}")))?;
 
         info!("HTTP server listening on {}", addr);
 
@@ -562,7 +562,7 @@ impl HttpServer {
                 let _ = shutdown_rx.wait_for(|&v| v).await;
             })
             .await
-            .map_err(|e| crate::EventBusError::Internal(format!("Server error: {}", e)))?;
+            .map_err(|e| crate::EventBusError::Internal(format!("Server error: {e}")))?;
 
         Ok(())
     }
@@ -601,7 +601,7 @@ async fn publish_event(
         .await
         .map_err(|e| {
             warn!("Publish failed for subject {}: {}", req.subject, e);
-            http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+            http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))
         })?;
 
     debug!("Published event to {}: seq={}", req.subject, seq);
@@ -629,7 +629,7 @@ async fn make_request(
             ),
             _ => {
                 warn!("Request failed for subject {}: {}", req.subject, e);
-                http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+                http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))
             }
         })?;
 
@@ -726,7 +726,7 @@ async fn recreate_persisted_subscription(
     // Re-validate the URL — operator may have tightened the SSRF policy
     // since the entry was persisted.
     if let Err(e) = crate::delivery::validate_webhook_url_with_policy(&entry.url, policy) {
-        return RecreateOutcome::PermanentFailure(format!("URL no longer valid: {}", e));
+        return RecreateOutcome::PermanentFailure(format!("URL no longer valid: {e}"));
     }
 
     // Branch on the entry kind: AsyncWebhook subscriptions go through
@@ -771,8 +771,7 @@ async fn recreate_persisted_async_webhook(
     if prev >= MAX_HTTP_SUBSCRIPTIONS {
         subscription_count.fetch_sub(1, Ordering::Relaxed);
         return RecreateOutcome::TransientFailure(format!(
-            "subscription limit reached ({} max)",
-            MAX_HTTP_SUBSCRIPTIONS
+            "subscription limit reached ({MAX_HTTP_SUBSCRIPTIONS} max)"
         ));
     }
 
@@ -792,11 +791,11 @@ async fn recreate_persisted_async_webhook(
         Ok(sub) => sub,
         Err(crate::EventBusError::InvalidSubject(msg)) => {
             subscription_count.fetch_sub(1, Ordering::Relaxed);
-            return RecreateOutcome::PermanentFailure(format!("invalid pattern: {}", msg));
+            return RecreateOutcome::PermanentFailure(format!("invalid pattern: {msg}"));
         }
         Err(e) => {
             subscription_count.fetch_sub(1, Ordering::Relaxed);
-            return RecreateOutcome::TransientFailure(format!("{}", e));
+            return RecreateOutcome::TransientFailure(format!("{e}"));
         }
     };
     let bus_id = sub.id.clone();
@@ -832,7 +831,7 @@ async fn recreate_persisted_sync_interceptor(
     // entries persisted under the older policy.
 
     if let Err(e) = crate::transport::validate_remote_pattern(&entry.pattern) {
-        return RecreateOutcome::PermanentFailure(format!("pattern no longer permitted: {}", e));
+        return RecreateOutcome::PermanentFailure(format!("pattern no longer permitted: {e}"));
     }
     let effective_priority = crate::transport::clamp_remote_interceptor_priority(entry.priority);
     let clamped_timeout_ms = crate::transport::clamp_remote_interceptor_timeout(entry.timeout_ms);
@@ -844,8 +843,7 @@ async fn recreate_persisted_sync_interceptor(
     if prev >= MAX_HTTP_INTERCEPTORS {
         interceptor_count.fetch_sub(1, Ordering::Relaxed);
         return RecreateOutcome::TransientFailure(format!(
-            "interceptor cap reached ({} max)",
-            MAX_HTTP_INTERCEPTORS
+            "interceptor cap reached ({MAX_HTTP_INTERCEPTORS} max)"
         ));
     }
 
@@ -873,11 +871,11 @@ async fn recreate_persisted_sync_interceptor(
         Ok(id) => id,
         Err(crate::EventBusError::InvalidSubject(msg)) => {
             interceptor_count.fetch_sub(1, Ordering::Relaxed);
-            return RecreateOutcome::PermanentFailure(format!("invalid pattern: {}", msg));
+            return RecreateOutcome::PermanentFailure(format!("invalid pattern: {msg}"));
         }
         Err(e) => {
             interceptor_count.fetch_sub(1, Ordering::Relaxed);
-            return RecreateOutcome::TransientFailure(format!("{}", e));
+            return RecreateOutcome::TransientFailure(format!("{e}"));
         }
     };
 
@@ -940,10 +938,7 @@ async fn create_subscription(
         count.fetch_sub(1, Ordering::Relaxed);
         return Err(http_error_with_code(
             StatusCode::TOO_MANY_REQUESTS,
-            format!(
-                "Subscription limit reached ({} max)",
-                MAX_HTTP_SUBSCRIPTIONS
-            ),
+            format!("Subscription limit reached ({MAX_HTTP_SUBSCRIPTIONS} max)"),
             "SUBSCRIPTION_LIMIT",
         ));
     }
@@ -971,7 +966,7 @@ async fn create_subscription(
             );
             return Err(http_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("{}", e),
+                format!("{e}"),
             ));
         }
     };
@@ -1026,7 +1021,7 @@ async fn create_subscription(
             );
             return Err(http_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to persist subscription: {}", e),
+                format!("failed to persist subscription: {e}"),
             ));
         }
     } else {
@@ -1071,14 +1066,14 @@ async fn remove_subscription(
     if !was_present {
         return Err(http_error_with_code(
             StatusCode::NOT_FOUND,
-            format!("subscription {} not found", id),
+            format!("subscription {id} not found"),
             "SUBSCRIPTION_NOT_FOUND",
         ));
     }
 
     state.bus.unsubscribe(&id).await.map_err(|e| {
         warn!("Unsubscribe failed for id {}: {}", id, e);
-        http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+        http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))
     })?;
 
     // If this was a persisted subscription, drop the persisted entry too.
@@ -1131,8 +1126,7 @@ fn refuse_if_unauth_state_changing(state: &AppState, op_name: &str) -> Result<()
         return Err(http_error_with_code(
             StatusCode::UNAUTHORIZED,
             format!(
-                "{} requires a real authenticator (or HttpServer::unsafe_allow_http_dev_mode() for tests)",
-                op_name
+                "{op_name} requires a real authenticator (or HttpServer::unsafe_allow_http_dev_mode() for tests)"
             ),
             "AUTH_REQUIRED",
         ));
@@ -1178,8 +1172,7 @@ fn check_registration_rate_limit(state: &AppState) -> Result<(), HttpError> {
         return Err(http_error_with_code(
             StatusCode::TOO_MANY_REQUESTS,
             format!(
-                "registration rate limit reached ({} req/{}s)",
-                WEBHOOK_REGISTRATION_RATE_LIMIT, WEBHOOK_REGISTRATION_RATE_WINDOW_SECS
+                "registration rate limit reached ({WEBHOOK_REGISTRATION_RATE_LIMIT} req/{WEBHOOK_REGISTRATION_RATE_WINDOW_SECS}s)"
             ),
             "REGISTRATION_RATE_LIMIT",
         ));
@@ -1240,7 +1233,7 @@ async fn create_interceptor(
         icount.fetch_sub(1, Ordering::Relaxed);
         return Err(http_error_with_code(
             StatusCode::TOO_MANY_REQUESTS,
-            format!("Interceptor limit reached ({} max)", MAX_HTTP_INTERCEPTORS),
+            format!("Interceptor limit reached ({MAX_HTTP_INTERCEPTORS} max)"),
             "INTERCEPTOR_LIMIT",
         ));
     }
@@ -1271,7 +1264,7 @@ async fn create_interceptor(
             );
             return Err(http_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("{}", e),
+                format!("{e}"),
             ));
         }
     };
@@ -1323,7 +1316,7 @@ async fn create_interceptor(
             );
             return Err(http_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to persist interceptor: {}", e),
+                format!("failed to persist interceptor: {e}"),
             ));
         }
     } else {
@@ -1356,7 +1349,7 @@ async fn remove_interceptor(
     if !was_present {
         return Err(http_error_with_code(
             StatusCode::NOT_FOUND,
-            format!("interceptor {} not found", id),
+            format!("interceptor {id} not found"),
             "INTERCEPTOR_NOT_FOUND",
         ));
     }
@@ -1368,7 +1361,7 @@ async fn remove_interceptor(
         warn!("Interceptor unsubscribe failed for id {}: {}", id, e);
         return Err(http_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("{}", e),
+            format!("{e}"),
         ));
     }
 
@@ -1415,14 +1408,14 @@ async fn get_event(
 
     let event = state.bus.get_event(seq).await.map_err(|e| {
         warn!("get_event failed for seq {}: {}", seq, e);
-        http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+        http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))
     })?;
     let event = match event {
         Some(e) => e,
         None => {
             return Err(http_error_with_code(
                 StatusCode::NOT_FOUND,
-                format!("event {} not found", seq),
+                format!("event {seq} not found"),
                 "EVENT_NOT_FOUND",
             ));
         }
@@ -1471,7 +1464,7 @@ async fn list_dead_lettered(
         .await
         .map_err(|e| {
             warn!("query dead-lettered failed: {}", e);
-            http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{}", e))
+            http_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"))
         })?;
     let body: Vec<Value> = events.into_iter().map(stored_event_json).collect();
     Ok(Json(json!({ "events": body })))

--- a/crates/core/seidrum-eventbus/src/transport/mod.rs
+++ b/crates/core/seidrum-eventbus/src/transport/mod.rs
@@ -177,7 +177,7 @@ pub fn validate_and_decode_payload(payload: &str) -> Result<Vec<u8>, String> {
     }
     base64::engine::general_purpose::STANDARD
         .decode(payload)
-        .map_err(|e| format!("Base64 decode failed: {}", e))
+        .map_err(|e| format!("Base64 decode failed: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/core/seidrum-eventbus/src/transport/ws.rs
+++ b/crates/core/seidrum-eventbus/src/transport/ws.rs
@@ -388,7 +388,7 @@ impl WebSocketServer {
     pub async fn start(&self, addr: SocketAddr) -> crate::Result<()> {
         let listener = TcpListener::bind(addr)
             .await
-            .map_err(|e| crate::EventBusError::Internal(format!("Failed to bind: {}", e)))?;
+            .map_err(|e| crate::EventBusError::Internal(format!("Failed to bind: {e}")))?;
 
         info!("WebSocket server listening on {}", addr);
 
@@ -398,7 +398,7 @@ impl WebSocketServer {
             tokio::select! {
                 accept_result = listener.accept() => {
                     let (socket, peer_addr) = accept_result
-                        .map_err(|e| crate::EventBusError::Internal(format!("Accept failed: {}", e)))?;
+                        .map_err(|e| crate::EventBusError::Internal(format!("Accept failed: {e}")))?;
 
                     let bus = Arc::clone(&self.bus);
                     let auth = Arc::clone(&self.authenticator);
@@ -571,7 +571,7 @@ async fn serve_connection(
                 // Validate frame size
                 if text.len() > MAX_FRAME_SIZE {
                     let err = ServerMessage::Error {
-                        message: format!("Message too large (max {} bytes)", MAX_FRAME_SIZE),
+                        message: format!("Message too large (max {MAX_FRAME_SIZE} bytes)"),
                         correlation_id: None,
                     };
                     if let Ok(json) = serde_json::to_string(&err) {
@@ -594,7 +594,7 @@ async fn serve_connection(
                             dev_mode,
                         ).await {
                             let error_msg = ServerMessage::Error {
-                                message: format!("{}", e),
+                                message: format!("{e}"),
                                 correlation_id: None,
                             };
                             if let Ok(json) = serde_json::to_string(&error_msg) {
@@ -605,7 +605,7 @@ async fn serve_connection(
                     Err(e) => {
                         warn!("Invalid operation from {}: {}", peer_addr, e);
                         let error_msg = ServerMessage::Error {
-                            message: format!("Invalid operation: {}", e),
+                            message: format!("Invalid operation: {e}"),
                             correlation_id: None,
                         };
                         if let Ok(json) = serde_json::to_string(&error_msg) {
@@ -711,7 +711,7 @@ async fn ws_send(
     sender
         .send(tokio_tungstenite::tungstenite::Message::text(text))
         .await
-        .map_err(|e| crate::EventBusError::Internal(format!("WebSocket send failed: {}", e)))
+        .map_err(|e| crate::EventBusError::Internal(format!("WebSocket send failed: {e}")))
 }
 
 /// Validate and decode a base64 payload, mapping to our error type.
@@ -744,8 +744,7 @@ async fn handle_operation(
     let refuse_if_open = |op_name: &str| -> crate::Result<()> {
         if auth_open && !dev_mode {
             return Err(crate::EventBusError::Internal(format!(
-                "{} requires a real Authenticator (or WebSocketServer::unsafe_allow_ws_dev_mode() for tests) — AUTH_REQUIRED",
-                op_name
+                "{op_name} requires a real Authenticator (or WebSocketServer::unsafe_allow_ws_dev_mode() for tests) — AUTH_REQUIRED"
             )));
         }
         Ok(())
@@ -785,8 +784,7 @@ async fn handle_operation(
             // Enforce per-connection subscription limit
             if subscriptions.len() >= MAX_SUBSCRIPTIONS_PER_CONNECTION {
                 return Err(crate::EventBusError::Internal(format!(
-                    "Subscription limit reached ({} max per connection)",
-                    MAX_SUBSCRIPTIONS_PER_CONNECTION
+                    "Subscription limit reached ({MAX_SUBSCRIPTIONS_PER_CONNECTION} max per connection)"
                 )));
             }
 
@@ -896,7 +894,7 @@ async fn handle_operation(
                 }
                 Err(e) => {
                     let response = ServerMessage::Error {
-                        message: format!("{}", e),
+                        message: format!("{e}"),
                         correlation_id,
                     };
                     if let Ok(json) = serde_json::to_string(&response) {
@@ -937,16 +935,14 @@ async fn handle_operation(
             }
             if RESERVED_CHANNEL_TYPE_NAMES.contains(&channel_type.as_str()) {
                 return Err(crate::EventBusError::InvalidSubject(format!(
-                    "channel_type '{}' is reserved",
-                    channel_type
+                    "channel_type '{channel_type}' is reserved"
                 )));
             }
 
             // F3: per-connection cap.
             if remote_channels.len() >= MAX_CHANNEL_TYPES_PER_CONNECTION {
                 return Err(crate::EventBusError::Internal(format!(
-                    "channel type limit reached ({} max per WS connection)",
-                    MAX_CHANNEL_TYPES_PER_CONNECTION
+                    "channel type limit reached ({MAX_CHANNEL_TYPES_PER_CONNECTION} max per WS connection)"
                 )));
             }
 
@@ -954,8 +950,7 @@ async fn handle_operation(
             // per-connection (this map) and globally (the bus registry).
             if remote_channels.contains_key(&channel_type) {
                 return Err(crate::EventBusError::InvalidSubject(format!(
-                    "channel type '{}' is already registered on this connection",
-                    channel_type
+                    "channel type '{channel_type}' is already registered on this connection"
                 )));
             }
             // Best-effort global check via the engine — if a channel
@@ -1049,8 +1044,7 @@ async fn handle_operation(
             // interceptor table for the whole bus.
             if remote_interceptors.len() >= MAX_INTERCEPTORS_PER_CONNECTION {
                 return Err(crate::EventBusError::Internal(format!(
-                    "interceptor limit reached ({} max per WS connection)",
-                    MAX_INTERCEPTORS_PER_CONNECTION
+                    "interceptor limit reached ({MAX_INTERCEPTORS_PER_CONNECTION} max per WS connection)"
                 )));
             }
 

--- a/crates/core/seidrum-eventbus/tests/phase4_transport.rs
+++ b/crates/core/seidrum-eventbus/tests/phase4_transport.rs
@@ -136,7 +136,7 @@ mod tests {
                 );
             }
             other => {
-                panic!("Expected Webhook config, got {:?}", other);
+                panic!("Expected Webhook config, got {other:?}");
             }
         }
     }
@@ -210,7 +210,7 @@ mod tests {
 
         let client = reqwest::Client::new();
         let resp = client
-            .post(format!("http://{}/subscribe", addr))
+            .post(format!("http://{addr}/subscribe"))
             .json(&serde_json::json!({
                 "pattern": "persist.test",
                 "url": "http://127.0.0.1:1/never-called",
@@ -296,7 +296,7 @@ mod tests {
 
         let client = reqwest::Client::new();
         let resp = client
-            .post(format!("http://{}/subscribe", addr))
+            .post(format!("http://{addr}/subscribe"))
             .json(&serde_json::json!({
                 "pattern": "persist.delete",
                 "url": "http://127.0.0.1:1/never-called",
@@ -313,7 +313,7 @@ mod tests {
 
         // Now DELETE it.
         let resp = client
-            .delete(format!("http://{}/subscribe/{}", addr, bus_id))
+            .delete(format!("http://{addr}/subscribe/{bus_id}"))
             .send()
             .await
             .unwrap();
@@ -554,7 +554,7 @@ mod tests {
 
         let client = reqwest::Client::new();
         let resp = client
-            .get(format!("http://{}/dead-letter?subject=dl.http", http_addr))
+            .get(format!("http://{http_addr}/dead-letter?subject=dl.http"))
             .send()
             .await
             .unwrap();
@@ -564,7 +564,7 @@ mod tests {
         assert_eq!(body["events"][0]["seq"].as_u64(), Some(seq));
 
         let resp = client
-            .post(format!("http://{}/dead-letter/{}/replay", http_addr, seq))
+            .post(format!("http://{http_addr}/dead-letter/{seq}/replay"))
             .send()
             .await
             .unwrap();
@@ -586,7 +586,7 @@ mod tests {
             .await
             .unwrap();
         let resp = client
-            .delete(format!("http://{}/dead-letter/{}", http_addr, seq))
+            .delete(format!("http://{http_addr}/dead-letter/{seq}"))
             .send()
             .await
             .unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
         wait_for_http_ready(env.http_addr).await;
 
         // Register the webhook sync interceptor via the new endpoint.
-        let webhook_url = format!("http://{}/intercept", interceptor_addr);
+        let webhook_url = format!("http://{interceptor_addr}/intercept");
         let resp = reqwest::Client::new()
             .post(format!("http://{}/interceptors", env.http_addr))
             .json(&serde_json::json!({
@@ -1089,7 +1089,7 @@ mod tests {
         let env = test_bus_with_transports().await;
         wait_for_http_ready(env.http_addr).await;
 
-        let webhook_url = format!("http://{}/intercept", interceptor_addr);
+        let webhook_url = format!("http://{interceptor_addr}/intercept");
         let resp = reqwest::Client::new()
             .post(format!("http://{}/interceptors", env.http_addr))
             .json(&serde_json::json!({
@@ -1154,7 +1154,7 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), 400, "pattern {:?} must be rejected", pattern);
+            assert_eq!(resp.status(), 400, "pattern {pattern:?} must be rejected");
             let body: serde_json::Value = resp.json().await.unwrap();
             assert_eq!(body["code"], "INVALID_INTERCEPTOR_PATTERN");
         }
@@ -1185,7 +1185,7 @@ mod tests {
         wait_for_http_ready(addr).await;
 
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/interceptors", addr))
+            .post(format!("http://{addr}/interceptors"))
             .json(&serde_json::json!({
                 "pattern": "events.audit",
                 "url": "http://127.0.0.1:1/never-called",
@@ -1233,7 +1233,7 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), 200, "request {} should succeed", i);
+            assert_eq!(resp.status(), 200, "request {i} should succeed");
         }
         // The 65th must fail.
         let resp = client
@@ -1274,7 +1274,7 @@ mod tests {
         wait_for_http_ready(addr).await;
 
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/interceptors", addr))
+            .post(format!("http://{addr}/interceptors"))
             .json(&serde_json::json!({
                 "pattern": "events.foo",
                 "url": "http://127.0.0.1:1/never-called",
@@ -1289,7 +1289,7 @@ mod tests {
 
         // Same for POST /subscribe.
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/subscribe", addr))
+            .post(format!("http://{addr}/subscribe"))
             .json(&serde_json::json!({
                 "pattern": "events.foo",
                 "url": "http://127.0.0.1:1/never-called",
@@ -1326,7 +1326,7 @@ mod tests {
         wait_for_http_ready(addr).await;
 
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/subscribe", addr))
+            .post(format!("http://{addr}/subscribe"))
             .json(&serde_json::json!({
                 "pattern": "events.foo",
                 "url": "http://127.0.0.1/hook",
@@ -1376,7 +1376,7 @@ mod tests {
         wait_for_http_ready(addr).await;
 
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/interceptors", addr))
+            .post(format!("http://{addr}/interceptors"))
             .json(&serde_json::json!({
                 "pattern": "events.persisted",
                 "url": "http://127.0.0.1:1/never-called",
@@ -1503,14 +1503,14 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            assert_eq!(resp.status(), 200, "register {} should succeed", suffix);
+            assert_eq!(resp.status(), 200, "register {suffix} should succeed");
         }
 
         // Subscribe to each subject and publish — the original payload
         // should always reach the subscriber because every fallback
         // path returns Pass.
         for suffix in ["five_hundred", "garbage", "invalid_b64"] {
-            let subject = format!("e2e.fallback.{}", suffix);
+            let subject = format!("e2e.fallback.{suffix}");
             let opts = SubscribeOpts {
                 priority: 200,
                 mode: SubscriptionMode::Async,
@@ -1530,8 +1530,7 @@ mod tests {
                 .expect("rx not closed");
             assert_eq!(
                 received.payload, b"original",
-                "fallback {} should leave payload unchanged",
-                suffix
+                "fallback {suffix} should leave payload unchanged"
             );
         }
 
@@ -1660,8 +1659,7 @@ mod tests {
             assert_eq!(
                 resp.status(),
                 400,
-                "subscribe pattern {:?} must be rejected",
-                pattern
+                "subscribe pattern {pattern:?} must be rejected"
             );
             let body: serde_json::Value = resp.json().await.unwrap();
             assert_eq!(body["code"], "INVALID_SUBSCRIBE_PATTERN");
@@ -1706,8 +1704,7 @@ mod tests {
             let parsed: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
             assert_eq!(
                 parsed["op"], "error",
-                "WS subscribe with pattern {:?} must error",
-                pattern
+                "WS subscribe with pattern {pattern:?} must error"
             );
         }
 
@@ -1737,7 +1734,7 @@ mod tests {
             .unwrap();
         wait_for_ws_ready(ws_addr).await;
 
-        let url = format!("ws://{}", ws_addr);
+        let url = format!("ws://{ws_addr}");
         let (ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
         let (mut write, mut read) = ws_stream.split();
 
@@ -1764,8 +1761,7 @@ mod tests {
                 .as_str()
                 .unwrap_or("")
                 .contains("AUTH_REQUIRED"),
-            "expected AUTH_REQUIRED, got {:?}",
-            parsed
+            "expected AUTH_REQUIRED, got {parsed:?}"
         );
 
         // register_channel_type should also be refused.
@@ -1830,8 +1826,7 @@ mod tests {
             let parsed: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
             assert_eq!(
                 parsed["op"], "error",
-                "channel name {:?} must be rejected",
-                name
+                "channel name {name:?} must be rejected"
             );
         }
 
@@ -1926,8 +1921,7 @@ mod tests {
         // Must be Permanent so the retry task doesn't keep trying.
         assert!(
             matches!(result, Err(DeliveryError::Permanent(_))),
-            "expected Permanent, got {:?}",
-            result
+            "expected Permanent, got {result:?}"
         );
     }
 
@@ -2044,7 +2038,7 @@ mod tests {
 
         // POST /subscribe returns 500 because save_subscription errors.
         let resp = reqwest::Client::new()
-            .post(format!("http://{}/subscribe", addr))
+            .post(format!("http://{addr}/subscribe"))
             .json(&serde_json::json!({
                 "pattern": "any.subject",
                 "url": "http://127.0.0.1:1/hook",

--- a/crates/core/seidrum-eventbus/tests/phase5_retry.rs
+++ b/crates/core/seidrum-eventbus/tests/phase5_retry.rs
@@ -53,7 +53,7 @@ impl DeliveryChannel for FlakyChannel {
     ) -> DeliveryResult<DeliveryReceipt> {
         let call = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
         if call <= self.fail_attempts {
-            Err(DeliveryError::Failed(format!("flaky failure #{}", call)))
+            Err(DeliveryError::Failed(format!("flaky failure #{call}")))
         } else {
             Ok(DeliveryReceipt {
                 delivered_at: 0,
@@ -423,8 +423,7 @@ async fn test_with_retry_poll_interval_order_independent() {
 
     assert!(
         calls >= 3,
-        "expected at least 3 retry calls with 30ms poll interval, got {}",
-        calls
+        "expected at least 3 retry calls with 30ms poll interval, got {calls}"
     );
 }
 

--- a/crates/core/seidrum-kernel/src/brain/client.rs
+++ b/crates/core/seidrum-kernel/src/brain/client.rs
@@ -35,9 +35,9 @@ impl ArangoClient {
 
         // ArangoDB uses HTTP basic auth; default user is "root".
         use base64::Engine as _;
-        let credentials = format!("root:{}", password);
+        let credentials = format!("root:{password}");
         let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
-        let auth_header = format!("Basic {}", encoded);
+        let auth_header = format!("Basic {encoded}");
 
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -71,7 +71,7 @@ impl ArangoClient {
             .json(body)
             .send()
             .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .with_context(|| format!("POST {url} failed"))?;
 
         let status = resp.status();
         let text = resp.text().await.context("failed to read response body")?;
@@ -92,7 +92,7 @@ impl ArangoClient {
             .header("Authorization", &self.auth_header)
             .send()
             .await
-            .with_context(|| format!("GET {} failed", url))?;
+            .with_context(|| format!("GET {url} failed"))?;
 
         let status = resp.status();
         let text = resp.text().await.context("failed to read response body")?;
@@ -217,7 +217,7 @@ impl ArangoClient {
         unique: bool,
         sparse: bool,
     ) -> Result<()> {
-        let url = self.db_url(&format!("/_api/index?collection={}", collection));
+        let url = self.db_url(&format!("/_api/index?collection={collection}"));
         let body = serde_json::json!({
             "type": "persistent",
             "fields": fields,
@@ -247,7 +247,7 @@ impl ArangoClient {
         dimension: u32,
         metric: &str,
     ) -> Result<()> {
-        let url = self.db_url(&format!("/_api/index?collection={}", collection));
+        let url = self.db_url(&format!("/_api/index?collection={collection}"));
         let body = serde_json::json!({
             "type": "mdi-prefixed",
             "fields": [field],
@@ -342,7 +342,7 @@ impl ArangoClient {
 
     /// Insert a document into a collection. Returns the created document metadata.
     pub async fn insert_document(&self, collection: &str, doc: &Value) -> Result<Value> {
-        let url = self.db_url(&format!("/_api/document/{}", collection));
+        let url = self.db_url(&format!("/_api/document/{collection}"));
         let resp = self.post(&url, doc).await?;
 
         if resp.get("error").and_then(|v| v.as_bool()).unwrap_or(false) {
@@ -369,9 +369,8 @@ impl ArangoClient {
             r#"UPSERT {{ _key: @key }}
                INSERT MERGE(@doc, {{ _key: @key }})
                UPDATE MERGE(OLD, @doc)
-               IN {}
-               RETURN {{ doc: NEW, is_new: IS_NULL(OLD) }}"#,
-            collection
+               IN {collection}
+               RETURN {{ doc: NEW, is_new: IS_NULL(OLD) }}"#
         );
         let bind_vars = serde_json::json!({
             "key": key,
@@ -413,7 +412,7 @@ impl ArangoClient {
 
     /// Get a single document by collection and key.
     pub async fn get_document(&self, collection: &str, key: &str) -> Result<Option<Value>> {
-        let url = self.db_url(&format!("/_api/document/{}/{}", collection, key));
+        let url = self.db_url(&format!("/_api/document/{collection}/{key}"));
         trace!("GET {}", url);
         let resp = self
             .http
@@ -421,7 +420,7 @@ impl ArangoClient {
             .header("Authorization", &self.auth_header)
             .send()
             .await
-            .with_context(|| format!("GET {} failed", url))?;
+            .with_context(|| format!("GET {url} failed"))?;
 
         let status = resp.status();
         if status.as_u16() == 404 {

--- a/crates/core/seidrum-kernel/src/brain/init.rs
+++ b/crates/core/seidrum-kernel/src/brain/init.rs
@@ -53,7 +53,7 @@ pub async fn initialize_brain(client: &ArangoClient) -> Result<()> {
         client
             .create_collection(name)
             .await
-            .with_context(|| format!("creating vertex collection '{}'", name))?;
+            .with_context(|| format!("creating vertex collection '{name}'"))?;
         info!("  [OK] {}", name);
     }
 
@@ -63,7 +63,7 @@ pub async fn initialize_brain(client: &ArangoClient) -> Result<()> {
         client
             .create_edge_collection(name)
             .await
-            .with_context(|| format!("creating edge collection '{}'", name))?;
+            .with_context(|| format!("creating edge collection '{name}'"))?;
         info!("  [OK] {}", name);
     }
 

--- a/crates/core/seidrum-kernel/src/brain/service.rs
+++ b/crates/core/seidrum-kernel/src/brain/service.rs
@@ -506,7 +506,7 @@ async fn publish_response<T: serde::Serialize>(
     let bytes = serde_json::to_vec(&envelope).context("failed to serialize response")?;
     nats.publish_bytes(subject.to_string(), bytes)
         .await
-        .with_context(|| format!("failed to publish to {}", subject))?;
+        .with_context(|| format!("failed to publish to {subject}"))?;
     debug!(subject, "published response event");
     Ok(())
 }
@@ -530,7 +530,7 @@ async fn reply_with<T: serde::Serialize>(
     let bytes = serde_json::to_vec(&envelope).context("failed to serialize reply")?;
     nats.publish_bytes(reply_subject.to_string(), bytes)
         .await
-        .with_context(|| format!("failed to reply to {}", reply_subject))?;
+        .with_context(|| format!("failed to reply to {reply_subject}"))?;
     debug!(reply_subject, "sent reply");
     Ok(())
 }
@@ -549,7 +549,7 @@ fn generate_entity_key(name: &str) -> String {
         .chars()
         .map(|c| if c.is_alphanumeric() { c } else { '_' })
         .collect();
-    format!("entity_{}", slug)
+    format!("entity_{slug}")
 }
 
 /// Generate a fact key.
@@ -745,8 +745,8 @@ async fn handle_entity_upsert(
         let edge_data = serde_json::json!({
             "mention_type": mention_type,
         });
-        let from = format!("content/{}", content_key);
-        let to = format!("entities/{}", entity_key);
+        let from = format!("content/{content_key}");
+        let to = format!("entities/{entity_key}");
         if let Err(e) = arango.insert_edge("mentions", &from, &to, &edge_data).await {
             warn!(error = %e, "failed to create mentions edge (may already exist)");
         }
@@ -882,8 +882,8 @@ async fn handle_fact_upsert(
                 "reason": "updated via brain.fact.upsert",
                 "superseded_at": now,
             });
-            let from = format!("facts/{}", fact_key);
-            let to = format!("facts/{}", old_key);
+            let from = format!("facts/{fact_key}");
+            let to = format!("facts/{old_key}");
             let _ = arango
                 .insert_edge("supersedes", &from, &to, &edge_data)
                 .await;
@@ -916,7 +916,7 @@ async fn handle_fact_upsert(
                 "extraction_confidence": req.confidence,
                 "extracted_at": now,
             });
-            let from = format!("facts/{}", fact_key);
+            let from = format!("facts/{fact_key}");
             let to = format!("content/{}", req.source_content);
             let _ = arango
                 .insert_edge("derived_from", &from, &to, &derived_edge)
@@ -954,7 +954,7 @@ async fn handle_fact_upsert(
             "extraction_confidence": req.confidence,
             "extracted_at": now,
         });
-        let from = format!("facts/{}", fact_key);
+        let from = format!("facts/{fact_key}");
         let to = format!("content/{}", req.source_content);
         let _ = arango
             .insert_edge("derived_from", &from, &to, &derived_edge)
@@ -1044,12 +1044,12 @@ async fn detect_collection_id(arango: &ArangoClient, key: &str) -> Result<String
     // Try common collections in order
     for collection in &["entities", "content", "facts", "tasks"] {
         if let Ok(Some(_)) = arango.get_document(collection, key).await {
-            return Ok(format!("{}/{}", collection, key));
+            return Ok(format!("{collection}/{key}"));
         }
     }
     // Default to entities if not found (the insert might fail, but that is
     // the caller's problem).
-    Ok(format!("entities/{}", key))
+    Ok(format!("entities/{key}"))
 }
 
 /// Handle `brain.task.upsert` — create or update a task.
@@ -1355,8 +1355,7 @@ async fn handle_vector_search(
                 FILTER LENGTH(INTERSECTION(doc_scopes, @allowed_scopes)) > 0
                 SORT distance DESC
                 LIMIT @limit
-                RETURN MERGE(doc, {{ _similarity: distance }})"#,
-            collection = collection
+                RETURN MERGE(doc, {{ _similarity: distance }})"#
         )
     } else {
         format!(
@@ -1365,8 +1364,7 @@ async fn handle_vector_search(
                 FILTER distance != null
                 SORT distance DESC
                 LIMIT @limit
-                RETURN MERGE(doc, {{ _similarity: distance }})"#,
-            collection = collection
+                RETURN MERGE(doc, {{ _similarity: distance }})"#
         )
     };
 
@@ -1482,8 +1480,7 @@ async fn handle_hybrid_search(
                 FILTER LENGTH(INTERSECTION(doc_scopes, @allowed_scopes)) > 0
                 SORT distance DESC
                 LIMIT @limit
-                RETURN {{ doc, distance, source: "vector_match" }}"#,
-            safe_collection = safe_collection
+                RETURN {{ doc, distance, source: "vector_match" }}"#
         )
     } else {
         format!(
@@ -1492,8 +1489,7 @@ async fn handle_hybrid_search(
                 FILTER distance != null
                 SORT distance DESC
                 LIMIT @limit
-                RETURN {{ doc, distance, source: "vector_match" }}"#,
-            safe_collection = safe_collection
+                RETURN {{ doc, distance, source: "vector_match" }}"#
         )
     };
 
@@ -1589,10 +1585,9 @@ async fn handle_graph_traverse(
     };
 
     let aql = format!(
-        r#"FOR v, e, p IN 1..@depth {direction} @start
+        r#"FOR v, e, p IN 1..@depth {direction_keyword} @start
              GRAPH "brain"
              RETURN {{ vertex: v, edge: e }}"#,
-        direction = direction_keyword,
     );
 
     let bind_vars = serde_json::json!({
@@ -1625,7 +1620,7 @@ async fn handle_get_facts(
     let entity_id = if start_vertex.contains('/') {
         start_vertex.to_string()
     } else {
-        format!("entities/{}", start_vertex)
+        format!("entities/{start_vertex}")
     };
 
     let aql = r#"
@@ -1690,7 +1685,7 @@ async fn handle_get_context(
     let scope_id = if scope.contains('/') {
         scope.to_string()
     } else {
-        format!("scopes/{}", scope)
+        format!("scopes/{scope}")
     };
 
     let bind_vars = serde_json::json!({
@@ -1744,13 +1739,13 @@ async fn handle_conversation_create(
 
     // Create scoped_to edge linking conversation to user's scope
     if let Some(user_id) = &req.user_id {
-        let user_scope = format!("scopes/scope_{}", user_id);
+        let user_scope = format!("scopes/scope_{user_id}");
         let edge_data = serde_json::json!({
             "relevance": 1.0,
             "added_at": now,
             "added_by": "kernel",
         });
-        let from = format!("conversations/{}", conv_id);
+        let from = format!("conversations/{conv_id}");
         let _ = arango
             .insert_edge("scoped_to", &from, &user_scope, &edge_data)
             .await;
@@ -1915,12 +1910,11 @@ async fn handle_conversation_find(
             FILTER conv.platform == @platform
             FILTER conv.metadata[@meta_key] == @meta_value
             FILTER conv.state == "active"
-            {}
+            {user_filter}
             SORT conv.updated_at DESC
             LIMIT 1
             RETURN MERGE(conv, {{ id: conv._key }})
-    "#,
-        user_filter
+    "#
     );
 
     let mut bind_vars = serde_json::json!({
@@ -2003,7 +1997,7 @@ async fn handle_conversation_list(
     let query = format!(
         r#"
             FOR conv IN conversations
-                {}
+                {filter_clause}
                 SORT conv.updated_at DESC
                 LIMIT @limit
                 RETURN {{
@@ -2014,8 +2008,7 @@ async fn handle_conversation_list(
                     state: conv.state,
                     updated_at: conv.updated_at
                 }}
-        "#,
-        filter_clause
+        "#
     );
 
     let bind_vars = Value::Object(bind_vars);
@@ -2512,7 +2505,7 @@ async fn handle_user_create(
     }
 
     // Create the user scope
-    let user_scope_key = format!("scope_{}", user_id);
+    let user_scope_key = format!("scope_{user_id}");
     let scope_doc = serde_json::json!({
         "_key": user_scope_key,
         "name": format!("{}'s scope", req.username),
@@ -2957,11 +2950,10 @@ async fn handle_audit_query(
 
     let query = format!(
         r#"
-        LET total = LENGTH(FOR a IN audit_log {} RETURN 1)
-        LET entries = (FOR a IN audit_log {} SORT a.timestamp DESC LIMIT @limit RETURN a)
+        LET total = LENGTH(FOR a IN audit_log {filter_clause} RETURN 1)
+        LET entries = (FOR a IN audit_log {filter_clause} SORT a.timestamp DESC LIMIT @limit RETURN a)
         RETURN {{ total: total, entries: entries }}
-    "#,
-        filter_clause, filter_clause
+    "#
     );
 
     let result = arango

--- a/crates/core/seidrum-kernel/src/consciousness/builtin_capabilities.rs
+++ b/crates/core/seidrum-kernel/src/consciousness/builtin_capabilities.rs
@@ -119,7 +119,7 @@ pub async fn handle_subscribe_events(
                     origin: None,
                 };
 
-                let consciousness_subject = format!("agent.{}.consciousness", agent_id_clone);
+                let consciousness_subject = format!("agent.{agent_id_clone}.consciousness");
                 if let Ok(bytes) = serde_json::to_vec(&event) {
                     if let Err(e) = nats_clone.publish_bytes(consciousness_subject, bytes).await {
                         warn!(%e, "Failed to publish consciousness event");
@@ -337,7 +337,7 @@ pub async fn handle_schedule_wake(
             origin: None,
         };
 
-        let subject = format!("agent.{}.consciousness", agent_id_clone);
+        let subject = format!("agent.{agent_id_clone}.consciousness");
         if let Ok(bytes) = serde_json::to_vec(&event) {
             let _ = nats_clone.publish_bytes(subject, bytes).await;
         }

--- a/crates/core/seidrum-kernel/src/consciousness/guardrails.rs
+++ b/crates/core/seidrum-kernel/src/consciousness/guardrails.rs
@@ -52,7 +52,7 @@ impl GuardrailState {
         }
 
         // Loop detection
-        let key = format!("{}:{}", tool_name, arguments_hash);
+        let key = format!("{tool_name}:{arguments_hash}");
         let count = self.tool_call_history.entry(key).or_insert(0);
         *count += 1;
         if *count >= self.config.loop_detection_threshold {

--- a/crates/core/seidrum-kernel/src/consciousness/service.rs
+++ b/crates/core/seidrum-kernel/src/consciousness/service.rs
@@ -142,7 +142,7 @@ impl ConsciousnessService {
                             origin: None,
                         };
 
-                        let subject = format!("agent.{}.consciousness", agent_id);
+                        let subject = format!("agent.{agent_id}.consciousness");
                         if let Ok(bytes) = serde_json::to_vec(&event) {
                             let _ = nats.publish_bytes(subject, bytes).await;
                         }
@@ -167,7 +167,7 @@ impl ConsciousnessService {
             let agent_id_sub = agent_id.clone();
             let tx_clone = tx.clone();
             tokio::spawn(async move {
-                let subject = format!("agent.{}.consciousness", agent_id_sub);
+                let subject = format!("agent.{agent_id_sub}.consciousness");
                 let mut sub = match nats_sub.subscribe(subject.clone()).await {
                     Ok(s) => s,
                     Err(e) => {
@@ -761,7 +761,7 @@ async fn process_consciousness_event(
 
     // C1: Use configurable LLM provider instead of hardcoded "google"
     let llm_provider = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "google".to_string());
-    let llm_subject = format!("llm.provider.{}", llm_provider);
+    let llm_subject = format!("llm.provider.{llm_provider}");
 
     // 7. Dispatch to LLM provider (120s timeout)
     let llm_response: LlmResponse = match tokio::time::timeout(
@@ -803,19 +803,16 @@ async fn process_consciousness_event(
                 );
                 guardrail_msg = match violation {
                     guardrails::GuardrailViolation::TurnLimitReached(n) => {
-                        format!("Tool call limit reached ({} turns). Stopping.", n)
+                        format!("Tool call limit reached ({n} turns). Stopping.")
                     }
                     guardrails::GuardrailViolation::TimeLimitReached(s) => {
-                        format!("Time limit reached ({}s). Stopping.", s)
+                        format!("Time limit reached ({s}s). Stopping.")
                     }
                     guardrails::GuardrailViolation::LoopDetected { tool_name, count } => {
-                        format!(
-                            "Loop detected: {} called {} times with same args.",
-                            tool_name, count
-                        )
+                        format!("Loop detected: {tool_name} called {count} times with same args.")
                     }
                     guardrails::GuardrailViolation::HitlRequired(n) => {
-                        format!("Human approval needed after {} turns.", n)
+                        format!("Human approval needed after {n} turns.")
                     }
                 };
                 guardrail_triggered = true;
@@ -1066,12 +1063,12 @@ fn build_full_system_prompt(
 
     // S1+S2: Use cached identity prompt instead of reading from disk each time
     if !cached_identity.is_empty() {
-        parts.push(format!("## Agent Identity\n\n{}", cached_identity));
+        parts.push(format!("## Agent Identity\n\n{cached_identity}"));
     }
 
     // Agent description
     if let Some(ref desc) = agent_def.description {
-        parts.push(format!("## Agent Description\n\n{}", desc));
+        parts.push(format!("## Agent Description\n\n{desc}"));
     }
 
     // Skill snippets
@@ -1082,7 +1079,7 @@ fn build_full_system_prompt(
             .map(|(i, s)| format!("### Skill {}\n{}", i + 1, s))
             .collect::<Vec<_>>()
             .join("\n\n");
-        parts.push(format!("## Active Skills\n\n{}", skills_section));
+        parts.push(format!("## Active Skills\n\n{skills_section}"));
     }
 
     parts.join("\n\n---\n\n")
@@ -1105,12 +1102,12 @@ fn build_full_system_prompt_with_preferences(
 
     // S1+S2: Use cached identity prompt instead of reading from disk each time
     if !cached_identity.is_empty() {
-        parts.push(format!("## Agent Identity\n\n{}", cached_identity));
+        parts.push(format!("## Agent Identity\n\n{cached_identity}"));
     }
 
     // Agent description
     if let Some(ref desc) = agent_def.description {
-        parts.push(format!("## Agent Description\n\n{}", desc));
+        parts.push(format!("## Agent Description\n\n{desc}"));
     }
 
     // Skill snippets
@@ -1121,7 +1118,7 @@ fn build_full_system_prompt_with_preferences(
             .map(|(i, s)| format!("### Skill {}\n{}", i + 1, s))
             .collect::<Vec<_>>()
             .join("\n\n");
-        parts.push(format!("## Active Skills\n\n{}", skills_section));
+        parts.push(format!("## Active Skills\n\n{skills_section}"));
     }
 
     // User preferences (Phase 2.3)
@@ -1139,8 +1136,7 @@ fn build_full_system_prompt_with_preferences(
             .collect::<Vec<_>>()
             .join("\n");
         parts.push(format!(
-            "## User Preferences\nThe following preferences have been learned from past interactions. Apply them:\n{}",
-            prefs_section
+            "## User Preferences\nThe following preferences have been learned from past interactions. Apply them:\n{prefs_section}"
         ));
     }
 
@@ -1221,7 +1217,7 @@ async fn store_preference_fact(
     preference_value: &str,
     confidence: f64,
 ) -> Result<()> {
-    let predicate = format!("user_prefers_{}", preference_key);
+    let predicate = format!("user_prefers_{preference_key}");
 
     let fact_request = FactUpsertRequest {
         subject: agent_id.to_string(),
@@ -1229,7 +1225,7 @@ async fn store_preference_fact(
         object: None,
         value: Some(preference_value.to_string()),
         confidence,
-        source_content: format!("User preference: {} = {}", preference_key, preference_value),
+        source_content: format!("User preference: {preference_key} = {preference_value}"),
         valid_from: Some(Utc::now()),
     };
 
@@ -1276,7 +1272,7 @@ async fn store_preference_fact(
                 return Ok(());
             }
             Ok(Err(e)) => {
-                last_error = format!("NATS request failed: {}", e);
+                last_error = format!("NATS request failed: {e}");
                 warn!(
                     agent_id = %agent_id,
                     key = %preference_key,
@@ -1304,9 +1300,7 @@ async fn store_preference_fact(
         "All preference fact upsert attempts failed"
     );
     Err(anyhow::anyhow!(
-        "Preference fact upsert failed after {} retries: {}",
-        max_retries,
-        last_error
+        "Preference fact upsert failed after {max_retries} retries: {last_error}"
     ))
 }
 

--- a/crates/core/seidrum-kernel/src/embedding/service.rs
+++ b/crates/core/seidrum-kernel/src/embedding/service.rs
@@ -82,7 +82,7 @@ impl EmbeddingService {
             .context("failed to read embedding response")?;
 
         if !status.is_success() {
-            anyhow::bail!("embedding API returned {}: {}", status, text_resp);
+            anyhow::bail!("embedding API returned {status}: {text_resp}");
         }
 
         let json: serde_json::Value =

--- a/crates/core/seidrum-kernel/src/embedding/skill_loader.rs
+++ b/crates/core/seidrum-kernel/src/embedding/skill_loader.rs
@@ -183,25 +183,16 @@ skill:
 
     #[test]
     fn reject_invalid_skill_id() {
-        // Empty ID
-        assert!("".is_empty());
+        fn is_valid_skill_id(id: &str) -> bool {
+            !id.is_empty()
+                && id.len() <= 254
+                && id
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        }
 
-        // ID with invalid chars
-        let id = "../../bad";
-        let valid = !id.is_empty()
-            && id.len() <= 254
-            && id
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '-' || c == '_');
-        assert!(!valid);
-
-        // Valid ID
-        let id = "code-review_v2";
-        let valid = !id.is_empty()
-            && id.len() <= 254
-            && id
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '-' || c == '_');
-        assert!(valid);
+        assert!(!is_valid_skill_id(""));
+        assert!(!is_valid_skill_id("../../bad"));
+        assert!(is_valid_skill_id("code-review_v2"));
     }
 }

--- a/crates/core/seidrum-kernel/src/main.rs
+++ b/crates/core/seidrum-kernel/src/main.rs
@@ -86,15 +86,15 @@ async fn run_serve() -> anyhow::Result<()> {
         std::env::var("EVENTBUS_WS_ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
     let ws_addr: std::net::SocketAddr = ws_addr_str
         .parse()
-        .map_err(|e| anyhow::anyhow!("invalid EVENTBUS_WS_ADDR '{}': {}", ws_addr_str, e))?;
+        .map_err(|e| anyhow::anyhow!("invalid EVENTBUS_WS_ADDR '{ws_addr_str}': {e}"))?;
 
     let data_dir = std::env::var("EVENTBUS_DATA_DIR").unwrap_or_else(|_| "data".to_string());
     std::fs::create_dir_all(&data_dir)?;
-    let db_path = format!("{}/eventbus.redb", data_dir);
+    let db_path = format!("{data_dir}/eventbus.redb");
 
     let store = std::sync::Arc::new(
         seidrum_eventbus::storage::redb_store::RedbEventStore::open(&db_path)
-            .map_err(|e| anyhow::anyhow!("failed to open eventbus store at {}: {}", db_path, e))?,
+            .map_err(|e| anyhow::anyhow!("failed to open eventbus store at {db_path}: {e}"))?,
     );
 
     let bus_handles = seidrum_eventbus::EventBusBuilder::new()
@@ -104,7 +104,7 @@ async fn run_serve() -> anyhow::Result<()> {
         .unsafe_allow_ws_dev_mode()
         .build_with_handles()
         .await
-        .map_err(|e| anyhow::anyhow!("failed to build eventbus: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("failed to build eventbus: {e}"))?;
 
     info!("eventbus started (WS transport on {})", ws_addr);
 
@@ -213,7 +213,6 @@ async fn run_serve() -> anyhow::Result<()> {
     // 9. Spawn the management HTTP server.
     let config_dir_path = std::path::PathBuf::from("config/");
     let agents_dir_path = std::path::PathBuf::from(&agents_dir);
-    let workflows_dir_path = std::path::PathBuf::from(&workflows_dir);
     let env_file = std::path::PathBuf::from(".env");
     let mgmt_listen_addr =
         std::env::var("MGMT_LISTEN_ADDR").unwrap_or_else(|_| "127.0.0.1:3030".to_string());
@@ -222,7 +221,6 @@ async fn run_serve() -> anyhow::Result<()> {
         nats_client.clone(),
         config_dir_path,
         agents_dir_path,
-        workflows_dir_path,
         env_file,
     );
     let management_handle = management_server.spawn(&mgmt_listen_addr).await?;
@@ -330,7 +328,7 @@ fn run_validate(config_path: &str) -> bool {
             Some(cfg)
         }
         Err(e) => {
-            errors.push(format!("Platform config: {}", e));
+            errors.push(format!("Platform config: {e}"));
             None
         }
     };
@@ -355,7 +353,7 @@ fn run_validate(config_path: &str) -> bool {
     let entries = match std::fs::read_dir(agents_path) {
         Ok(entries) => entries,
         Err(e) => {
-            errors.push(format!("Cannot read agents directory: {}", e));
+            errors.push(format!("Cannot read agents directory: {e}"));
             print_validation_summary(&ok_checks, &warnings, &errors);
             return false;
         }
@@ -367,7 +365,7 @@ fn run_validate(config_path: &str) -> bool {
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
-                errors.push(format!("Error reading directory entry: {}", e));
+                errors.push(format!("Error reading directory entry: {e}"));
                 continue;
             }
         };
@@ -402,8 +400,7 @@ fn run_validate(config_path: &str) -> bool {
             let agent_id = &agent_file.agent.id;
             if let Some(first_path) = seen_ids.get(agent_id) {
                 errors.push(format!(
-                    "Duplicate agent ID '{}': found in both '{}' and '{}'",
-                    agent_id, first_path, source_path
+                    "Duplicate agent ID '{agent_id}': found in both '{first_path}' and '{source_path}'"
                 ));
             } else {
                 seen_ids.insert(agent_id.clone(), source_path.clone());

--- a/crates/core/seidrum-kernel/src/management/handlers/agents.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/agents.rs
@@ -105,7 +105,7 @@ pub async fn get_agent(
 ) -> Result<Json<AgentDetailResponse>, (StatusCode, String)> {
     let agent_path = find_agent_file(&state.agents_dir, &id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, format!("Agent '{}' not found", id)))?;
+        .ok_or((StatusCode::NOT_FOUND, format!("Agent '{id}' not found")))?;
 
     let agent = load_agent_definition(&agent_path)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -223,7 +223,7 @@ pub fn find_agent_file(agents_dir: &PathBuf, id: &str) -> anyhow::Result<Option<
 
 async fn set_agent_enabled(state: &ManagementState, id: &str, enabled: bool) -> anyhow::Result<()> {
     let agent_path = find_agent_file(&state.agents_dir, id)?
-        .ok_or_else(|| anyhow::anyhow!("Agent '{}' not found", id))?;
+        .ok_or_else(|| anyhow::anyhow!("Agent '{id}' not found"))?;
 
     let mut agent = load_agent_definition(&agent_path)?;
     agent.enabled = enabled;

--- a/crates/core/seidrum-kernel/src/management/handlers/bundles.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/bundles.rs
@@ -18,10 +18,7 @@ use crate::management::state::ManagementState;
 /// Validate that a filename is safe (no path traversal)
 fn sanitize_filename(name: &str) -> Result<&str, (StatusCode, String)> {
     if name.contains("..") || name.contains('/') || name.contains('\\') || name.starts_with('.') {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!("Invalid filename: {}", name),
-        ));
+        return Err((StatusCode::BAD_REQUEST, format!("Invalid filename: {name}")));
     }
     Ok(name)
 }
@@ -98,10 +95,20 @@ pub async fn import_preset(
     match req.source.as_str() {
         "inline" => import_inline(&state, req).await.map(Json),
         "url" => {
-            // URL import would require HTTP client; for now return error
+            if req.url.trim().is_empty() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "URL import requires a non-empty url field.".to_string(),
+                ));
+            }
+
+            // URL import would require HTTP client; for now return error.
             Err((
                 StatusCode::NOT_IMPLEMENTED,
-                "URL import not yet implemented. Use inline import with preset YAML.".to_string(),
+                format!(
+                    "URL import is not yet implemented for '{}'. Use inline import with preset YAML.",
+                    req.url
+                ),
             ))
         }
         _ => Err((
@@ -118,7 +125,7 @@ pub async fn export_preset(
 ) -> Result<Json<ExportBundleResponse>, (StatusCode, String)> {
     let preset_path = super::presets::find_preset_file(&state.presets_dir, &id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{}' not found", id)))?;
+        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{id}' not found")))?;
 
     let preset_file = load_preset_file(&preset_path)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -179,7 +186,7 @@ pub async fn delete_preset(
 ) -> Result<StatusCode, (StatusCode, String)> {
     let preset_path = super::presets::find_preset_file(&state.presets_dir, &id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{}' not found", id)))?;
+        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{id}' not found")))?;
 
     std::fs::remove_file(&preset_path).map_err(|e| {
         error!("Failed to delete preset file: {}", e);
@@ -261,7 +268,7 @@ pub async fn list_presets_with_source(
         }
     }
 
-    presets.sort_by(|a, b| a.id.cmp(&b.id));
+    presets.sort_by_key(|preset| preset.id.clone());
     Ok(Json(presets))
 }
 
@@ -276,10 +283,7 @@ async fn import_inline(
     // Parse preset YAML
     let preset_file: PresetFile = serde_yaml::from_str(&req.preset_yaml).map_err(|e| {
         error!("Failed to parse preset YAML: {}", e);
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid preset YAML: {}", e),
-        )
+        (StatusCode::BAD_REQUEST, format!("Invalid preset YAML: {e}"))
     })?;
 
     let preset = &preset_file.preset;
@@ -298,7 +302,7 @@ async fn import_inline(
             error!("Failed to install bundle: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to install bundle: {}", e),
+                format!("Failed to install bundle: {e}"),
             )
         })
 }
@@ -330,9 +334,8 @@ async fn install_bundle(
                     continue;
                 }
 
-                std::fs::write(&dest, content).map_err(|e| {
-                    anyhow::anyhow!("Failed to write agent file {}: {}", agent_file, e)
-                })?;
+                std::fs::write(&dest, content)
+                    .map_err(|e| anyhow::anyhow!("Failed to write agent file {agent_file}: {e}"))?;
 
                 installed_agents.push(agent_file.clone());
             }
@@ -363,7 +366,7 @@ async fn install_bundle(
                 }
 
                 std::fs::write(&dest, content).map_err(|e| {
-                    anyhow::anyhow!("Failed to write prompt file {}: {}", prompt_file, e)
+                    anyhow::anyhow!("Failed to write prompt file {prompt_file}: {e}")
                 })?;
 
                 installed_prompts.push(prompt_file.clone());

--- a/crates/core/seidrum-kernel/src/management/handlers/config.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/config.rs
@@ -134,7 +134,7 @@ pub async fn set_env(
     let mut found = false;
     for line in &mut lines {
         let line_trimmed = line.trim();
-        if line_trimmed.starts_with(&format!("{}=", key)) {
+        if line_trimmed.starts_with(&format!("{key}=")) {
             // Replace existing key with properly escaped value
             *line = format!("{}={}", key, escape_env_value(&req.value));
             found = true;

--- a/crates/core/seidrum-kernel/src/management/handlers/packages.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/packages.rs
@@ -41,35 +41,6 @@ pub struct InstallRequest {
     pub confirm: bool,
 }
 
-#[derive(Serialize, Debug, Clone)]
-pub struct EnvVarInfo {
-    pub key: String,
-    pub label: String,
-    pub help: String,
-    pub required: bool,
-}
-
-#[derive(Serialize, Debug)]
-pub struct InstallPreview {
-    pub name: String,
-    pub version: String,
-    pub kind: String,
-    pub description: Option<String>,
-    pub author: Option<String>,
-    pub plugins_to_install: Vec<String>,
-    pub agents_to_install: Vec<String>,
-    pub env_required: Vec<EnvVarInfo>,
-    pub events_consumed: Vec<String>,
-    pub events_produced: Vec<String>,
-}
-
-#[derive(Serialize, Debug)]
-pub struct InstallResult {
-    pub success: bool,
-    pub message: String,
-    pub installed: Vec<String>,
-}
-
 #[derive(Serialize, Debug)]
 pub struct InstalledPackages {
     pub packages: Vec<InstalledPackageInfo>,
@@ -157,7 +128,7 @@ pub async fn search_packages(
             error!("Failed to load registries: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to load registries: {}", e),
+                format!("Failed to load registries: {e}"),
             )
                 .into_response()
         }
@@ -177,7 +148,7 @@ pub async fn install_package(
             error!("Failed to serialize install request: {}", e);
             return (
                 StatusCode::BAD_REQUEST,
-                format!("Failed to serialize request: {}", e),
+                format!("Failed to serialize request: {e}"),
             )
                 .into_response();
         }
@@ -197,7 +168,7 @@ pub async fn install_package(
             error!("Failed to send install request to daemon: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Install failed: {}", e),
+                format!("Install failed: {e}"),
             )
                 .into_response()
         }
@@ -217,7 +188,7 @@ pub async fn uninstall_package(
             error!("Failed to serialize uninstall request: {}", e);
             return (
                 StatusCode::BAD_REQUEST,
-                format!("Failed to serialize request: {}", e),
+                format!("Failed to serialize request: {e}"),
             )
                 .into_response();
         }
@@ -237,7 +208,7 @@ pub async fn uninstall_package(
             error!("Failed to send uninstall request to daemon: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Uninstall failed: {}", e),
+                format!("Uninstall failed: {e}"),
             )
                 .into_response()
         }

--- a/crates/core/seidrum-kernel/src/management/handlers/plugins.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/plugins.rs
@@ -167,10 +167,10 @@ pub async fn plugin_config_schema(
     let config = load_plugins_config(&state.plugins_yaml())
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let entry = config.plugins.get(&name).ok_or((
-        StatusCode::NOT_FOUND,
-        format!("Plugin '{}' not found", name),
-    ))?;
+    let entry = config
+        .plugins
+        .get(&name)
+        .ok_or((StatusCode::NOT_FOUND, format!("Plugin '{name}' not found")))?;
 
     let schema: Vec<PluginConfigSchemaItem> = entry
         .env
@@ -211,7 +211,7 @@ async fn set_plugin_enabled(
     config
         .plugins
         .get_mut(name)
-        .ok_or_else(|| anyhow::anyhow!("Plugin '{}' not found", name))?
+        .ok_or_else(|| anyhow::anyhow!("Plugin '{name}' not found"))?
         .enabled = enabled;
 
     save_plugins_config(&yaml_path, &config)?;
@@ -227,7 +227,7 @@ async fn get_plugin_detail(
     let entry = config
         .plugins
         .get(name)
-        .ok_or_else(|| anyhow::anyhow!("Plugin '{}' not found", name))?;
+        .ok_or_else(|| anyhow::anyhow!("Plugin '{name}' not found"))?;
 
     let running_plugins = query_running_plugins(state).await.unwrap_or_default();
     let running = running_plugins.contains(name);

--- a/crates/core/seidrum-kernel/src/management/handlers/presets.rs
+++ b/crates/core/seidrum-kernel/src/management/handlers/presets.rs
@@ -63,17 +63,6 @@ pub struct EnvRequirement {
 // ============================================================================
 
 #[derive(Debug, Serialize)]
-pub struct PresetListItem {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub icon: String,
-    pub required_plugins: usize,
-    pub recommended_plugins: usize,
-    pub required_agents: usize,
-}
-
-#[derive(Debug, Serialize)]
 pub struct ApplyPresetResponse {
     pub enabled_plugins: Vec<String>,
     pub enabled_agents: Vec<String>,
@@ -90,68 +79,6 @@ pub struct ApplyPresetRequest {
 // Handlers
 // ============================================================================
 
-/// List all presets from config/presets/ directory.
-pub async fn list_presets(
-    State(state): State<ManagementState>,
-) -> Result<Json<Vec<PresetListItem>>, (StatusCode, String)> {
-    let presets_dir = &state.presets_dir;
-
-    // Create directory if it doesn't exist
-    if !presets_dir.exists() {
-        std::fs::create_dir_all(presets_dir)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    }
-
-    let entries = std::fs::read_dir(presets_dir)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    let mut presets = Vec::new();
-
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                error!("Error reading presets directory entry: {}", e);
-                continue;
-            }
-        };
-
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-
-        if let Some(ext) = path.extension() {
-            if ext != "yaml" && ext != "yml" {
-                continue;
-            }
-        } else {
-            continue;
-        }
-
-        match load_preset(&path) {
-            Ok(preset_file) => {
-                let preset = &preset_file.preset;
-                presets.push(PresetListItem {
-                    id: preset.id.clone(),
-                    name: preset.name.clone(),
-                    description: preset.description.clone(),
-                    icon: preset.icon.clone(),
-                    required_plugins: preset.plugins.required.len(),
-                    recommended_plugins: preset.plugins.recommended.len(),
-                    required_agents: preset.agents.required.len(),
-                });
-            }
-            Err(e) => {
-                error!("Error loading preset from {:?}: {}", path, e);
-            }
-        }
-    }
-
-    presets.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(Json(presets))
-}
-
 /// Apply a preset by id.
 pub async fn apply_preset(
     State(state): State<ManagementState>,
@@ -160,7 +87,7 @@ pub async fn apply_preset(
 ) -> Result<Json<ApplyPresetResponse>, (StatusCode, String)> {
     let preset_path = find_preset_file(&state.presets_dir, &id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{}' not found", id)))?;
+        .ok_or((StatusCode::NOT_FOUND, format!("Preset '{id}' not found")))?;
 
     let preset_file = load_preset(&preset_path)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -322,7 +249,7 @@ pub fn find_preset_file(presets_dir: &PathBuf, id: &str) -> anyhow::Result<Optio
 
 async fn set_agent_enabled(state: &ManagementState, id: &str, enabled: bool) -> anyhow::Result<()> {
     let agent_path = super::agents::find_agent_file(&state.agents_dir, id)?
-        .ok_or_else(|| anyhow::anyhow!("Agent '{}' not found", id))?;
+        .ok_or_else(|| anyhow::anyhow!("Agent '{id}' not found"))?;
 
     let mut agent = super::agents::load_agent_definition(&agent_path)?;
     agent.enabled = enabled;

--- a/crates/core/seidrum-kernel/src/management/server.rs
+++ b/crates/core/seidrum-kernel/src/management/server.rs
@@ -18,18 +18,17 @@ impl ManagementServer {
         nats: seidrum_common::bus_client::BusClient,
         config_dir: PathBuf,
         agents_dir: PathBuf,
-        workflows_dir: PathBuf,
         env_file: PathBuf,
     ) -> Self {
         Self {
-            state: ManagementState::new(nats, config_dir, agents_dir, workflows_dir, env_file),
+            state: ManagementState::new(nats, config_dir, agents_dir, env_file),
         }
     }
 
     pub async fn spawn(self, listen_addr: &str) -> Result<tokio::task::JoinHandle<()>> {
         let addr: SocketAddr = listen_addr
             .parse()
-            .with_context(|| format!("Invalid management listen address: {}", listen_addr))?;
+            .with_context(|| format!("Invalid management listen address: {listen_addr}"))?;
 
         let cors = CorsLayer::new()
             .allow_origin(AllowOrigin::list([
@@ -62,7 +61,7 @@ impl ManagementServer {
 
         let listener = tokio::net::TcpListener::bind(addr)
             .await
-            .with_context(|| format!("Failed to bind management server to {}", addr))?;
+            .with_context(|| format!("Failed to bind management server to {addr}"))?;
 
         info!(%addr, "Management API server listening");
 

--- a/crates/core/seidrum-kernel/src/management/state.rs
+++ b/crates/core/seidrum-kernel/src/management/state.rs
@@ -6,7 +6,6 @@ pub struct ManagementState {
     pub nats: seidrum_common::bus_client::BusClient,
     pub config_dir: PathBuf,
     pub agents_dir: PathBuf,
-    pub workflows_dir: PathBuf,
     pub env_file: PathBuf,
     pub presets_dir: PathBuf,
 }
@@ -16,7 +15,6 @@ impl ManagementState {
         nats: seidrum_common::bus_client::BusClient,
         config_dir: PathBuf,
         agents_dir: PathBuf,
-        workflows_dir: PathBuf,
         env_file: PathBuf,
     ) -> Self {
         let presets_dir = config_dir.join("presets");
@@ -24,7 +22,6 @@ impl ManagementState {
             nats,
             config_dir,
             agents_dir,
-            workflows_dir,
             env_file,
             presets_dir,
         }

--- a/crates/core/seidrum-kernel/src/orchestrator/service.rs
+++ b/crates/core/seidrum-kernel/src/orchestrator/service.rs
@@ -320,7 +320,7 @@ impl WorkflowEngine {
             let sub = nats_client
                 .subscribe(subject.clone())
                 .await
-                .with_context(|| format!("failed to subscribe to trigger subject: {}", subject))?;
+                .with_context(|| format!("failed to subscribe to trigger subject: {subject}"))?;
             info!(subject = %subject, workflows = contexts.len(), "subscribed to trigger");
             trigger_subs.push((sub, contexts.clone()));
         }
@@ -748,8 +748,7 @@ mod tests {
         let warnings = engine.validate_pipeline(&agent);
         assert!(
             warnings.is_empty(),
-            "expected no warnings, got: {:?}",
-            warnings
+            "expected no warnings, got: {warnings:?}"
         );
     }
 
@@ -845,8 +844,7 @@ mod tests {
         let warnings = engine.validate_pipeline(&agent);
         assert!(
             warnings.is_empty(),
-            "expected no warnings, got: {:?}",
-            warnings
+            "expected no warnings, got: {warnings:?}"
         );
     }
 
@@ -941,8 +939,7 @@ mod tests {
         let warnings = engine.validate_pipeline(&agent);
         assert!(
             warnings.is_empty(),
-            "expected no warnings, got: {:?}",
-            warnings
+            "expected no warnings, got: {warnings:?}"
         );
     }
 }

--- a/crates/core/seidrum-kernel/src/plugin_storage/service.rs
+++ b/crates/core/seidrum-kernel/src/plugin_storage/service.rs
@@ -25,7 +25,7 @@ impl PluginStorageService {
 
     /// Build the compound document key: `{plugin_id}:{namespace}:{key}`.
     fn doc_key(plugin_id: &str, namespace: &str, key: &str) -> String {
-        format!("{}:{}:{}", plugin_id, namespace, key)
+        format!("{plugin_id}:{namespace}:{key}")
     }
 
     async fn handle_get(&self, req: StorageGetRequest) -> StorageGetResponse {

--- a/crates/core/seidrum-kernel/src/registry/service.rs
+++ b/crates/core/seidrum-kernel/src/registry/service.rs
@@ -200,7 +200,7 @@ impl RegistryService {
                     plugin_ids: None,
                     config_schema: schema,
                     error: if plugin.is_none() {
-                        Some(format!("Plugin '{}' not found", plugin_id))
+                        Some(format!("Plugin '{plugin_id}' not found"))
                     } else {
                         None
                     },

--- a/crates/core/seidrum-kernel/src/scope/service.rs
+++ b/crates/core/seidrum-kernel/src/scope/service.rs
@@ -159,7 +159,7 @@ impl ScopeService {
                 if s.contains('/') {
                     s.clone()
                 } else {
-                    format!("scopes/{}", s)
+                    format!("scopes/{s}")
                 }
             })
             .collect();
@@ -243,7 +243,7 @@ FOR __scope_doc IN __scope_candidates
                 if s.contains('/') {
                     s.clone()
                 } else {
-                    format!("scopes/{}", s)
+                    format!("scopes/{s}")
                 }
             })
             .collect();
@@ -332,8 +332,7 @@ mod tests {
             let s = entry.as_str().unwrap();
             assert!(
                 s.starts_with("scopes/"),
-                "scope ID '{}' should start with 'scopes/'",
-                s
+                "scope ID '{s}' should start with 'scopes/'"
             );
         }
     }
@@ -420,7 +419,7 @@ mod tests {
         // All should start with "scopes/".
         for entry in arr {
             let s = entry.as_str().unwrap();
-            assert!(s.starts_with("scopes/"), "expected scopes/ prefix: {}", s);
+            assert!(s.starts_with("scopes/"), "expected scopes/ prefix: {s}");
         }
 
         // The one that already had "scopes/" should not be double-prefixed.

--- a/crates/core/seidrum-kernel/src/tool_registry/service.rs
+++ b/crates/core/seidrum-kernel/src/tool_registry/service.rs
@@ -234,7 +234,7 @@ impl ToolRegistryService {
                 }),
             )
             .await
-            .with_context(|| format!("failed to upsert capability '{}'", tool_id))?;
+            .with_context(|| format!("failed to upsert capability '{tool_id}'"))?;
 
         // Cache in memory
         let entry = ToolEntry {
@@ -743,10 +743,10 @@ mod tests {
             tool_id: tool_id.to_string(),
             plugin_id: plugin_id.to_string(),
             name: name.to_string(),
-            summary_md: format!("Summary for {}", name),
-            manual_md: format!("# {}\n\nManual content.", name),
+            summary_md: format!("Summary for {name}"),
+            manual_md: format!("# {name}\n\nManual content."),
             parameters: serde_json::json!({"type": "object"}),
-            call_subject: format!("capability.call.{}", plugin_id),
+            call_subject: format!("capability.call.{plugin_id}"),
             kind: "tool".to_string(),
         }
     }

--- a/crates/core/seidrum-kernel/src/trace_collector/service.rs
+++ b/crates/core/seidrum-kernel/src/trace_collector/service.rs
@@ -299,7 +299,7 @@ impl TraceCollectorService {
                             })
                             .collect();
 
-                        summaries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+                        summaries.sort_by_key(|summary| std::cmp::Reverse(summary.started_at));
                         summaries.truncate(limit);
 
                         let response = TraceListResponse { traces: summaries };

--- a/crates/plugins/seidrum-api-gateway/src/audit.rs
+++ b/crates/plugins/seidrum-api-gateway/src/audit.rs
@@ -208,7 +208,7 @@ mod tests {
         let log = AuditLog::new(3);
 
         for i in 0..5 {
-            let entry = AuditEntryBuilder::new("action", &format!("user{}", i), "resource")
+            let entry = AuditEntryBuilder::new("action", &format!("user{i}"), "resource")
                 .method("POST")
                 .build();
             log.log(entry).await;
@@ -222,7 +222,7 @@ mod tests {
         let log = AuditLog::new(10);
 
         for i in 0..3 {
-            let entry = AuditEntryBuilder::new("action", &format!("user{}", i), "resource").build();
+            let entry = AuditEntryBuilder::new("action", &format!("user{i}"), "resource").build();
             log.log(entry).await;
         }
 

--- a/crates/plugins/seidrum-api-gateway/src/auth.rs
+++ b/crates/plugins/seidrum-api-gateway/src/auth.rs
@@ -256,9 +256,7 @@ mod tests {
             .generate_token("user1", "admin", vec!["scope_root".to_string()], None)
             .unwrap();
 
-        let result = handler
-            .authenticate(&format!("Bearer {}", token), None)
-            .await;
+        let result = handler.authenticate(&format!("Bearer {token}"), None).await;
         assert!(result.is_some());
         let auth = result.unwrap();
         assert_eq!(auth.subject, "user1");
@@ -280,9 +278,7 @@ mod tests {
             )
             .unwrap();
 
-        let result = handler
-            .authenticate(&format!("Bearer {}", token), None)
-            .await;
+        let result = handler.authenticate(&format!("Bearer {token}"), None).await;
         assert!(result.is_some());
         let auth = result.unwrap();
         assert_eq!(auth.subject, "alice");

--- a/crates/plugins/seidrum-api-gateway/src/connections.rs
+++ b/crates/plugins/seidrum-api-gateway/src/connections.rs
@@ -42,6 +42,12 @@ struct ConnectionManagerInner {
     pending: DashMap<String, PendingRequest>,
 }
 
+impl Default for ConnectionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ConnectionManager {
     pub fn new() -> Self {
         Self {
@@ -59,7 +65,7 @@ impl ConnectionManager {
         sender: mpsc::UnboundedSender<ServerMessage>,
     ) -> Result<(), String> {
         if self.inner.connections.contains_key(&plugin_id) {
-            return Err(format!("Plugin '{}' is already connected", plugin_id));
+            return Err(format!("Plugin '{plugin_id}' is already connected"));
         }
 
         self.inner.connections.insert(

--- a/crates/plugins/seidrum-api-gateway/src/dashboard.rs
+++ b/crates/plugins/seidrum-api-gateway/src/dashboard.rs
@@ -155,7 +155,7 @@ pub async fn plugin_health(
     State(state): State<AppState>,
     Path(plugin_id): Path<String>,
 ) -> impl IntoResponse {
-    let health_subject = format!("plugin.{}.health", plugin_id);
+    let health_subject = format!("plugin.{plugin_id}.health");
     let req = PluginHealthRequest {};
 
     match tokio::time::timeout(
@@ -315,7 +315,7 @@ pub async fn update_plugin_config(
         timestamp: Utc::now(),
     };
 
-    let subject = format!("plugin.{}.config.update", plugin_id);
+    let subject = format!("plugin.{plugin_id}.config.update");
     if let Ok(bytes) = serde_json::to_vec(&update) {
         let _ = state.nats.publish_bytes(&subject, bytes).await;
     }

--- a/crates/plugins/seidrum-api-gateway/src/jwt.rs
+++ b/crates/plugins/seidrum-api-gateway/src/jwt.rs
@@ -89,7 +89,7 @@ impl JwtService {
         validation.algorithms = vec![Algorithm::HS256];
 
         let token_data = decode::<Claims>(token, &self.decoding_key, &validation)
-            .map_err(|e| anyhow::anyhow!("JWT validation failed: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("JWT validation failed: {e}"))?;
 
         let claims = token_data.claims;
 

--- a/crates/plugins/seidrum-api-gateway/src/main.rs
+++ b/crates/plugins/seidrum-api-gateway/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
         description: "HTTP/WebSocket gateway for external plugins".to_string(),
         consumes: vec![],
         produces: vec![],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -421,7 +421,7 @@ async fn auth_rate_limit_middleware(
                     .method(&method)
                     .path(&path)
                     .status(429)
-                    .details(&format!("retry_after: {}s", retry_after_secs))
+                    .details(&format!("retry_after: {retry_after_secs}s"))
                     .build(),
             )
             .await;
@@ -1196,7 +1196,7 @@ async fn update_user_role_handler(
                 .log(
                     audit::AuditEntryBuilder::new("user.role_updated", &auth.subject, &user_id)
                         .method("PUT")
-                        .path(&format!("/api/v1/users/{}/role", user_id))
+                        .path(&format!("/api/v1/users/{user_id}/role"))
                         .status(200)
                         .user_id(auth.user_id)
                         .build(),
@@ -1258,7 +1258,7 @@ async fn delete_user_handler(
                 .log(
                     audit::AuditEntryBuilder::new("user.deleted", &auth.subject, &user_id)
                         .method("DELETE")
-                        .path(&format!("/api/v1/users/{}", user_id))
+                        .path(&format!("/api/v1/users/{user_id}"))
                         .status(200)
                         .user_id(auth.user_id)
                         .build(),
@@ -1515,7 +1515,7 @@ async fn revoke_apikey_handler(
                 .log(
                     audit::AuditEntryBuilder::new("apikey.revoked", &auth.subject, &key_id)
                         .method("DELETE")
-                        .path(&format!("/api/v1/apikeys/{}", key_id))
+                        .path(&format!("/api/v1/apikeys/{key_id}"))
                         .status(200)
                         .user_id(Some(user_id))
                         .build(),

--- a/crates/plugins/seidrum-api-gateway/src/rest.rs
+++ b/crates/plugins/seidrum-api-gateway/src/rest.rs
@@ -117,7 +117,7 @@ pub async fn call_capability(
     Path(capability_id): Path<String>,
     Json(body): Json<CapabilityCallBody>,
 ) -> impl IntoResponse {
-    let call_subject = format!("capability.call.{}", capability_id);
+    let call_subject = format!("capability.call.{capability_id}");
 
     let req = ToolCallRequest {
         tool_id: capability_id.clone(),

--- a/crates/plugins/seidrum-api-gateway/src/ws.rs
+++ b/crates/plugins/seidrum-api-gateway/src/ws.rs
@@ -53,7 +53,7 @@ pub async fn handle_ws(socket: WebSocket, nats: BusClient, connections: Connecti
             Ok(m) => m,
             Err(err) => {
                 let _ = tx.send(ServerMessage::Error {
-                    message: format!("Invalid message: {}", err),
+                    message: format!("Invalid message: {err}"),
                 });
                 continue;
             }
@@ -217,7 +217,7 @@ async fn handle_register(
 
     nats.publish_envelope("plugin.register", None, None, &register)
         .await
-        .map_err(|e| format!("Failed to publish plugin.register: {}", e))?;
+        .map_err(|e| format!("Failed to publish plugin.register: {e}"))?;
 
     info!(plugin_id = %plugin.id, "External plugin registered via gateway");
     Ok(())
@@ -227,11 +227,10 @@ async fn handle_register_capability(
     capability: &serde_json::Value,
     nats: &BusClient,
 ) -> Result<(), String> {
-    let bytes =
-        serde_json::to_vec(capability).map_err(|e| format!("Failed to serialize: {}", e))?;
+    let bytes = serde_json::to_vec(capability).map_err(|e| format!("Failed to serialize: {e}"))?;
     nats.publish_bytes("capability.register", bytes)
         .await
-        .map_err(|e| format!("Failed to publish capability.register: {}", e))?;
+        .map_err(|e| format!("Failed to publish capability.register: {e}"))?;
     Ok(())
 }
 
@@ -257,7 +256,7 @@ async fn spawn_capability_listener(
     nats: &BusClient,
     connections: &ConnectionManager,
 ) {
-    let subject = format!("capability.call.{}", plugin_id);
+    let subject = format!("capability.call.{plugin_id}");
     let nats_client = nats.clone();
     let conn_inner = connections.clone();
     let pid = plugin_id.to_string();
@@ -311,7 +310,7 @@ async fn spawn_capability_listener(
 }
 
 async fn spawn_health_listener(plugin_id: &str, nats: &BusClient, connections: &ConnectionManager) {
-    let subject = format!("plugin.{}.health", plugin_id);
+    let subject = format!("plugin.{plugin_id}.health");
     let nats_client = nats.clone();
     let conn_inner = connections.clone();
     let pid = plugin_id.to_string();

--- a/crates/plugins/seidrum-api-gateway/tests/integration_tests.rs
+++ b/crates/plugins/seidrum-api-gateway/tests/integration_tests.rs
@@ -28,9 +28,7 @@ mod tests {
             .generate_token("testuser", "user", vec!["read".to_string()], None)
             .unwrap();
 
-        let result = handler
-            .authenticate(&format!("Bearer {}", token), None)
-            .await;
+        let result = handler.authenticate(&format!("Bearer {token}"), None).await;
         assert!(result.is_some());
         let auth = result.unwrap();
         assert_eq!(auth.subject, "testuser");
@@ -169,7 +167,7 @@ mod tests {
 
         // Log 10 entries but max is 5
         for i in 0..10 {
-            let entry = AuditEntryBuilder::new("action", &format!("user{}", i), "resource").build();
+            let entry = AuditEntryBuilder::new("action", &format!("user{i}"), "resource").build();
             log.log(entry).await;
         }
 
@@ -182,7 +180,7 @@ mod tests {
 
         // Log 3 entries
         for i in 0..3 {
-            let entry = AuditEntryBuilder::new("action", &format!("user{}", i), "resource").build();
+            let entry = AuditEntryBuilder::new("action", &format!("user{i}"), "resource").build();
             log.log(entry).await;
         }
 

--- a/crates/plugins/seidrum-calendar/src/main.rs
+++ b/crates/plugins/seidrum-calendar/src/main.rs
@@ -53,7 +53,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
     })?;
 
     let profiles: serde_json::Value = serde_json::from_str(&content)
-        .map_err(|e| anyhow::anyhow!("Failed to parse OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to parse OpenClaw auth-profiles.json: {e}"))?;
 
     let key = profiles
         .get("profiles")
@@ -128,10 +128,7 @@ async fn poll_calendar(
     let now = chrono::Utc::now();
     let time_max = now + chrono::Duration::days(7);
 
-    let url = format!(
-        "https://www.googleapis.com/calendar/v3/calendars/{}/events",
-        calendar_id
-    );
+    let url = format!("https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events");
 
     let resp = client
         .get(&url)
@@ -149,9 +146,7 @@ async fn poll_calendar(
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         return Err(anyhow::anyhow!(
-            "Google Calendar API error ({}): {}",
-            status,
-            body
+            "Google Calendar API error ({status}): {body}"
         ));
     }
 
@@ -190,8 +185,7 @@ async fn poll_calendar(
             .unwrap_or("");
 
         let text = format!(
-            "Event: {}\nWhen: {} - {}\nLocation: {}\nDescription: {}",
-            summary, start_str, end_str, location, description
+            "Event: {summary}\nWhen: {start_str} - {end_str}\nLocation: {location}\nDescription: {description}"
         );
 
         let mut metadata = HashMap::new();
@@ -233,10 +227,7 @@ async fn create_calendar_event(
     calendar_id: &str,
     event: &CalendarEventCreate,
 ) -> Result<()> {
-    let url = format!(
-        "https://www.googleapis.com/calendar/v3/calendars/{}/events",
-        calendar_id
-    );
+    let url = format!("https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events");
 
     let body = serde_json::json!({
         "summary": event.summary,
@@ -257,9 +248,7 @@ async fn create_calendar_event(
         let status = resp.status();
         let resp_body = resp.text().await.unwrap_or_default();
         return Err(anyhow::anyhow!(
-            "Google Calendar create event error ({}): {}",
-            status,
-            resp_body
+            "Google Calendar create event error ({status}): {resp_body}"
         ));
     }
 
@@ -278,10 +267,7 @@ async fn search_calendar_events(
     let now = chrono::Utc::now();
     let time_max = now + chrono::Duration::days(days_ahead);
 
-    let url = format!(
-        "https://www.googleapis.com/calendar/v3/calendars/{}/events",
-        calendar_id
-    );
+    let url = format!("https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events");
 
     let resp = client
         .get(&url)
@@ -300,9 +286,7 @@ async fn search_calendar_events(
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         return Err(anyhow::anyhow!(
-            "Google Calendar API error ({}): {}",
-            status,
-            body
+            "Google Calendar API error ({status}): {body}"
         ));
     }
 

--- a/crates/plugins/seidrum-claude-code/src/main.rs
+++ b/crates/plugins/seidrum-claude-code/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         description: "Run Claude Code CLI for agentic coding tasks".to_string(),
         consumes: vec!["capability.call.claude-code".to_string()],
         produces: vec![],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: Some(serde_json::json!({
@@ -370,7 +370,7 @@ async fn run_claude_code(
         Err(err) => {
             error!(%err, "Failed to spawn claude CLI");
             return ClaudeCodeResponse {
-                result: format!("Failed to start Claude Code CLI: {}", err),
+                result: format!("Failed to start Claude Code CLI: {err}"),
                 session_id: None,
                 model: None,
                 usage: None,
@@ -427,7 +427,7 @@ async fn run_claude_code(
             }
         }
         Ok(Err(err)) => ClaudeCodeResponse {
-            result: format!("Process error: {}", err),
+            result: format!("Process error: {err}"),
             session_id: None,
             model: None,
             usage: None,

--- a/crates/plugins/seidrum-code-executor/src/main.rs
+++ b/crates/plugins/seidrum-code-executor/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
         description: "Sandboxed code execution as an LLM tool".to_string(),
         consumes: vec!["capability.call.code-executor".to_string()],
         produces: vec![],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -229,8 +229,7 @@ async fn execute_code(request: &CodeExecuteRequest) -> CodeExecuteResponse {
             return CodeExecuteResponse {
                 stdout: String::new(),
                 stderr: format!(
-                    "Unsupported language: {}. Supported: python, bash, javascript",
-                    other
+                    "Unsupported language: {other}. Supported: python, bash, javascript"
                 ),
                 exit_code: -1,
                 timed_out: false,
@@ -247,7 +246,7 @@ async fn execute_code(request: &CodeExecuteRequest) -> CodeExecuteResponse {
         Ok(response) => response,
         Err(err) => CodeExecuteResponse {
             stdout: String::new(),
-            stderr: format!("Execution error: {}", err),
+            stderr: format!("Execution error: {err}"),
             exit_code: -1,
             timed_out: false,
         },
@@ -327,7 +326,7 @@ async fn run_child_with_timeout(
         }
         Ok(Err(err)) => Ok(CodeExecuteResponse {
             stdout: String::new(),
-            stderr: format!("Process error: {}", err),
+            stderr: format!("Process error: {err}"),
             exit_code: -1,
             timed_out: false,
         }),
@@ -335,7 +334,7 @@ async fn run_child_with_timeout(
             // Timeout — process is dropped and killed automatically
             Ok(CodeExecuteResponse {
                 stdout: String::new(),
-                stderr: format!("Execution timed out after {}s", timeout_secs),
+                stderr: format!("Execution timed out after {timeout_secs}s"),
                 exit_code: -1,
                 timed_out: true,
             })

--- a/crates/plugins/seidrum-email/src/main.rs
+++ b/crates/plugins/seidrum-email/src/main.rs
@@ -162,7 +162,7 @@ async fn poll_imap(cli: &Cli, nats: &seidrum_common::bus_client::BusClient) -> R
         let combined_text = if subject.is_empty() {
             text_body.clone()
         } else {
-            format!("{}\n\n{}", subject, text_body)
+            format!("{subject}\n\n{text_body}")
         };
 
         let mut metadata = HashMap::new();
@@ -233,44 +233,49 @@ fn send_email(cli: &Cli, outbound: &ChannelOutbound) -> Result<()> {
     Ok(())
 }
 
+struct SmtpSettings<'a> {
+    host: &'a str,
+    port: u16,
+    user: &'a str,
+    password: &'a str,
+    from: &'a str,
+}
+
+struct EmailToolMessage<'a> {
+    to: &'a str,
+    subject: &'a str,
+    body: &'a str,
+    in_reply_to: Option<&'a str>,
+}
+
 /// Send an email via SMTP, used by the tool.call.email handler.
-fn send_email_tool_impl(
-    smtp_host: &str,
-    smtp_port: u16,
-    smtp_user: &str,
-    smtp_password: &str,
-    smtp_from: &str,
-    to: &str,
-    subject: &str,
-    body: &str,
-    in_reply_to: Option<&str>,
-) -> Result<()> {
+fn send_email_tool_impl(settings: &SmtpSettings<'_>, message: &EmailToolMessage<'_>) -> Result<()> {
     use lettre::message::header::ContentType;
     use lettre::transport::smtp::authentication::Credentials;
     use lettre::{Message, SmtpTransport, Transport};
 
     let mut builder = Message::builder()
-        .from(smtp_from.parse().context("Invalid from address")?)
-        .to(to.parse().context("Invalid to address")?)
-        .subject(subject)
+        .from(settings.from.parse().context("Invalid from address")?)
+        .to(message.to.parse().context("Invalid to address")?)
+        .subject(message.subject)
         .header(ContentType::TEXT_PLAIN);
 
-    if let Some(reply_id) = in_reply_to {
+    if let Some(reply_id) = message.in_reply_to {
         builder = builder.in_reply_to(reply_id.to_string());
     }
 
-    let email = builder.body(body.to_string())?;
+    let email = builder.body(message.body.to_string())?;
 
-    let creds = Credentials::new(smtp_user.to_string(), smtp_password.to_string());
+    let creds = Credentials::new(settings.user.to_string(), settings.password.to_string());
 
-    let mailer = SmtpTransport::starttls_relay(smtp_host)?
-        .port(smtp_port)
+    let mailer = SmtpTransport::starttls_relay(settings.host)?
+        .port(settings.port)
         .credentials(creds)
         .build();
 
     mailer.send(&email)?;
 
-    info!(to = %to, subject = %subject, "Sent email via SMTP (tool call)");
+    info!(to = %message.to, subject = %message.subject, "Sent email via SMTP (tool call)");
     Ok(())
 }
 
@@ -500,17 +505,21 @@ async fn main() -> Result<()> {
 
                     info!(to = %to, subject = %subject, "Sending email via tool");
 
-                    match send_email_tool_impl(
-                        &tool_smtp_host,
-                        tool_smtp_port,
-                        &tool_smtp_user,
-                        &tool_smtp_password,
-                        &tool_smtp_from,
-                        &to,
-                        &subject,
-                        &body,
-                        in_reply_to.as_deref(),
-                    ) {
+                    let smtp_settings = SmtpSettings {
+                        host: &tool_smtp_host,
+                        port: tool_smtp_port,
+                        user: &tool_smtp_user,
+                        password: &tool_smtp_password,
+                        from: &tool_smtp_from,
+                    };
+                    let email_message = EmailToolMessage {
+                        to: &to,
+                        subject: &subject,
+                        body: &body,
+                        in_reply_to: in_reply_to.as_deref(),
+                    };
+
+                    match send_email_tool_impl(&smtp_settings, &email_message) {
                         Ok(()) => ToolCallResponse {
                             tool_id: tool_request.tool_id,
                             result: serde_json::json!({"status": "sent", "to": to, "subject": subject}),

--- a/crates/plugins/seidrum-entity-extractor/src/main.rs
+++ b/crates/plugins/seidrum-entity-extractor/src/main.rs
@@ -99,7 +99,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
         .map(|h| h.join(".openclaw/agents/main/agent/auth-profiles.json"))
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let content = std::fs::read_to_string(&auth_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {e}"))?;
     let profiles: serde_json::Value = serde_json::from_str(&content)?;
     let key = profiles
         .get("profiles")
@@ -139,7 +139,7 @@ async fn main() -> Result<()> {
         description: "Extracts entities from stored content using LLM".to_string(),
         consumes: vec!["brain.content.stored".to_string()],
         produces: vec!["brain.entity.upsert".to_string()],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -370,8 +370,7 @@ Text to analyze:
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-        model, api_key
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     );
 
     let response = http
@@ -386,7 +385,7 @@ Text to analyze:
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Gemini API returned {}: {}", status, body);
+        anyhow::bail!("Gemini API returned {status}: {body}");
     }
 
     let api_response: GeminiResponse = response

--- a/crates/plugins/seidrum-event-emitter/src/main.rs
+++ b/crates/plugins/seidrum-event-emitter/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
             "brain.fact.upsert".to_string(),
             "agent.*.wake".to_string(),
         ],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -186,7 +186,7 @@ fn extract_actions(content: &str) -> StructuredActions {
 
     // Strategy 1: Look for typed markers like ```json:tasks, ```json:facts, ```json:wake
     for marker_type in &["tasks", "facts", "wake"] {
-        let marker = format!("```json:{}", marker_type);
+        let marker = format!("```json:{marker_type}");
         if let Some(start_idx) = content.find(&marker) {
             let after_marker = &content[start_idx + marker.len()..];
             if let Some(end_idx) = after_marker.find("```") {

--- a/crates/plugins/seidrum-fact-extractor/src/main.rs
+++ b/crates/plugins/seidrum-fact-extractor/src/main.rs
@@ -102,7 +102,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
         .map(|h| h.join(".openclaw/agents/main/agent/auth-profiles.json"))
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let content = std::fs::read_to_string(&auth_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {e}"))?;
     let profiles: serde_json::Value = serde_json::from_str(&content)?;
     let key = profiles
         .get("profiles")
@@ -205,15 +205,19 @@ async fn main() -> Result<()> {
             }
         };
 
+        let extraction_context = ExtractionContext {
+            api_key: &api_key,
+            model: &args.extraction_model,
+            correlation_id: &envelope.correlation_id,
+            scope: &envelope.scope,
+        };
+
         if let Err(err) = process_entity(
             &client,
             &http_client,
-            &api_key,
-            &args.extraction_model,
+            &extraction_context,
             &entity_upserted,
             &source_content,
-            &envelope.correlation_id,
-            &envelope.scope,
         )
         .await
         {
@@ -228,15 +232,19 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+struct ExtractionContext<'a> {
+    api_key: &'a str,
+    model: &'a str,
+    correlation_id: &'a Option<String>,
+    scope: &'a Option<String>,
+}
+
 async fn process_entity(
     nats: &seidrum_common::bus_client::BusClient,
     http: &reqwest::Client,
-    api_key: &str,
-    model: &str,
+    context: &ExtractionContext<'_>,
     entity: &EntityUpserted,
     source_content_key: &str,
-    correlation_id: &Option<String>,
-    scope: &Option<String>,
 ) -> Result<()> {
     // Step 1: Fetch the content text from the kernel via brain.query.request
     let query_req = BrainQueryRequest {
@@ -262,8 +270,8 @@ async fn process_entity(
     let query_envelope = EventEnvelope::new(
         "brain.query.request",
         PLUGIN_ID,
-        correlation_id.clone(),
-        scope.clone(),
+        context.correlation_id.clone(),
+        context.scope.clone(),
         &query_req,
     )?;
 
@@ -299,7 +307,8 @@ async fn process_entity(
     }
 
     // Step 2: Call LLM for fact extraction
-    let facts = extract_facts_via_llm(http, api_key, model, &raw_text, entity).await?;
+    let facts =
+        extract_facts_via_llm(http, context.api_key, context.model, &raw_text, entity).await?;
 
     info!(
         entity_key = %entity.entity_key,
@@ -322,8 +331,8 @@ async fn process_entity(
         let upsert_envelope = EventEnvelope::new(
             "brain.fact.upsert",
             PLUGIN_ID,
-            correlation_id.clone(),
-            scope.clone(),
+            context.correlation_id.clone(),
+            context.scope.clone(),
             &upsert,
         )?;
 
@@ -391,8 +400,7 @@ Text to analyze:
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-        model, api_key
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     );
 
     let response = http
@@ -407,7 +415,7 @@ Text to analyze:
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Gemini API returned {}: {}", status, body);
+        anyhow::bail!("Gemini API returned {status}: {body}");
     }
 
     let api_response: GeminiResponse = response

--- a/crates/plugins/seidrum-llm-anthropic/src/main.rs
+++ b/crates/plugins/seidrum-llm-anthropic/src/main.rs
@@ -147,7 +147,7 @@ async fn main() -> Result<()> {
                     error!(error = %e, "Failed to handle llm.provider.anthropic request");
                     let err_response = LlmResponse {
                         agent_id: "unknown".to_string(),
-                        content: Some(format!("LLM provider error: {}", e)),
+                        content: Some(format!("LLM provider error: {e}")),
                         tool_calls: None,
                         model_used: model,
                         provider: "anthropic".to_string(),
@@ -252,9 +252,9 @@ async fn handle_provider_request(
                     .unwrap_or("Unknown error")
                     .to_string(),
                 // Don't log raw body — it may contain sensitive headers or tokens
-                Err(_) => format!("Non-JSON error response (status {})", status),
+                Err(_) => format!("Non-JSON error response (status {status})"),
             };
-            anyhow::bail!("Anthropic API error ({}): {}", status, err_msg);
+            anyhow::bail!("Anthropic API error ({status}): {err_msg}");
         }
 
         let api_response: AnthropicResponse = serde_json::from_slice(&body_bytes)?;

--- a/crates/plugins/seidrum-llm-google/src/main.rs
+++ b/crates/plugins/seidrum-llm-google/src/main.rs
@@ -79,7 +79,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
     })?;
 
     let profiles: serde_json::Value = serde_json::from_str(&content)
-        .map_err(|e| anyhow::anyhow!("Failed to parse OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to parse OpenClaw auth-profiles.json: {e}"))?;
 
     let key = profiles
         .get("profiles")
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
                     // Send an error response back
                     let err_response = LlmResponse {
                         agent_id: "unknown".to_string(),
-                        content: Some(format!("LLM provider error: {}", e)),
+                        content: Some(format!("LLM provider error: {e}")),
                         tool_calls: None,
                         model_used: model,
                         provider: "google".to_string(),
@@ -291,8 +291,7 @@ async fn handle_provider_request(
         };
 
         let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-            model, api_key
+            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
         );
 
         let response = http
@@ -312,13 +311,13 @@ async fn handle_provider_request(
                         format!("code {:?}: {}", err.code, err.message)
                     } else {
                         // Don't log raw body — it may contain sensitive information
-                        format!("Non-error Gemini response with status {}", status)
+                        format!("Non-error Gemini response with status {status}")
                     }
                 }
                 // Don't log raw body — it may contain sensitive information
-                Err(_) => format!("Non-JSON error response (status {})", status),
+                Err(_) => format!("Non-JSON error response (status {status})"),
             };
-            anyhow::bail!("Gemini API error ({}): {}", status, err_msg);
+            anyhow::bail!("Gemini API error ({status}): {err_msg}");
         }
 
         let api_response: GeminiResponse = serde_json::from_slice(&body_bytes)?;

--- a/crates/plugins/seidrum-llm-google/src/translator.rs
+++ b/crates/plugins/seidrum-llm-google/src/translator.rs
@@ -208,7 +208,7 @@ fn generate_call_id() -> String {
         x
     });
 
-    format!("{:012x}-{:016x}", ts, rand_part)
+    format!("{ts:012x}-{rand_part:016x}")
 }
 
 #[cfg(test)]

--- a/crates/plugins/seidrum-llm-ollama/src/main.rs
+++ b/crates/plugins/seidrum-llm-ollama/src/main.rs
@@ -124,17 +124,17 @@ async fn main() -> Result<()> {
         let max_tool_rounds = cli.max_tool_rounds;
 
         tokio::spawn(async move {
-            let result = handle_provider_request(
-                &msg.payload,
-                &http_clone,
-                &ollama_url_clone,
-                configured_model.as_deref(),
-                &ollama_api_key,
+            let provider_context = ProviderRequestContext {
+                http: &http_clone,
+                ollama_url: &ollama_url_clone,
+                configured_model: configured_model.as_deref(),
+                ollama_api_key: &ollama_api_key,
                 max_tokens,
                 max_tool_rounds,
-                &nats_clone,
-            )
-            .await;
+                nats: &nats_clone,
+            };
+
+            let result = handle_provider_request(&msg.payload, &provider_context).await;
 
             match result {
                 Ok(response) => {
@@ -156,7 +156,7 @@ async fn main() -> Result<()> {
                     error!(error = %e, "Failed to handle llm.provider.ollama request");
                     let err_response = LlmResponse {
                         agent_id: "unknown".to_string(),
-                        content: Some(format!("LLM provider error: {}", e)),
+                        content: Some(format!("LLM provider error: {e}")),
                         tool_calls: None,
                         model_used: configured_model.unwrap_or_else(|| "<auto>".to_string()),
                         provider: "ollama".to_string(),
@@ -258,7 +258,7 @@ async fn fetch_models(
     let body_bytes = response.bytes().await?;
     if !status.is_success() {
         let body = String::from_utf8_lossy(&body_bytes);
-        anyhow::bail!("failed to list Ollama models ({}): {}", status, body);
+        anyhow::bail!("failed to list Ollama models ({status}): {body}");
     }
 
     let tags: OllamaTagsResponse =
@@ -320,21 +320,31 @@ fn build_ollama_options(
 // Provider request handler
 // ---------------------------------------------------------------------------
 
-async fn handle_provider_request(
-    payload: &[u8],
-    http: &reqwest::Client,
-    ollama_url: &str,
-    configured_model: Option<&str>,
-    ollama_api_key: &str,
+struct ProviderRequestContext<'a> {
+    http: &'a reqwest::Client,
+    ollama_url: &'a str,
+    configured_model: Option<&'a str>,
+    ollama_api_key: &'a str,
     max_tokens: u32,
     max_tool_rounds: u32,
-    nats: &seidrum_common::bus_client::BusClient,
+    nats: &'a seidrum_common::bus_client::BusClient,
+}
+
+async fn handle_provider_request(
+    payload: &[u8],
+    context: &ProviderRequestContext<'_>,
 ) -> Result<LlmResponse> {
     let request: UnifiedLlmRequest = serde_json::from_slice(payload)?;
 
     let agent_id = &request.agent_id;
     let correlation_id = request.correlation_id.as_deref();
-    let model = resolve_model(http, ollama_url, configured_model, ollama_api_key).await?;
+    let model = resolve_model(
+        context.http,
+        context.ollama_url,
+        context.configured_model,
+        context.ollama_api_key,
+    )
+    .await?;
 
     info!(
         agent_id = %agent_id,
@@ -354,7 +364,7 @@ async fn handle_provider_request(
         Some(unified_to_ollama_tools(&request.tools))
     };
 
-    let options = build_ollama_options(&request, max_tokens);
+    let options = build_ollama_options(&request, context.max_tokens);
 
     // Tool call loop
     let mut total_input_tokens: u32 = 0;
@@ -364,7 +374,7 @@ async fn handle_provider_request(
     let mut finish_reason = "stop".to_string();
     let start = Instant::now();
 
-    for round in 0..=max_tool_rounds {
+    for round in 0..=context.max_tool_rounds {
         info!(round, "LLM call round");
 
         let api_request = OllamaRequest {
@@ -375,9 +385,9 @@ async fn handle_provider_request(
             stream: false,
         };
 
-        let url = ollama_endpoint(ollama_url, "chat");
+        let url = ollama_endpoint(context.ollama_url, "chat");
 
-        let response = apply_ollama_auth(http.post(&url), ollama_api_key)
+        let response = apply_ollama_auth(context.http.post(&url), context.ollama_api_key)
             .header("Content-Type", "application/json")
             .json(&api_request)
             .send()
@@ -394,26 +404,25 @@ async fn handle_provider_request(
                     .unwrap_or("Unknown error")
                     .to_string(),
                 // Don't log raw body — it may contain sensitive information
-                Err(_) => format!("Non-JSON error response (status {})", status),
+                Err(_) => format!("Non-JSON error response (status {status})"),
             };
 
             if err_msg.contains("not found") {
-                let available = fetch_models(http, ollama_url, ollama_api_key)
-                    .await
-                    .ok()
-                    .filter(|models| !models.is_empty())
-                    .map(|models| available_models_summary(&models));
+                let available =
+                    fetch_models(context.http, context.ollama_url, context.ollama_api_key)
+                        .await
+                        .ok()
+                        .filter(|models| !models.is_empty())
+                        .map(|models| available_models_summary(&models));
 
                 if let Some(available_models) = available {
                     anyhow::bail!(
-                        "Ollama model '{}' not found. Available models: {}",
-                        model,
-                        available_models
+                        "Ollama model '{model}' not found. Available models: {available_models}"
                     );
                 }
             }
 
-            anyhow::bail!("Ollama API error ({}): {}", status, err_msg);
+            anyhow::bail!("Ollama API error ({status}): {err_msg}");
         }
 
         let api_response: OllamaResponse = serde_json::from_slice(&body_bytes)?;
@@ -450,11 +459,11 @@ async fn handle_provider_request(
             .map(|tcs| ollama_tool_calls_to_unified(tcs))
             .unwrap_or_default();
 
-        if tool_calls.is_empty() || round == max_tool_rounds {
+        if tool_calls.is_empty() || round == context.max_tool_rounds {
             // No tool calls or max rounds hit -- done
-            if round == max_tool_rounds && !tool_calls.is_empty() {
+            if round == context.max_tool_rounds && !tool_calls.is_empty() {
                 warn!(
-                    max_rounds = max_tool_rounds,
+                    max_rounds = context.max_tool_rounds,
                     "Hit maximum tool call rounds, returning partial content"
                 );
             }
@@ -491,7 +500,7 @@ async fn handle_provider_request(
 
             let tool_result = match tokio::time::timeout(
                 std::time::Duration::from_secs(30),
-                nats.request_bytes("capability.call", req_bytes),
+                context.nats.request_bytes("capability.call", req_bytes),
             )
             .await
             {

--- a/crates/plugins/seidrum-llm-openai/src/main.rs
+++ b/crates/plugins/seidrum-llm-openai/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
                     error!(error = %e, "Failed to handle llm.provider.openai request");
                     let err_response = LlmResponse {
                         agent_id: "unknown".to_string(),
-                        content: Some(format!("LLM provider error: {}", e)),
+                        content: Some(format!("LLM provider error: {e}")),
                         tool_calls: None,
                         model_used: model,
                         provider: "openai".to_string(),
@@ -236,7 +236,7 @@ async fn handle_provider_request(
 
         let response = http
             .post("https://api.openai.com/v1/chat/completions")
-            .header("Authorization", format!("Bearer {}", api_key))
+            .header("Authorization", format!("Bearer {api_key}"))
             .header("Content-Type", "application/json")
             .json(&api_request)
             .send()
@@ -254,9 +254,9 @@ async fn handle_provider_request(
                     .unwrap_or("Unknown error")
                     .to_string(),
                 // Don't log raw body — it may contain sensitive headers or tokens
-                Err(_) => format!("Non-JSON error response (status {})", status),
+                Err(_) => format!("Non-JSON error response (status {status})"),
             };
-            anyhow::bail!("OpenAI API error ({}): {}", status, err_msg);
+            anyhow::bail!("OpenAI API error ({status}): {err_msg}");
         }
 
         let api_response: OpenAiResponse = serde_json::from_slice(&body_bytes)?;

--- a/crates/plugins/seidrum-llm-openai/src/translator.rs
+++ b/crates/plugins/seidrum-llm-openai/src/translator.rs
@@ -72,16 +72,16 @@ pub fn unified_to_openai_tools(tools: &[ToolSchema]) -> Vec<OpenAiTool> {
 pub fn openai_tool_calls_to_unified(tool_calls: &[OpenAiToolCall]) -> Vec<UnifiedToolCall> {
     tool_calls
         .iter()
-        .filter_map(|tc| {
+        .map(|tc| {
             // Parse arguments from JSON string
             let args = serde_json::from_str(&tc.function.arguments)
                 .unwrap_or_else(|_| serde_json::json!({}));
 
-            Some(UnifiedToolCall {
+            UnifiedToolCall {
                 id: tc.id.clone(),
                 name: tc.function.name.clone(),
                 arguments: args,
-            })
+            }
         })
         .collect()
 }

--- a/crates/plugins/seidrum-llm-router/src/context_assembly.rs
+++ b/crates/plugins/seidrum-llm-router/src/context_assembly.rs
@@ -123,10 +123,7 @@ fn format_tasks(tasks: &[Value]) -> String {
                 .get("due_date")
                 .and_then(|v| v.as_str())
                 .unwrap_or("no due date");
-            format!(
-                "- [{}] {} (priority: {}, due: {})",
-                status, title, priority, due
-            )
+            format!("- [{status}] {title} (priority: {priority}, due: {due})")
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -155,7 +152,7 @@ fn format_history(history: &[Value]) -> String {
             if content.is_empty() {
                 return None;
             }
-            Some(format!("{}: {}", role, content))
+            Some(format!("{role}: {content}"))
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -175,7 +172,7 @@ fn format_skills(skills: &[Value]) -> String {
             if snippet.is_empty() {
                 return None;
             }
-            Some(format!("[Active Skill: {}]\n{}", id, snippet))
+            Some(format!("[Active Skill: {id}]\n{snippet}"))
         })
         .collect::<Vec<_>>()
         .join("\n\n")
@@ -200,7 +197,7 @@ fn format_similar_content(content: &[Value]) -> String {
                 return None;
             }
             match score {
-                Some(s) => Some(format!("[relevance: {:.2}] {}", s, text)),
+                Some(s) => Some(format!("[relevance: {s:.2}] {text}")),
                 None => Some(text.to_string()),
             }
         })
@@ -381,8 +378,7 @@ pub fn assemble_context(
         messages.push(SimpleMessage {
             role: "user".to_string(),
             content: format!(
-                "[System context - relevant knowledge]\n{}\n[End system context]",
-                rag_text
+                "[System context - relevant knowledge]\n{rag_text}\n[End system context]"
             ),
         });
         messages.push(SimpleMessage {

--- a/crates/plugins/seidrum-llm-router/src/main.rs
+++ b/crates/plugins/seidrum-llm-router/src/main.rs
@@ -205,18 +205,17 @@ async fn main() -> Result<()> {
         while let Some(msg) = tokio::select! {
             m = futures_next(&mut sub) => m,
         } {
-            if let Err(e) = handle_message(
-                &msg.payload,
-                &msg.subject,
+            let handler_config = MessageHandlerConfig {
                 max_tokens,
                 max_context_tokens,
                 max_dynamic_tools,
                 provider_timeout,
-                &prompt_template1,
-                &nats1,
-                &routing_config1,
-            )
-            .await
+                prompt_template: &prompt_template1,
+                routing_config: &routing_config1,
+            };
+
+            if let Err(e) =
+                handle_message(&msg.payload, &msg.subject, &handler_config, &nats1).await
             {
                 error!(error = %e, subject = %msg.subject, "Failed to process message");
             }
@@ -226,18 +225,17 @@ async fn main() -> Result<()> {
     let handle_inbound = tokio::spawn(async move {
         let mut sub = sub_inbound;
         while let Some(msg) = futures_next(&mut sub).await {
-            if let Err(e) = handle_message(
-                &msg.payload,
-                &msg.subject,
+            let handler_config = MessageHandlerConfig {
                 max_tokens,
                 max_context_tokens,
                 max_dynamic_tools,
                 provider_timeout,
-                &prompt_template,
-                &nats_pub,
-                &routing_config,
-            )
-            .await
+                prompt_template: &prompt_template,
+                routing_config: &routing_config,
+            };
+
+            if let Err(e) =
+                handle_message(&msg.payload, &msg.subject, &handler_config, &nats_pub).await
             {
                 error!(error = %e, subject = %msg.subject, "Failed to process message");
             }
@@ -264,16 +262,20 @@ async fn futures_next(
 // Message handler
 // ---------------------------------------------------------------------------
 
-async fn handle_message(
-    payload: &[u8],
-    subject: &str,
+struct MessageHandlerConfig<'a> {
     max_tokens: u32,
     max_context_tokens: usize,
     max_dynamic_tools: u32,
     provider_timeout: u64,
-    prompt_template: &str,
+    prompt_template: &'a str,
+    routing_config: &'a routing::RoutingStrategy,
+}
+
+async fn handle_message(
+    payload: &[u8],
+    subject: &str,
+    config: &MessageHandlerConfig<'_>,
     nats: &seidrum_common::bus_client::BusClient,
-    routing_config: &routing::RoutingStrategy,
 ) -> Result<()> {
     info!(subject = %subject, "Received event");
 
@@ -305,9 +307,9 @@ async fn handle_message(
                 .to_string();
 
             let config = ContextConfig {
-                max_context_tokens,
-                max_response_tokens: max_tokens as usize,
-                prompt_template: prompt_template.to_string(),
+                max_context_tokens: config.max_context_tokens,
+                max_response_tokens: config.max_tokens as usize,
+                prompt_template: config.prompt_template.to_string(),
             };
 
             let assembled = assemble_context(&config, &ctx)?;
@@ -359,7 +361,7 @@ async fn handle_message(
     // Query tool registry for available tools
     let mut tool_schemas = tools::meta_tools();
     let registry_tools =
-        tools::query_tool_registry(nats, &user_text_for_tools, max_dynamic_tools).await;
+        tools::query_tool_registry(nats, &user_text_for_tools, config.max_dynamic_tools).await;
     // Deduplicate: only add registry tools whose names don't collide with meta tools (O(n))
     let meta_names: std::collections::HashSet<String> =
         tool_schemas.iter().map(|t| t.name.clone()).collect();
@@ -380,15 +382,14 @@ async fn handle_message(
             + messages
                 .iter()
                 .map(|m| {
-                    context_assembly::count_tokens(&m.content.as_ref().unwrap_or(&String::new()))
-                        + 4
+                    context_assembly::count_tokens(m.content.as_ref().unwrap_or(&String::new())) + 4
                 })
                 .sum::<usize>()
     } else {
         messages
             .iter()
             .map(|m| {
-                context_assembly::count_tokens(&m.content.as_ref().unwrap_or(&String::new())) + 4
+                context_assembly::count_tokens(m.content.as_ref().unwrap_or(&String::new())) + 4
             })
             .sum::<usize>()
     };
@@ -411,7 +412,7 @@ async fn handle_message(
         tools: tool_schemas,
         config: LlmCallConfig {
             temperature: Some(0.7),
-            max_tokens: Some(max_tokens),
+            max_tokens: Some(config.max_tokens),
             top_p: None,
         },
         routing_strategy: "best-first".to_string(),
@@ -424,7 +425,7 @@ async fn handle_message(
     let request_bytes = serde_json::to_vec(&unified_request)?;
 
     // Get list of providers to try (in order)
-    let providers_to_try = get_providers_to_try(&request_profile, routing_config);
+    let providers_to_try = get_providers_to_try(&request_profile, config.routing_config);
 
     info!(
         providers = ?providers_to_try.iter().map(|p| p.name()).collect::<Vec<_>>(),
@@ -449,7 +450,7 @@ async fn handle_message(
         let start = Instant::now();
 
         let provider_response = tokio::time::timeout(
-            std::time::Duration::from_secs(provider_timeout),
+            std::time::Duration::from_secs(config.provider_timeout),
             nats.request_bytes(subject.clone(), request_bytes.clone()),
         )
         .await;
@@ -487,7 +488,7 @@ async fn handle_message(
             }
             Err(_) => {
                 let err_msg = format!("Provider {} request timed out", provider.name());
-                warn!(provider = %provider.name(), timeout_secs = provider_timeout, "Request timed out");
+                warn!(provider = %provider.name(), timeout_secs = config.provider_timeout, "Request timed out");
                 last_error = Some(err_msg);
             }
         }
@@ -505,7 +506,7 @@ async fn handle_message(
 
         LlmResponse {
             agent_id: agent_id.clone(),
-            content: Some(format!("Error: {}", error_msg)),
+            content: Some(format!("Error: {error_msg}")),
             tool_calls: None,
             model_used: "unknown".to_string(),
             provider: provider_name.to_string(),
@@ -560,8 +561,7 @@ fn build_routing_config(strategy: &str, fallback_str: &str) -> Result<routing::R
             routing::IntelligentRoutingConfig::default(),
         )),
         other => Err(anyhow::anyhow!(
-            "Unknown routing strategy: {}. Use 'fixed', 'fallback', or 'intelligent'",
-            other
+            "Unknown routing strategy: {other}. Use 'fixed', 'fallback', or 'intelligent'"
         )),
     }
 }
@@ -574,8 +574,7 @@ fn parse_provider(name: &str) -> Result<routing::Provider> {
         "anthropic" | "claude" => Ok(routing::Provider::Anthropic),
         "ollama" | "local" => Ok(routing::Provider::Ollama),
         other => Err(anyhow::anyhow!(
-            "Unknown provider: {}. Use 'google', 'openai', 'anthropic', or 'ollama'",
-            other
+            "Unknown provider: {other}. Use 'google', 'openai', 'anthropic', or 'ollama'"
         )),
     }
 }
@@ -626,7 +625,7 @@ fn generate_ulid() -> String {
         .unwrap_or_default()
         .as_millis();
     let rand_part: u64 = rand_u64();
-    format!("{:012x}-{:016x}", ts, rand_part)
+    format!("{ts:012x}-{rand_part:016x}")
 }
 
 /// Simple pseudo-random u64 using thread-local state seeded from the clock.

--- a/crates/plugins/seidrum-notification/src/main.rs
+++ b/crates/plugins/seidrum-notification/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
             "channel.telegram.outbound".to_string(),
             "channel.cli.outbound".to_string(),
         ],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -393,7 +393,7 @@ async fn send_notification(
         actions: vec![],
     };
 
-    let subject = format!("channel.{}.outbound", channel);
+    let subject = format!("channel.{channel}.outbound");
 
     let envelope = EventEnvelope::new(&subject, PLUGIN_ID, correlation_id, scope, &outbound)?;
 
@@ -421,10 +421,10 @@ fn format_task_created(task: &TaskCreated, channel: &str) -> (String, String) {
             priority_emoji, task.priority, task.title, task.scope
         );
         if let Some(ref desc) = task.description {
-            text.push_str(&format!("\n*Description:* {}", desc));
+            text.push_str(&format!("\n*Description:* {desc}"));
         }
         if let Some(ref agent) = task.assigned_agent {
-            text.push_str(&format!("\n*Assigned to:* {}", agent));
+            text.push_str(&format!("\n*Assigned to:* {agent}"));
         }
         if let Some(ref due) = task.due_date {
             text.push_str(&format!("\n*Due:* {}", due.format("%Y-%m-%d %H:%M UTC")));
@@ -436,7 +436,7 @@ fn format_task_created(task: &TaskCreated, channel: &str) -> (String, String) {
             task.title, task.priority, task.scope
         );
         if let Some(ref desc) = task.description {
-            text.push_str(&format!(" - {}", desc));
+            text.push_str(&format!(" - {desc}"));
         }
         (text, "plain".to_string())
     }
@@ -447,15 +447,15 @@ fn format_task_completed(task: &TaskCompleted, channel: &str) -> (String, String
     if channel == "telegram" {
         let mut text = format!("\u{2705} *Task Completed*\n\n*Task:* {}", task.task_key);
         if let Some(ref result) = task.result {
-            text.push_str(&format!("\n*Result:* {}", result));
+            text.push_str(&format!("\n*Result:* {result}"));
         }
         let duration = format_duration_ms(task.duration_ms);
-        text.push_str(&format!("\n*Duration:* {}", duration));
+        text.push_str(&format!("\n*Duration:* {duration}"));
         (text, "markdown".to_string())
     } else {
         let mut text = format!("[TASK COMPLETED] {}", task.task_key);
         if let Some(ref result) = task.result {
-            text.push_str(&format!(" - Result: {}", result));
+            text.push_str(&format!(" - Result: {result}"));
         }
         text.push_str(&format!(" (took {})", format_duration_ms(task.duration_ms)));
         (text, "plain".to_string())
@@ -475,7 +475,7 @@ fn format_health_alert(health: &SystemHealth, channel: &str) -> (String, String)
     if channel == "telegram" {
         let text = format!(
             "\u{1f6a8} *System Health Alert*\n\n*Issues:*\n{}\n\n*Active plugins:* {}\n*Uptime:* {}s",
-            issues.iter().map(|i| format!("\u{274c} {}", i)).collect::<Vec<_>>().join("\n"),
+            issues.iter().map(|i| format!("\u{274c} {i}")).collect::<Vec<_>>().join("\n"),
             health.active_plugins.len(),
             health.uptime_seconds,
         );
@@ -494,13 +494,13 @@ fn format_health_alert(health: &SystemHealth, channel: &str) -> (String, String)
 /// Format milliseconds into a human-readable duration string.
 fn format_duration_ms(ms: u64) -> String {
     if ms < 1000 {
-        format!("{}ms", ms)
+        format!("{ms}ms")
     } else if ms < 60_000 {
         format!("{:.1}s", ms as f64 / 1000.0)
     } else {
         let minutes = ms / 60_000;
         let seconds = (ms % 60_000) / 1000;
-        format!("{}m {}s", minutes, seconds)
+        format!("{minutes}m {seconds}s")
     }
 }
 

--- a/crates/plugins/seidrum-scope-classifier/src/main.rs
+++ b/crates/plugins/seidrum-scope-classifier/src/main.rs
@@ -94,7 +94,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
         .map(|h| h.join(".openclaw/agents/main/agent/auth-profiles.json"))
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let content = std::fs::read_to_string(&auth_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {e}"))?;
     let profiles: serde_json::Value = serde_json::from_str(&content)?;
     let key = profiles
         .get("profiles")
@@ -134,7 +134,7 @@ async fn main() -> Result<()> {
         description: "Classifies content into scopes using LLM".to_string(),
         consumes: vec!["brain.content.stored".to_string()],
         produces: vec!["brain.scope.assign".to_string()],
-        health_subject: format!("plugin.{}.health", PLUGIN_ID),
+        health_subject: format!("plugin.{PLUGIN_ID}.health"),
         consumed_event_types: vec![],
         produced_event_types: vec![],
         config_schema: None,
@@ -405,8 +405,7 @@ Content to classify:
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-        model, api_key
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     );
 
     let response = http
@@ -421,7 +420,7 @@ Content to classify:
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Gemini API returned {}: {}", status, body);
+        anyhow::bail!("Gemini API returned {status}: {body}");
     }
 
     let api_response: GeminiResponse = response

--- a/crates/plugins/seidrum-task-detector/src/main.rs
+++ b/crates/plugins/seidrum-task-detector/src/main.rs
@@ -99,7 +99,7 @@ fn resolve_google_api_key(cli_key: &Option<String>) -> Result<String> {
         .map(|h| h.join(".openclaw/agents/main/agent/auth-profiles.json"))
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
     let content = std::fs::read_to_string(&auth_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to read OpenClaw auth-profiles.json: {e}"))?;
     let profiles: serde_json::Value = serde_json::from_str(&content)?;
     let key = profiles
         .get("profiles")
@@ -198,17 +198,16 @@ async fn main() -> Result<()> {
             "Processing LLM response for task detection"
         );
 
-        if let Err(err) = detect_and_publish_tasks(
-            &client,
-            &http_client,
-            &api_key,
-            &args.detection_model,
-            &content,
-            &llm_response.agent_id,
-            &envelope.correlation_id,
-            &envelope.scope,
-        )
-        .await
+        let detection_context = DetectionContext {
+            api_key: &api_key,
+            model: &args.detection_model,
+            agent_id: &llm_response.agent_id,
+            correlation_id: &envelope.correlation_id,
+            scope: &envelope.scope,
+        };
+
+        if let Err(err) =
+            detect_and_publish_tasks(&client, &http_client, &detection_context, &content).await
         {
             error!(
                 agent_id = %llm_response.agent_id,
@@ -221,18 +220,22 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+struct DetectionContext<'a> {
+    api_key: &'a str,
+    model: &'a str,
+    agent_id: &'a str,
+    correlation_id: &'a Option<String>,
+    scope: &'a Option<String>,
+}
+
 async fn detect_and_publish_tasks(
     nats: &seidrum_common::bus_client::BusClient,
     http: &reqwest::Client,
-    api_key: &str,
-    model: &str,
+    context: &DetectionContext<'_>,
     llm_content: &str,
-    agent_id: &str,
-    correlation_id: &Option<String>,
-    scope: &Option<String>,
 ) -> Result<()> {
     // Step 1: Call LLM to detect tasks
-    let tasks = detect_tasks_via_llm(http, api_key, model, llm_content).await?;
+    let tasks = detect_tasks_via_llm(http, context.api_key, context.model, llm_content).await?;
 
     if tasks.is_empty() {
         info!("No tasks detected in LLM response");
@@ -246,7 +249,7 @@ async fn detect_and_publish_tasks(
         let task_scope = task
             .scope
             .clone()
-            .or_else(|| scope.clone())
+            .or_else(|| context.scope.clone())
             .unwrap_or_else(|| "scope_root".to_string());
 
         let upsert_payload = serde_json::json!({
@@ -254,7 +257,7 @@ async fn detect_and_publish_tasks(
             "description": task.description,
             "status": "open",
             "priority": task.priority,
-            "assigned_agent": agent_id,
+            "assigned_agent": context.agent_id,
             "due_date": task.due_date,
             "context": {
                 "scope": task_scope,
@@ -264,7 +267,7 @@ async fn detect_and_publish_tasks(
         let upsert_envelope = EventEnvelope::new(
             "brain.task.upsert",
             PLUGIN_ID,
-            correlation_id.clone(),
+            context.correlation_id.clone(),
             Some(task_scope.clone()),
             &upsert_payload,
         )?;
@@ -329,8 +332,7 @@ Text to analyze:
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-        model, api_key
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     );
 
     let response = http
@@ -345,7 +347,7 @@ Text to analyze:
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Gemini API returned {}: {}", status, body);
+        anyhow::bail!("Gemini API returned {status}: {body}");
     }
 
     let api_response: GeminiResponse = response

--- a/crates/plugins/seidrum-telegram/src/commands.rs
+++ b/crates/plugins/seidrum-telegram/src/commands.rs
@@ -239,7 +239,7 @@ async fn fetch_capability_details(nats: &BusClient, tool_id: &str) -> (String, S
         _ => {
             // Fallback: derive from tool_id
             let plugin_id = tool_id.split('.').next().unwrap_or("unknown").to_string();
-            let call_subject = format!("capability.call.{}", tool_id);
+            let call_subject = format!("capability.call.{tool_id}");
             (plugin_id, call_subject)
         }
     }
@@ -278,15 +278,19 @@ pub async fn set_telegram_commands(bot: &Bot, registry: &CommandRegistry) {
 
 /// Execute a parsed command. Returns Ok(()) even for unknown commands
 /// (sends an error message to the user instead of failing).
+pub struct CommandExecutionContext<'a> {
+    pub chat_id: i64,
+    pub thread_id: Option<ThreadId>,
+    pub user_id: u64,
+    pub registry: &'a CommandRegistry,
+    pub bot: &'a Bot,
+    pub nats: &'a BusClient,
+}
+
 pub async fn execute_command(
     command: &str,
     args: &str,
-    chat_id: i64,
-    thread_id: Option<ThreadId>,
-    user_id: u64,
-    registry: &CommandRegistry,
-    bot: &Bot,
-    nats: &BusClient,
+    context: &CommandExecutionContext<'_>,
 ) -> Result<()> {
     // Strip bot username suffix if present (e.g., "/help@my_bot" -> "help")
     let cmd_name = command
@@ -295,41 +299,24 @@ pub async fn execute_command(
         .unwrap_or(command)
         .trim_start_matches('/');
 
-    info!(command = %cmd_name, %chat_id, %user_id, "Executing command");
+    info!(command = %cmd_name, chat_id = %context.chat_id, user_id = %context.user_id, "Executing command");
 
-    let entry = registry.find(cmd_name).await;
+    let entry = context.registry.find(cmd_name).await;
 
     match entry {
         Some(entry) => match &entry.kind {
-            CommandKind::BuiltIn => {
-                execute_builtin(
-                    cmd_name, args, chat_id, thread_id, user_id, registry, bot, nats,
-                )
-                .await
-            }
+            CommandKind::BuiltIn => execute_builtin(cmd_name, args, context).await,
             CommandKind::Capability {
                 capability_id,
                 plugin_id,
                 call_subject,
-            } => {
-                execute_capability(
-                    capability_id,
-                    plugin_id,
-                    call_subject,
-                    args,
-                    chat_id,
-                    thread_id,
-                    bot,
-                    nats,
-                )
-                .await
-            }
+            } => execute_capability(capability_id, plugin_id, call_subject, args, context).await,
         },
         None => {
             send_reply(
-                bot,
-                chat_id,
-                thread_id,
+                context.bot,
+                context.chat_id,
+                context.thread_id,
                 "Unknown command. Type /help for available commands.",
             )
             .await
@@ -341,53 +328,49 @@ pub async fn execute_command(
 async fn execute_builtin(
     command: &str,
     args: &str,
-    chat_id: i64,
-    thread_id: Option<ThreadId>,
-    user_id: u64,
-    registry: &CommandRegistry,
-    bot: &Bot,
-    nats: &BusClient,
+    context: &CommandExecutionContext<'_>,
 ) -> Result<()> {
     match command {
         "start" => {
             send_reply(
-                bot,
-                chat_id,
-                thread_id,
+                context.bot,
+                context.chat_id,
+                context.thread_id,
                 "\u{1f44b} Welcome to Seidrum!\n\nI'm your personal AI assistant. \
                  Send me a message, voice note, or photo.\n\nType /help to see available commands.",
             )
             .await
         }
         "help" => {
-            let commands = registry.list().await;
+            let commands = context.registry.list().await;
             let mut text = String::from("\u{2699}\u{fe0f} <b>Available Commands</b>\n\n");
             for cmd in &commands {
                 text.push_str(&format!("/{}", cmd.name));
                 if let Some(ref usage) = cmd.usage {
-                    text.push_str(&format!(" {}", usage));
+                    text.push_str(&format!(" {usage}"));
                 }
                 text.push_str(&format!(" — {}\n", cmd.description));
             }
-            send_html_reply(bot, chat_id, thread_id, &text).await
+            send_html_reply(context.bot, context.chat_id, context.thread_id, &text).await
         }
         "info" => {
-            let thread_str = thread_id
+            let thread_str = context
+                .thread_id
                 .map(|t| format!("{}", t.0))
                 .unwrap_or_else(|| "none".to_string());
             let text = format!(
                 "\u{2139}\u{fe0f} <b>Chat Info</b>\n\n\
                  Chat ID: <code>{}</code>\n\
-                 Thread ID: <code>{}</code>\n\
+                 Thread ID: <code>{thread_str}</code>\n\
                  User ID: <code>{}</code>",
-                chat_id, thread_str, user_id
+                context.chat_id, context.user_id
             );
-            send_html_reply(bot, chat_id, thread_id, &text).await
+            send_html_reply(context.bot, context.chat_id, context.thread_id, &text).await
         }
         "plugins" => {
             let text = match tokio::time::timeout(
                 Duration::from_secs(3),
-                nats.request::<_, RegistryQueryResponse>(
+                context.nats.request::<_, RegistryQueryResponse>(
                     "registry.query",
                     &RegistryQuery::ListPlugins,
                 ),
@@ -409,19 +392,19 @@ async fn execute_builtin(
                         text
                     }
                 }
-                Ok(Err(err)) => format!("Failed to query plugins: {}", err),
-                Err(_) => "Plugin registry query timed out.".to_string(),
+                Ok(Err(err)) => format!("Failed to query plugins: {err}"),
+                Err(_) => "Plugin context.registry query timed out.".to_string(),
             };
-            send_html_reply(bot, chat_id, thread_id, &text).await
+            send_html_reply(context.bot, context.chat_id, context.thread_id, &text).await
         }
         "link" => {
-            let tid = match thread_id {
+            let tid = match context.thread_id {
                 Some(tid) => tid,
                 None => {
                     return send_reply(
-                        bot,
-                        chat_id,
-                        thread_id,
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
                         "/link can only be used inside a thread.",
                     )
                     .await;
@@ -431,15 +414,15 @@ async fn execute_builtin(
             let path = args.trim();
             if path.is_empty() {
                 return send_reply(
-                    bot,
-                    chat_id,
-                    thread_id,
+                    context.bot,
+                    context.chat_id,
+                    context.thread_id,
                     "Usage: /link <path>\nExample: /link /home/user/projects/myapp",
                 )
                 .await;
             }
 
-            let storage_key = format!("{}:{}", chat_id, tid.0);
+            let storage_key = format!("{}:{}", context.chat_id, tid.0);
             let req = StorageSetRequest {
                 plugin_id: "telegram".to_string(),
                 namespace: "thread_links".to_string(),
@@ -449,52 +432,68 @@ async fn execute_builtin(
 
             match tokio::time::timeout(
                 Duration::from_secs(5),
-                nats.request::<_, StorageSetResponse>("storage.set", &req),
+                context
+                    .nats
+                    .request::<_, StorageSetResponse>("storage.set", &req),
             )
             .await
             {
                 Ok(Ok(resp)) if resp.success => {
-                    info!(%chat_id, thread_id = %tid.0, %path, "Thread linked to project");
+                    info!(%context.chat_id, context.thread_id = %tid.0, %path, "Thread linked to project");
                     send_html_reply(
-                        bot,
-                        chat_id,
-                        thread_id,
-                        &format!("Thread linked to <code>{}</code>", path),
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        &format!("Thread linked to <code>{path}</code>"),
                     )
                     .await
                 }
                 Ok(Ok(resp)) => {
                     let err_msg = resp.error.unwrap_or_else(|| "unknown error".to_string());
                     send_reply(
-                        bot,
-                        chat_id,
-                        thread_id,
-                        &format!("Failed to save link: {}", err_msg),
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        &format!("Failed to save link: {err_msg}"),
                     )
                     .await
                 }
                 Ok(Err(err)) => {
                     warn!(%err, "storage.set request failed");
-                    send_reply(bot, chat_id, thread_id, "Failed to save link.").await
+                    send_reply(
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        "Failed to save link.",
+                    )
+                    .await
                 }
-                Err(_) => send_reply(bot, chat_id, thread_id, "Storage request timed out.").await,
+                Err(_) => {
+                    send_reply(
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        "Storage request timed out.",
+                    )
+                    .await
+                }
             }
         }
         "unlink" => {
-            let tid = match thread_id {
+            let tid = match context.thread_id {
                 Some(tid) => tid,
                 None => {
                     return send_reply(
-                        bot,
-                        chat_id,
-                        thread_id,
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
                         "/unlink can only be used inside a thread.",
                     )
                     .await;
                 }
             };
 
-            let storage_key = format!("{}:{}", chat_id, tid.0);
+            let storage_key = format!("{}:{}", context.chat_id, tid.0);
             let req = StorageDeleteRequest {
                 plugin_id: "telegram".to_string(),
                 namespace: "thread_links".to_string(),
@@ -503,40 +502,68 @@ async fn execute_builtin(
 
             match tokio::time::timeout(
                 Duration::from_secs(5),
-                nats.request::<_, StorageDeleteResponse>("storage.delete", &req),
+                context
+                    .nats
+                    .request::<_, StorageDeleteResponse>("storage.delete", &req),
             )
             .await
             {
                 Ok(Ok(resp)) if resp.existed => {
-                    info!(%chat_id, thread_id = %tid.0, "Thread unlinked");
-                    send_reply(bot, chat_id, thread_id, "Thread unlinked from project.").await
+                    info!(%context.chat_id, context.thread_id = %tid.0, "Thread unlinked");
+                    send_reply(
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        "Thread unlinked from project.",
+                    )
+                    .await
                 }
                 Ok(Ok(_)) => {
                     send_reply(
-                        bot,
-                        chat_id,
-                        thread_id,
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
                         "This thread is not linked to any project.",
                     )
                     .await
                 }
                 Ok(Err(err)) => {
                     warn!(%err, "storage.delete request failed");
-                    send_reply(bot, chat_id, thread_id, "Failed to unlink.").await
+                    send_reply(
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        "Failed to unlink.",
+                    )
+                    .await
                 }
-                Err(_) => send_reply(bot, chat_id, thread_id, "Storage request timed out.").await,
+                Err(_) => {
+                    send_reply(
+                        context.bot,
+                        context.chat_id,
+                        context.thread_id,
+                        "Storage request timed out.",
+                    )
+                    .await
+                }
             }
         }
         "restart" => {
-            send_reply(bot, chat_id, thread_id, "Restarting Telegram plugin...").await?;
+            send_reply(
+                context.bot,
+                context.chat_id,
+                context.thread_id,
+                "Restarting Telegram plugin...",
+            )
+            .await?;
             info!("Restart requested via /restart command");
             std::process::exit(0);
         }
         _ => {
             send_reply(
-                bot,
-                chat_id,
-                thread_id,
+                context.bot,
+                context.chat_id,
+                context.thread_id,
                 "Unknown command. Type /help for available commands.",
             )
             .await
@@ -578,18 +605,17 @@ async fn execute_capability(
     plugin_id: &str,
     call_subject: &str,
     args: &str,
-    chat_id: i64,
-    thread_id: Option<ThreadId>,
-    bot: &Bot,
-    nats: &BusClient,
+    context: &CommandExecutionContext<'_>,
 ) -> Result<()> {
     let mut arguments = serde_json::json!({
         "args": args,
-        "chat_id": chat_id.to_string(),
+        "context.chat_id": context.chat_id.to_string(),
     });
 
     // Inject linked working_dir if this thread is linked to a project
-    if let Some(working_dir) = get_thread_working_dir(nats, chat_id, thread_id).await {
+    if let Some(working_dir) =
+        get_thread_working_dir(context.nats, context.chat_id, context.thread_id).await
+    {
         arguments
             .as_object_mut()
             .unwrap()
@@ -600,12 +626,14 @@ async fn execute_capability(
         tool_id: capability_id.to_string(),
         plugin_id: plugin_id.to_string(),
         arguments,
-        correlation_id: Some(format!("telegram:{}:cmd", chat_id)),
+        correlation_id: Some(format!("telegram:{}:cmd", context.chat_id)),
     };
 
     match tokio::time::timeout(
         Duration::from_secs(120),
-        nats.request::<_, ToolCallResponse>(call_subject, &req),
+        context
+            .nats
+            .request::<_, ToolCallResponse>(call_subject, &req),
     )
     .await
     {
@@ -616,9 +644,9 @@ async fn execute_capability(
                     .as_str()
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| resp.result.to_string());
-                format!("\u{274c} Command failed: {}", msg)
+                format!("\u{274c} Command failed: {msg}")
             } else {
-                // Handle both string results and JSON objects with a "result" field
+                // Handle context.both string results and JSON objects with a "result" field
                 resp.result
                     .as_str()
                     .map(|s| s.to_string())
@@ -630,23 +658,23 @@ async fn execute_capability(
                     })
                     .unwrap_or_else(|| resp.result.to_string())
             };
-            send_reply(bot, chat_id, thread_id, &text).await
+            send_reply(context.bot, context.chat_id, context.thread_id, &text).await
         }
         Ok(Err(err)) => {
             warn!(%err, capability_id, "Capability call failed");
             send_reply(
-                bot,
-                chat_id,
-                thread_id,
-                &format!("\u{274c} Command error: {}", err),
+                context.bot,
+                context.chat_id,
+                context.thread_id,
+                &format!("\u{274c} Command error: {err}"),
             )
             .await
         }
         Err(_) => {
             send_reply(
-                bot,
-                chat_id,
-                thread_id,
+                context.bot,
+                context.chat_id,
+                context.thread_id,
                 "\u{23f3} Command timed out. Please try again.",
             )
             .await
@@ -689,7 +717,7 @@ async fn send_html_reply(
         Ok(_) => Ok(()),
         Err(err) => {
             warn!(%err, "HTML send failed, retrying as plain text");
-            let mut req = bot.send_message(chat, &crate::markdown::strip_markdown(text));
+            let mut req = bot.send_message(chat, crate::markdown::strip_markdown(text));
             if let Some(tid) = thread_id {
                 req = req.message_thread_id(tid);
             }
@@ -754,7 +782,7 @@ pub async fn spawn_capability_listener(nats: BusClient, registry: CommandRegistr
                         }
                     };
 
-                    if reg.kind != "command" && reg.kind != "both" {
+                    if reg.kind != "command" && reg.kind != "context.both" {
                         continue;
                     }
 

--- a/crates/plugins/seidrum-telegram/src/inbound.rs
+++ b/crates/plugins/seidrum-telegram/src/inbound.rs
@@ -53,21 +53,19 @@ pub async fn handle_message(
             let cmd_name = parts[0].trim_start_matches('/');
             let args = parts.get(1).copied().unwrap_or("");
             let uid = msg.from.as_ref().map(|u| u.id.0).unwrap_or(0);
-            return crate::commands::execute_command(
-                cmd_name,
-                args,
-                msg.chat.id.0,
-                msg.thread_id,
-                uid,
+            let context = crate::commands::CommandExecutionContext {
+                chat_id: msg.chat.id.0,
+                thread_id: msg.thread_id,
+                user_id: uid,
                 registry,
                 bot,
                 nats,
-            )
-            .await;
+            };
+            return crate::commands::execute_command(cmd_name, args, &context).await;
         }
 
         let display_text = if is_edited {
-            format!("[The user edited their previous message to:]\n{}", text)
+            format!("[The user edited their previous message to:]\n{text}")
         } else {
             text.to_string()
         };
@@ -93,8 +91,7 @@ pub async fn handle_message(
         {
             Ok(Some(transcript)) => {
                 format!(
-                    "[Voice message transcription \u{2014} some words may be mistranscribed]\n{}",
-                    transcript
+                    "[Voice message transcription \u{2014} some words may be mistranscribed]\n{transcript}"
                 )
             }
             Ok(None) => "[Voice message received but transcript was empty]".to_string(),
@@ -105,10 +102,7 @@ pub async fn handle_message(
         };
 
         let display_text = if is_edited {
-            format!(
-                "[The user edited their previous message to:]\n{}",
-                transcript
-            )
+            format!("[The user edited their previous message to:]\n{transcript}")
         } else {
             transcript
         };
@@ -135,7 +129,7 @@ pub async fn handle_message(
 
             let caption = msg.caption().unwrap_or("The user sent an image.");
             let display_text = if is_edited {
-                format!("[The user edited their previous message to:]\n{}", caption)
+                format!("[The user edited their previous message to:]\n{caption}")
             } else {
                 caption.to_string()
             };
@@ -171,10 +165,10 @@ pub async fn handle_message(
         let caption = msg
             .caption()
             .map(|c| c.to_string())
-            .unwrap_or_else(|| format!("Document: {}", file_name));
+            .unwrap_or_else(|| format!("Document: {file_name}"));
 
         let display_text = if is_edited {
-            format!("[The user edited their previous message to:]\n{}", caption)
+            format!("[The user edited their previous message to:]\n{caption}")
         } else {
             caption
         };

--- a/crates/plugins/seidrum-telegram/src/media.rs
+++ b/crates/plugins/seidrum-telegram/src/media.rs
@@ -75,10 +75,7 @@ pub async fn download_document(
 
 /// Call Telegram's getFile API to retrieve the file_path for downloading.
 async fn get_telegram_file_path(token: &str, file_id: &str) -> anyhow::Result<String> {
-    let url = format!(
-        "https://api.telegram.org/bot{}/getFile?file_id={}",
-        token, file_id
-    );
+    let url = format!("https://api.telegram.org/bot{token}/getFile?file_id={file_id}");
 
     let client = reqwest::Client::new();
     let resp = client
@@ -107,7 +104,7 @@ async fn get_telegram_file_path(token: &str, file_id: &str) -> anyhow::Result<St
 
 /// Download a file from Telegram's file storage by its file_path.
 async fn download_telegram_file(token: &str, file_path: &str) -> anyhow::Result<Vec<u8>> {
-    let url = format!("https://api.telegram.org/file/bot{}/{}", token, file_path);
+    let url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
 
     let client = reqwest::Client::new();
     let resp = client

--- a/crates/plugins/seidrum-telegram/src/split.rs
+++ b/crates/plugins/seidrum-telegram/src/split.rs
@@ -50,7 +50,7 @@ pub fn split_message(text: &str, max_len: usize) -> Vec<String> {
             let prefix = if fence_lang.is_empty() {
                 "```\n".to_string()
             } else {
-                format!("```{}\n", fence_lang)
+                format!("```{fence_lang}\n")
             };
             chunk_str = prefix + &chunk_str;
         }

--- a/crates/plugins/seidrum-telegram/src/voice.rs
+++ b/crates/plugins/seidrum-telegram/src/voice.rs
@@ -63,7 +63,7 @@ pub async fn transcribe_voice(
 
     if !ffmpeg_output.status.success() {
         let stderr = String::from_utf8_lossy(&ffmpeg_output.stderr);
-        bail!("ffmpeg conversion failed: {}", stderr);
+        bail!("ffmpeg conversion failed: {stderr}");
     }
     debug!("Converted OGG to WAV");
 
@@ -83,7 +83,7 @@ pub async fn transcribe_voice(
 
     if !whisper_output.status.success() {
         let stderr = String::from_utf8_lossy(&whisper_output.stderr);
-        bail!("whisper-cli transcription failed: {}", stderr);
+        bail!("whisper-cli transcription failed: {stderr}");
     }
 
     // Step 7: Parse transcript
@@ -107,10 +107,7 @@ pub async fn transcribe_voice(
 
 /// Call Telegram's getFile API to get the file_path for downloading.
 async fn get_telegram_file_path(token: &str, file_id: &str) -> anyhow::Result<String> {
-    let url = format!(
-        "https://api.telegram.org/bot{}/getFile?file_id={}",
-        token, file_id
-    );
+    let url = format!("https://api.telegram.org/bot{token}/getFile?file_id={file_id}");
 
     let client = reqwest::Client::new();
     let resp = client
@@ -139,7 +136,7 @@ async fn get_telegram_file_path(token: &str, file_id: &str) -> anyhow::Result<St
 
 /// Download a file from Telegram's file storage.
 async fn download_telegram_file(token: &str, file_path: &str) -> anyhow::Result<Vec<u8>> {
-    let url = format!("https://api.telegram.org/file/bot{}/{}", token, file_path);
+    let url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
 
     let client = reqwest::Client::new();
     let resp = client

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. **Rust** (stable) — [rustup.rs](https://rustup.rs)
+1. **Rust** 1.88 or newer — [rustup.rs](https://rustup.rs). The repository includes `rust-toolchain.toml`, so `rustup` will select the pinned toolchain automatically.
 2. **Docker** — [docker.com/get-started](https://docker.com/get-started) (required for ArangoDB on macOS; on Linux, Podman also works)
 3. **At least one LLM API key** — Google (Gemini) or OpenAI
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- Pin Rust toolchain to 1.88.0 and declare workspace MSRV as Rust 1.88.
- Align CI/release workflows and contributor docs with the pinned toolchain and strict clippy gate.
- Clean full-workspace clippy warnings across core and plugin crates without adding broad lint suppressions.

## Local verification
Using clean Linux rustup env: rustc 1.96.0, repo policy Rust 1.88.0 / MSRV 1.88.

- cargo fmt --all --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

All passed locally.