### PR TITLE
feat(agent-runtime): add runtime spine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,6 +3490,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "seidrum-agent-runtime"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "ulid",
+]
+
+[[package]]
 name = "seidrum-api-gateway"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/core/seidrum-common",
+    "crates/core/seidrum-agent-runtime",
     "crates/core/seidrum-kernel",
     "crates/core/seidrum-daemon",
     "crates/core/seidrum-e2e",

--- a/crates/core/seidrum-agent-runtime/Cargo.toml
+++ b/crates/core/seidrum-agent-runtime/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "seidrum-agent-runtime"
+version = "0.1.0"
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+ulid = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/core/seidrum-agent-runtime/src/lib.rs
+++ b/crates/core/seidrum-agent-runtime/src/lib.rs
@@ -1,0 +1,395 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum RuntimeError {
+    #[error("provider error: {0}")]
+    Provider(String),
+    #[error("tool `{tool_name}` failed: {message}")]
+    Tool { tool_name: String, message: String },
+    #[error("store error: {0}")]
+    Store(String),
+    #[error("tool `{0}` is not registered")]
+    ToolNotRegistered(String),
+    #[error("provider did not return a final response within {0} iterations")]
+    IterationLimit(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnInput {
+    pub session_id: String,
+    pub agent_id: String,
+    pub user_message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnOutput {
+    pub session_id: String,
+    pub agent_id: String,
+    pub final_text: String,
+    pub events: Vec<RuntimeEvent>,
+    pub tool_results: Vec<ToolResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeEvent {
+    OutboundResponse {
+        session_id: String,
+        agent_id: String,
+        text: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub call_id: String,
+    pub tool_name: String,
+    pub content: String,
+    pub is_error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRequest {
+    pub session_id: String,
+    pub agent_id: String,
+    pub messages: Vec<ContextMessage>,
+    pub tool_results: Vec<ToolResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderResponse {
+    pub final_text: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
+}
+
+impl ProviderResponse {
+    pub fn final_text(text: impl Into<String>) -> Self {
+        Self {
+            final_text: Some(text.into()),
+            tool_calls: Vec::new(),
+        }
+    }
+
+    pub fn tool_calls(calls: impl IntoIterator<Item = ToolCall>) -> Self {
+        Self {
+            final_text: None,
+            tool_calls: calls.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub max_tool_iterations: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_tool_iterations: 4,
+        }
+    }
+}
+
+#[async_trait]
+pub trait AgentProvider: Send + Sync + Clone + 'static {
+    async fn complete(&self, request: ProviderRequest) -> Result<ProviderResponse, RuntimeError>;
+}
+
+#[async_trait]
+pub trait ToolExecutor: Send + Sync + 'static {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError>;
+}
+
+#[async_trait]
+pub trait RuntimeStore: Send + Sync + Clone + 'static {
+    async fn append(&self, record: StoredTurnRecord) -> Result<(), RuntimeError>;
+    async fn records(&self, session_id: &str) -> Result<Vec<StoredTurnRecord>, RuntimeError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StoredTurnRecord {
+    UserMessage {
+        record_id: String,
+        sequence: u64,
+        session_id: String,
+        agent_id: String,
+        content: String,
+    },
+    AssistantToolCall {
+        record_id: String,
+        sequence: u64,
+        session_id: String,
+        agent_id: String,
+        call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
+    ToolResult {
+        record_id: String,
+        sequence: u64,
+        session_id: String,
+        agent_id: String,
+        call_id: String,
+        tool_name: String,
+        content: String,
+        is_error: bool,
+    },
+    AssistantMessage {
+        record_id: String,
+        sequence: u64,
+        session_id: String,
+        agent_id: String,
+        content: String,
+    },
+}
+
+impl StoredTurnRecord {
+    pub fn record_id(&self) -> &str {
+        match self {
+            Self::UserMessage { record_id, .. }
+            | Self::AssistantToolCall { record_id, .. }
+            | Self::ToolResult { record_id, .. }
+            | Self::AssistantMessage { record_id, .. } => record_id,
+        }
+    }
+
+    pub fn sequence(&self) -> u64 {
+        match self {
+            Self::UserMessage { sequence, .. }
+            | Self::AssistantToolCall { sequence, .. }
+            | Self::ToolResult { sequence, .. }
+            | Self::AssistantMessage { sequence, .. } => *sequence,
+        }
+    }
+
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::UserMessage { session_id, .. }
+            | Self::AssistantToolCall { session_id, .. }
+            | Self::ToolResult { session_id, .. }
+            | Self::AssistantMessage { session_id, .. } => session_id,
+        }
+    }
+
+    pub fn agent_id(&self) -> &str {
+        match self {
+            Self::UserMessage { agent_id, .. }
+            | Self::AssistantToolCall { agent_id, .. }
+            | Self::ToolResult { agent_id, .. }
+            | Self::AssistantMessage { agent_id, .. } => agent_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryTurnStore {
+    inner: Arc<Mutex<InMemoryTurnStoreInner>>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryTurnStoreInner {
+    records_by_session: HashMap<String, Vec<StoredTurnRecord>>,
+}
+
+#[async_trait]
+impl RuntimeStore for InMemoryTurnStore {
+    async fn append(&self, record: StoredTurnRecord) -> Result<(), RuntimeError> {
+        let session_id = record.session_id().to_string();
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| RuntimeError::Store("in-memory store lock poisoned".to_string()))?;
+        inner
+            .records_by_session
+            .entry(session_id)
+            .or_default()
+            .push(record);
+        Ok(())
+    }
+
+    async fn records(&self, session_id: &str) -> Result<Vec<StoredTurnRecord>, RuntimeError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| RuntimeError::Store("in-memory store lock poisoned".to_string()))?;
+        Ok(inner
+            .records_by_session
+            .get(session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
+
+pub struct AgentRuntime<P, S> {
+    provider: P,
+    store: S,
+    tools: HashMap<String, Arc<dyn ToolExecutor>>,
+    config: RuntimeConfig,
+}
+
+impl<P, S> AgentRuntime<P, S>
+where
+    P: AgentProvider,
+    S: RuntimeStore,
+{
+    pub fn new(provider: P, store: S, config: RuntimeConfig) -> Self {
+        Self {
+            provider,
+            store,
+            tools: HashMap::new(),
+            config,
+        }
+    }
+
+    pub fn with_tool(mut self, name: impl Into<String>, tool: impl ToolExecutor) -> Self {
+        self.tools.insert(name.into(), Arc::new(tool));
+        self
+    }
+
+    pub async fn run_turn(&self, input: TurnInput) -> Result<TurnOutput, RuntimeError> {
+        let mut sequence = self.next_sequence(&input.session_id).await?;
+        self.store
+            .append(StoredTurnRecord::UserMessage {
+                record_id: new_record_id(),
+                sequence,
+                session_id: input.session_id.clone(),
+                agent_id: input.agent_id.clone(),
+                content: input.user_message.clone(),
+            })
+            .await?;
+        sequence += 1;
+
+        let messages = vec![ContextMessage {
+            role: "user".to_string(),
+            content: input.user_message.clone(),
+        }];
+        let mut tool_results = Vec::new();
+
+        for _ in 0..self.config.max_tool_iterations {
+            let response = self
+                .provider
+                .complete(ProviderRequest {
+                    session_id: input.session_id.clone(),
+                    agent_id: input.agent_id.clone(),
+                    messages: messages.clone(),
+                    tool_results: tool_results.clone(),
+                })
+                .await?;
+
+            if let Some(final_text) = response.final_text {
+                self.store
+                    .append(StoredTurnRecord::AssistantMessage {
+                        record_id: new_record_id(),
+                        sequence,
+                        session_id: input.session_id.clone(),
+                        agent_id: input.agent_id.clone(),
+                        content: final_text.clone(),
+                    })
+                    .await?;
+
+                let event = RuntimeEvent::OutboundResponse {
+                    session_id: input.session_id.clone(),
+                    agent_id: input.agent_id.clone(),
+                    text: final_text.clone(),
+                };
+                return Ok(TurnOutput {
+                    session_id: input.session_id,
+                    agent_id: input.agent_id,
+                    final_text,
+                    events: vec![event],
+                    tool_results,
+                });
+            }
+
+            for call in response.tool_calls {
+                self.store
+                    .append(StoredTurnRecord::AssistantToolCall {
+                        record_id: new_record_id(),
+                        sequence,
+                        session_id: input.session_id.clone(),
+                        agent_id: input.agent_id.clone(),
+                        call_id: call.id.clone(),
+                        tool_name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                    })
+                    .await?;
+                sequence += 1;
+
+                let result = self.execute_tool(call).await;
+                self.store
+                    .append(StoredTurnRecord::ToolResult {
+                        record_id: new_record_id(),
+                        sequence,
+                        session_id: input.session_id.clone(),
+                        agent_id: input.agent_id.clone(),
+                        call_id: result.call_id.clone(),
+                        tool_name: result.tool_name.clone(),
+                        content: result.content.clone(),
+                        is_error: result.is_error,
+                    })
+                    .await?;
+                sequence += 1;
+                tool_results.push(result);
+            }
+        }
+
+        Err(RuntimeError::IterationLimit(
+            self.config.max_tool_iterations,
+        ))
+    }
+
+    async fn execute_tool(&self, call: ToolCall) -> ToolResult {
+        let call_id = call.id.clone();
+        let tool_name = call.name.clone();
+        let Some(tool) = self.tools.get(&call.name) else {
+            return ToolResult {
+                call_id,
+                tool_name: tool_name.clone(),
+                content: RuntimeError::ToolNotRegistered(tool_name).to_string(),
+                is_error: true,
+            };
+        };
+
+        match tool.execute(call).await {
+            Ok(result) => result,
+            Err(RuntimeError::Tool { message, .. }) => ToolResult {
+                call_id,
+                tool_name,
+                content: message,
+                is_error: true,
+            },
+            Err(error) => ToolResult {
+                call_id,
+                tool_name,
+                content: error.to_string(),
+                is_error: true,
+            },
+        }
+    }
+
+    async fn next_sequence(&self, session_id: &str) -> Result<u64, RuntimeError> {
+        Ok(self.store.records(session_id).await?.len() as u64 + 1)
+    }
+}
+
+fn new_record_id() -> String {
+    ulid::Ulid::new().to_string()
+}

--- a/crates/core/seidrum-agent-runtime/tests/runtime_spine.rs
+++ b/crates/core/seidrum-agent-runtime/tests/runtime_spine.rs
@@ -1,0 +1,226 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use seidrum_agent_runtime::{
+    AgentProvider, AgentRuntime, InMemoryTurnStore, ProviderRequest, ProviderResponse,
+    RuntimeConfig, RuntimeError, RuntimeEvent, RuntimeStore, StoredTurnRecord, ToolCall,
+    ToolExecutor, ToolResult, TurnInput,
+};
+use serde_json::json;
+
+#[derive(Clone)]
+struct ScriptedProvider {
+    responses: Arc<Mutex<VecDeque<ProviderResponse>>>,
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: impl IntoIterator<Item = ProviderResponse>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AgentProvider for ScriptedProvider {
+    async fn complete(&self, request: ProviderRequest) -> Result<ProviderResponse, RuntimeError> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .push(request);
+        self.responses
+            .lock()
+            .expect("responses lock poisoned")
+            .pop_front()
+            .ok_or_else(|| RuntimeError::Provider("no scripted response".to_string()))
+    }
+}
+
+#[derive(Clone)]
+struct EchoTool;
+
+#[async_trait]
+impl ToolExecutor for EchoTool {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError> {
+        let value = call
+            .arguments
+            .get("text")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        Ok(ToolResult {
+            call_id: call.id,
+            tool_name: call.name,
+            content: format!("echo: {value}"),
+            is_error: false,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct FailingTool;
+
+#[async_trait]
+impl ToolExecutor for FailingTool {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError> {
+        Err(RuntimeError::Tool {
+            tool_name: call.name,
+            message: "boom".to_string(),
+        })
+    }
+}
+
+fn input() -> TurnInput {
+    TurnInput {
+        session_id: "session-1".to_string(),
+        agent_id: "agent-1".to_string(),
+        user_message: "hello".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn run_turn_without_tools_persists_user_and_assistant_and_returns_outbound_event() {
+    let provider = ScriptedProvider::new([ProviderResponse::final_text("hi there")]);
+    let store = InMemoryTurnStore::default();
+    let runtime = AgentRuntime::new(provider, store.clone(), RuntimeConfig::default());
+
+    let output = runtime.run_turn(input()).await.expect("turn should run");
+
+    assert_eq!(output.session_id, "session-1");
+    assert_eq!(output.agent_id, "agent-1");
+    assert_eq!(output.final_text, "hi there");
+    assert_eq!(output.events.len(), 1);
+    assert_eq!(
+        output.events[0],
+        RuntimeEvent::OutboundResponse {
+            session_id: "session-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            text: "hi there".to_string(),
+        }
+    );
+
+    let records = store
+        .records("session-1")
+        .await
+        .expect("records should load");
+    assert_eq!(records.len(), 2);
+    assert!(matches!(records[0], StoredTurnRecord::UserMessage { .. }));
+    assert!(matches!(
+        records[1],
+        StoredTurnRecord::AssistantMessage { .. }
+    ));
+}
+
+#[tokio::test]
+async fn run_turn_executes_one_registered_tool_then_persists_final_response() {
+    let provider = ScriptedProvider::new([
+        ProviderResponse::tool_calls([ToolCall {
+            id: "call-1".to_string(),
+            name: "echo".to_string(),
+            arguments: json!({ "text": "ping" }),
+        }]),
+        ProviderResponse::final_text("tool says echo: ping"),
+    ]);
+    let store = InMemoryTurnStore::default();
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default())
+        .with_tool("echo", EchoTool);
+
+    let output = runtime.run_turn(input()).await.expect("turn should run");
+
+    assert_eq!(output.final_text, "tool says echo: ping");
+    assert_eq!(output.tool_results.len(), 1);
+    assert_eq!(output.tool_results[0].content, "echo: ping");
+    assert!(!output.tool_results[0].is_error);
+
+    let requests = provider.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[1].tool_results.len(), 1);
+    assert_eq!(requests[1].tool_results[0].content, "echo: ping");
+
+    let records = store
+        .records("session-1")
+        .await
+        .expect("records should load");
+    assert!(records.iter().any(|record| matches!(
+        record,
+        StoredTurnRecord::AssistantToolCall { tool_name, .. } if tool_name == "echo"
+    )));
+    assert!(records.iter().any(|record| matches!(
+        record,
+        StoredTurnRecord::ToolResult { tool_name, content, is_error, .. }
+            if tool_name == "echo" && content == "echo: ping" && !is_error
+    )));
+    assert!(matches!(
+        records.last(),
+        Some(StoredTurnRecord::AssistantMessage { .. })
+    ));
+}
+
+#[tokio::test]
+async fn run_turn_records_tool_error_and_continues_provider_loop() {
+    let provider = ScriptedProvider::new([
+        ProviderResponse::tool_calls([ToolCall {
+            id: "call-1".to_string(),
+            name: "fail".to_string(),
+            arguments: json!({}),
+        }]),
+        ProviderResponse::final_text("I could not run the tool"),
+    ]);
+    let store = InMemoryTurnStore::default();
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default())
+        .with_tool("fail", FailingTool);
+
+    let output = runtime
+        .run_turn(input())
+        .await
+        .expect("turn should recover");
+
+    assert_eq!(output.final_text, "I could not run the tool");
+    assert_eq!(output.tool_results.len(), 1);
+    assert!(output.tool_results[0].is_error);
+    assert_eq!(output.tool_results[0].content, "boom");
+
+    let requests = provider.requests();
+    assert_eq!(requests.len(), 2);
+    assert!(requests[1].tool_results[0].is_error);
+
+    let records = store
+        .records("session-1")
+        .await
+        .expect("records should load");
+    assert!(records.iter().any(|record| matches!(
+        record,
+        StoredTurnRecord::ToolResult { tool_name, content, is_error, .. }
+            if tool_name == "fail" && content == "boom" && *is_error
+    )));
+}
+
+#[tokio::test]
+async fn persisted_trace_records_include_session_agent_and_ordered_record_ids() {
+    let provider = ScriptedProvider::new([ProviderResponse::final_text("done")]);
+    let store = InMemoryTurnStore::default();
+    let runtime = AgentRuntime::new(provider, store.clone(), RuntimeConfig::default());
+
+    runtime.run_turn(input()).await.expect("turn should run");
+
+    let records = store
+        .records("session-1")
+        .await
+        .expect("records should load");
+    assert_eq!(records.len(), 2);
+    for (index, record) in records.iter().enumerate() {
+        assert_eq!(record.session_id(), "session-1");
+        assert_eq!(record.agent_id(), "agent-1");
+        assert_eq!(record.sequence(), index as u64 + 1);
+        assert!(!record.record_id().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add new core crate `seidrum-agent-runtime` and wire it into the workspace.
- Introduce a minimal provider-neutral `AgentRuntime` with mockable provider, tool executor, and turn store traits.
- Add in-memory append-only turn store records for user messages, assistant messages, assistant tool calls, and tool results.
- Return deterministic `TurnOutput` with outbound response event conversion.

## TDD evidence
RED captured before implementation:
`cargo test -p seidrum-agent-runtime --test runtime_spine` failed with unresolved imports for the wished-for runtime API.

## Test Plan
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test -p seidrum-agent-runtime`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Notes
- Scope intentionally stays on the runtime spine with mock provider/tool/store abstractions; no real provider, Telegram, or durable database integration yet.