### PR TITLE
feat(agent-runtime): add durable turn store replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,9 +3494,11 @@ name = "seidrum-agent-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "redb",
  "seidrum-common",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "ulid",

--- a/crates/core/seidrum-agent-runtime/Cargo.toml
+++ b/crates/core/seidrum-agent-runtime/Cargo.toml
@@ -9,8 +9,10 @@ async-trait = "0.1"
 seidrum-common = { path = "../seidrum-common" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+redb = "2"
 thiserror = "2"
 ulid = "1"
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/core/seidrum-agent-runtime/src/lib.rs
+++ b/crates/core/seidrum-agent-runtime/src/lib.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use redb::{Database, ReadableTable};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -235,6 +237,174 @@ impl RuntimeStore for InMemoryTurnStore {
             .get(session_id)
             .cloned()
             .unwrap_or_default())
+    }
+}
+
+const RUNTIME_RECORDS_TABLE: redb::TableDefinition<u64, &[u8]> =
+    redb::TableDefinition::new("runtime_records");
+
+#[derive(Debug, Clone)]
+pub struct RedbTurnStore {
+    db: Arc<Database>,
+}
+
+impl RedbTurnStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, RuntimeError> {
+        let path = path.as_ref();
+        let db = Database::create(path)
+            .map_err(|error| RuntimeError::Store(format!("failed to open redb store: {error}")))?;
+
+        let write_txn = db.begin_write().map_err(|error| {
+            RuntimeError::Store(format!("failed to begin redb initialization: {error}"))
+        })?;
+        {
+            write_txn
+                .open_table(RUNTIME_RECORDS_TABLE)
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to open runtime records table: {error}"))
+                })?;
+        }
+        write_txn.commit().map_err(|error| {
+            RuntimeError::Store(format!("failed to commit redb initialization: {error}"))
+        })?;
+
+        Ok(Self { db: Arc::new(db) })
+    }
+}
+
+#[async_trait]
+impl RuntimeStore for RedbTurnStore {
+    async fn append(&self, record: StoredTurnRecord) -> Result<(), RuntimeError> {
+        let serialized = serde_json::to_vec(&record).map_err(|error| {
+            RuntimeError::Store(format!("failed to serialize turn record: {error}"))
+        })?;
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb write: {error}")))?;
+        {
+            let mut records_table =
+                write_txn
+                    .open_table(RUNTIME_RECORDS_TABLE)
+                    .map_err(|error| {
+                        RuntimeError::Store(format!(
+                            "failed to open runtime records table: {error}"
+                        ))
+                    })?;
+            let store_sequence = records_table
+                .last()
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to read last record: {error}"))
+                })?
+                .map(|(key, _)| key.value())
+                .unwrap_or(0)
+                + 1;
+            records_table
+                .insert(store_sequence, serialized.as_slice())
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to insert record: {error}"))
+                })?;
+        }
+        write_txn
+            .commit()
+            .map_err(|error| RuntimeError::Store(format!("failed to commit record: {error}")))?;
+        Ok(())
+    }
+
+    async fn records(&self, session_id: &str) -> Result<Vec<StoredTurnRecord>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let records_table = read_txn
+            .open_table(RUNTIME_RECORDS_TABLE)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to open runtime records table: {error}"))
+            })?;
+        let mut records = Vec::new();
+
+        for entry in records_table.iter().map_err(|error| {
+            RuntimeError::Store(format!("failed to iterate runtime records: {error}"))
+        })? {
+            let (_, data) = entry
+                .map_err(|error| RuntimeError::Store(format!("failed to read record: {error}")))?;
+            let record: StoredTurnRecord =
+                serde_json::from_slice(data.value()).map_err(|error| {
+                    RuntimeError::Store(format!("failed to deserialize turn record: {error}"))
+                })?;
+            if record.session_id() == session_id {
+                records.push(record);
+            }
+        }
+
+        records.sort_by_key(|record| record.sequence());
+        Ok(records)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeTrace {
+    pub session_id: String,
+    pub agent_id: String,
+    pub records: Vec<StoredTurnRecord>,
+    pub outbound_events: Vec<RuntimeEvent>,
+}
+
+pub async fn replay_session_trace<S>(
+    store: &S,
+    session_id: &str,
+) -> Result<RuntimeTrace, RuntimeError>
+where
+    S: RuntimeStore,
+{
+    let records = store.records(session_id).await?;
+    let agent_id = records
+        .first()
+        .map(|record| record.agent_id().to_string())
+        .unwrap_or_default();
+    Ok(build_trace(session_id, agent_id, records))
+}
+
+pub async fn replay_agent_session_trace<S>(
+    store: &S,
+    session_id: &str,
+    agent_id: &str,
+) -> Result<RuntimeTrace, RuntimeError>
+where
+    S: RuntimeStore,
+{
+    let records = store
+        .records(session_id)
+        .await?
+        .into_iter()
+        .filter(|record| record.agent_id() == agent_id)
+        .collect();
+    Ok(build_trace(session_id, agent_id.to_string(), records))
+}
+
+fn build_trace(session_id: &str, agent_id: String, records: Vec<StoredTurnRecord>) -> RuntimeTrace {
+    let outbound_events = records
+        .iter()
+        .filter_map(|record| match record {
+            StoredTurnRecord::AssistantMessage {
+                session_id,
+                agent_id,
+                content,
+                ..
+            } => Some(RuntimeEvent::OutboundResponse {
+                session_id: session_id.clone(),
+                agent_id: agent_id.clone(),
+                text: content.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+
+    RuntimeTrace {
+        session_id: session_id.to_string(),
+        agent_id,
+        records,
+        outbound_events,
     }
 }
 

--- a/crates/core/seidrum-agent-runtime/tests/durable_store.rs
+++ b/crates/core/seidrum-agent-runtime/tests/durable_store.rs
@@ -1,0 +1,224 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use seidrum_agent_runtime::{
+    replay_agent_session_trace, replay_session_trace, AgentProvider, AgentRuntime, ProviderRequest,
+    ProviderResponse, RedbTurnStore, RuntimeConfig, RuntimeError, RuntimeEvent, RuntimeStore,
+    StoredTurnRecord, ToolCall, ToolExecutor, ToolResult, TurnInput,
+};
+use serde_json::json;
+
+#[derive(Clone)]
+struct ScriptedProvider {
+    responses: Arc<Mutex<VecDeque<ProviderResponse>>>,
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: impl IntoIterator<Item = ProviderResponse>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AgentProvider for ScriptedProvider {
+    async fn complete(&self, request: ProviderRequest) -> Result<ProviderResponse, RuntimeError> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .push(request);
+        self.responses
+            .lock()
+            .expect("responses lock poisoned")
+            .pop_front()
+            .ok_or_else(|| RuntimeError::Provider("no scripted response".to_string()))
+    }
+}
+
+#[derive(Clone)]
+struct PanicProvider;
+
+#[async_trait]
+impl AgentProvider for PanicProvider {
+    async fn complete(&self, _request: ProviderRequest) -> Result<ProviderResponse, RuntimeError> {
+        panic!("replay must not call provider boundaries")
+    }
+}
+
+#[derive(Clone)]
+struct EchoTool;
+
+#[async_trait]
+impl ToolExecutor for EchoTool {
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError> {
+        let value = call
+            .arguments
+            .get("text")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        Ok(ToolResult {
+            call_id: call.id,
+            tool_name: call.name,
+            content: format!("echo: {value}"),
+            is_error: false,
+        })
+    }
+}
+
+fn input(session_id: &str, agent_id: &str, user_message: &str) -> TurnInput {
+    TurnInput {
+        session_id: session_id.to_string(),
+        agent_id: agent_id.to_string(),
+        user_message: user_message.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn durable_store_persists_records_across_reopen() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .append(StoredTurnRecord::UserMessage {
+            record_id: "record-1".to_string(),
+            sequence: 1,
+            session_id: "session-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            content: "hello".to_string(),
+        })
+        .await
+        .expect("append should persist");
+    drop(store);
+
+    let reopened = RedbTurnStore::open(&path).expect("store should reopen");
+    let records = reopened
+        .records("session-1")
+        .await
+        .expect("records should load after reopen");
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].record_id(), "record-1");
+    assert_eq!(records[0].sequence(), 1);
+}
+
+#[tokio::test]
+async fn run_turn_with_durable_store_can_be_replayed_without_provider_or_tool() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    let provider = ScriptedProvider::new([
+        ProviderResponse::tool_calls([ToolCall {
+            id: "call-1".to_string(),
+            name: "echo".to_string(),
+            arguments: json!({ "text": "ping" }),
+        }]),
+        ProviderResponse::final_text("tool says echo: ping"),
+    ]);
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default())
+        .with_tool("echo", EchoTool);
+
+    runtime
+        .run_turn(input("session-1", "agent-1", "hello"))
+        .await
+        .expect("turn should run");
+    assert_eq!(provider.requests().len(), 2);
+    drop(runtime);
+    drop(store);
+
+    let replay_store = RedbTurnStore::open(&path).expect("store should reopen");
+    let _unused_runtime = AgentRuntime::new(
+        PanicProvider,
+        replay_store.clone(),
+        RuntimeConfig::default(),
+    );
+    let trace = replay_agent_session_trace(&replay_store, "session-1", "agent-1")
+        .await
+        .expect("trace should replay");
+
+    assert_eq!(trace.session_id, "session-1");
+    assert_eq!(trace.agent_id, "agent-1");
+    assert_eq!(trace.records.len(), 4);
+    assert!(matches!(
+        trace.records[0],
+        StoredTurnRecord::UserMessage { .. }
+    ));
+    assert!(matches!(
+        trace.records[1],
+        StoredTurnRecord::AssistantToolCall { .. }
+    ));
+    assert!(matches!(
+        trace.records[2],
+        StoredTurnRecord::ToolResult { .. }
+    ));
+    assert!(matches!(
+        trace.records[3],
+        StoredTurnRecord::AssistantMessage { .. }
+    ));
+    assert_eq!(
+        trace.outbound_events,
+        vec![RuntimeEvent::OutboundResponse {
+            session_id: "session-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            text: "tool says echo: ping".to_string(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn replay_filters_by_session_and_preserves_order() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+
+    for (session_id, sequence, content) in [
+        ("session-1", 2, "second"),
+        ("session-2", 1, "other"),
+        ("session-1", 1, "first"),
+    ] {
+        store
+            .append(StoredTurnRecord::UserMessage {
+                record_id: format!("{session_id}-{sequence}"),
+                sequence,
+                session_id: session_id.to_string(),
+                agent_id: "agent-1".to_string(),
+                content: content.to_string(),
+            })
+            .await
+            .expect("append should persist");
+    }
+
+    let trace = replay_session_trace(&store, "session-1")
+        .await
+        .expect("trace should replay");
+
+    assert_eq!(trace.records.len(), 2);
+    assert_eq!(trace.records[0].sequence(), 1);
+    assert_eq!(trace.records[1].sequence(), 2);
+    assert!(trace
+        .records
+        .iter()
+        .all(|record| record.session_id() == "session-1"));
+}
+
+#[tokio::test]
+async fn durable_store_reports_corrupt_or_unreadable_data_as_store_error() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    std::fs::write(&path, b"not a redb database").expect("write corrupt data");
+
+    let error = RedbTurnStore::open(&path).expect_err("corrupt data should not open");
+
+    assert!(matches!(error, RuntimeError::Store(message) if message.contains("redb")));
+}


### PR DESCRIPTION
## Summary
- add redb-backed RuntimeStore implementation for durable turn records
- add replay/read helpers for session and agent-session traces with deterministic outbound events
- cover persistence across reopen, replay without provider/tool calls, session filtering/order, and corrupt redb open errors

## Test plan
- RED captured before implementation: cargo test -p seidrum-agent-runtime durable_store --test durable_store failed on missing RedbTurnStore/replay APIs and tempfile dev dependency
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p seidrum-agent-runtime
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

## Scope notes
- uses redb because seidrum-eventbus already uses it cleanly; no external DB/services or real provider credentials
- no cron/job scheduler implemented; M2C can build on this durable trace/store seam