### PR TITLE
feat(agent-runtime): add durable job runs

### DIFF
--- a/crates/core/seidrum-agent-runtime/src/lib.rs
+++ b/crates/core/seidrum-agent-runtime/src/lib.rs
@@ -201,6 +201,60 @@ impl StoredTurnRecord {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JobDefinition {
+    pub job_id: String,
+    pub agent_id: String,
+    /// Explicit continuation session for the job. When omitted, force-run
+    /// creates a durable per-run session id.
+    pub session_id: Option<String>,
+    pub prompt: String,
+    /// Opaque schedule text for future daemon scheduling. M2C only stores it
+    /// and supports manual force-run.
+    pub schedule_spec: Option<String>,
+    pub enabled: bool,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JobRunStatus {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JobRunRecord {
+    pub run_id: String,
+    pub job_id: String,
+    pub session_id: String,
+    pub status: JobRunStatus,
+    pub started_sequence: u64,
+    pub completed_sequence: Option<u64>,
+    pub output_summary: Option<String>,
+    pub final_text: Option<String>,
+    pub error: Option<String>,
+    pub trace_session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JobRunReplay {
+    pub run: JobRunRecord,
+    pub trace: RuntimeTrace,
+}
+
+#[async_trait]
+pub trait DurableJobStore: RuntimeStore {
+    async fn put_job_definition(&self, definition: JobDefinition) -> Result<(), RuntimeError>;
+    async fn job_definition(&self, job_id: &str) -> Result<Option<JobDefinition>, RuntimeError>;
+    async fn list_job_definitions(&self) -> Result<Vec<JobDefinition>, RuntimeError>;
+    async fn put_job_run(&self, run: JobRunRecord) -> Result<(), RuntimeError>;
+    async fn job_run(&self, run_id: &str) -> Result<Option<JobRunRecord>, RuntimeError>;
+    async fn list_job_runs(&self, job_id: &str) -> Result<Vec<JobRunRecord>, RuntimeError>;
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryTurnStore {
     inner: Arc<Mutex<InMemoryTurnStoreInner>>,
@@ -242,6 +296,9 @@ impl RuntimeStore for InMemoryTurnStore {
 
 const RUNTIME_RECORDS_TABLE: redb::TableDefinition<u64, &[u8]> =
     redb::TableDefinition::new("runtime_records");
+const JOB_DEFINITIONS_TABLE: redb::TableDefinition<&str, &[u8]> =
+    redb::TableDefinition::new("job_definitions");
+const JOB_RUNS_TABLE: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new("job_runs");
 
 #[derive(Debug, Clone)]
 pub struct RedbTurnStore {
@@ -263,6 +320,14 @@ impl RedbTurnStore {
                 .map_err(|error| {
                     RuntimeError::Store(format!("failed to open runtime records table: {error}"))
                 })?;
+            write_txn
+                .open_table(JOB_DEFINITIONS_TABLE)
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to open job definitions table: {error}"))
+                })?;
+            write_txn.open_table(JOB_RUNS_TABLE).map_err(|error| {
+                RuntimeError::Store(format!("failed to open job runs table: {error}"))
+            })?;
         }
         write_txn.commit().map_err(|error| {
             RuntimeError::Store(format!("failed to commit redb initialization: {error}"))
@@ -339,6 +404,152 @@ impl RuntimeStore for RedbTurnStore {
 
         records.sort_by_key(|record| record.sequence());
         Ok(records)
+    }
+}
+
+#[async_trait]
+impl DurableJobStore for RedbTurnStore {
+    async fn put_job_definition(&self, definition: JobDefinition) -> Result<(), RuntimeError> {
+        let serialized = serde_json::to_vec(&definition).map_err(|error| {
+            RuntimeError::Store(format!("failed to serialize job definition: {error}"))
+        })?;
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb write: {error}")))?;
+        {
+            let mut table = write_txn
+                .open_table(JOB_DEFINITIONS_TABLE)
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to open job definitions table: {error}"))
+                })?;
+            table
+                .insert(definition.job_id.as_str(), serialized.as_slice())
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to insert job definition: {error}"))
+                })?;
+        }
+        write_txn.commit().map_err(|error| {
+            RuntimeError::Store(format!("failed to commit job definition: {error}"))
+        })?;
+        Ok(())
+    }
+
+    async fn job_definition(&self, job_id: &str) -> Result<Option<JobDefinition>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn
+            .open_table(JOB_DEFINITIONS_TABLE)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to open job definitions table: {error}"))
+            })?;
+        table
+            .get(job_id)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to read job definition: {error}"))
+            })?
+            .map(|data| {
+                serde_json::from_slice(data.value()).map_err(|error| {
+                    RuntimeError::Store(format!("failed to deserialize job definition: {error}"))
+                })
+            })
+            .transpose()
+    }
+
+    async fn list_job_definitions(&self) -> Result<Vec<JobDefinition>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn
+            .open_table(JOB_DEFINITIONS_TABLE)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to open job definitions table: {error}"))
+            })?;
+        let mut definitions = Vec::new();
+        for entry in table.iter().map_err(|error| {
+            RuntimeError::Store(format!("failed to iterate job definitions: {error}"))
+        })? {
+            let (_, data) = entry.map_err(|error| {
+                RuntimeError::Store(format!("failed to read job definition: {error}"))
+            })?;
+            definitions.push(serde_json::from_slice(data.value()).map_err(|error| {
+                RuntimeError::Store(format!("failed to deserialize job definition: {error}"))
+            })?);
+        }
+        definitions.sort_by(|left: &JobDefinition, right| left.job_id.cmp(&right.job_id));
+        Ok(definitions)
+    }
+
+    async fn put_job_run(&self, run: JobRunRecord) -> Result<(), RuntimeError> {
+        let serialized = serde_json::to_vec(&run).map_err(|error| {
+            RuntimeError::Store(format!("failed to serialize job run: {error}"))
+        })?;
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb write: {error}")))?;
+        {
+            let mut table = write_txn.open_table(JOB_RUNS_TABLE).map_err(|error| {
+                RuntimeError::Store(format!("failed to open job runs table: {error}"))
+            })?;
+            table
+                .insert(run.run_id.as_str(), serialized.as_slice())
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to insert job run: {error}"))
+                })?;
+        }
+        write_txn
+            .commit()
+            .map_err(|error| RuntimeError::Store(format!("failed to commit job run: {error}")))?;
+        Ok(())
+    }
+
+    async fn job_run(&self, run_id: &str) -> Result<Option<JobRunRecord>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn.open_table(JOB_RUNS_TABLE).map_err(|error| {
+            RuntimeError::Store(format!("failed to open job runs table: {error}"))
+        })?;
+        table
+            .get(run_id)
+            .map_err(|error| RuntimeError::Store(format!("failed to read job run: {error}")))?
+            .map(|data| {
+                serde_json::from_slice(data.value()).map_err(|error| {
+                    RuntimeError::Store(format!("failed to deserialize job run: {error}"))
+                })
+            })
+            .transpose()
+    }
+
+    async fn list_job_runs(&self, job_id: &str) -> Result<Vec<JobRunRecord>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn.open_table(JOB_RUNS_TABLE).map_err(|error| {
+            RuntimeError::Store(format!("failed to open job runs table: {error}"))
+        })?;
+        let mut runs = Vec::new();
+        for entry in table
+            .iter()
+            .map_err(|error| RuntimeError::Store(format!("failed to iterate job runs: {error}")))?
+        {
+            let (_, data) = entry
+                .map_err(|error| RuntimeError::Store(format!("failed to read job run: {error}")))?;
+            let run: JobRunRecord = serde_json::from_slice(data.value()).map_err(|error| {
+                RuntimeError::Store(format!("failed to deserialize job run: {error}"))
+            })?;
+            if run.job_id == job_id {
+                runs.push(run);
+            }
+        }
+        runs.sort_by_key(|run| run.started_sequence);
+        Ok(runs)
     }
 }
 
@@ -558,6 +769,96 @@ where
     async fn next_sequence(&self, session_id: &str) -> Result<u64, RuntimeError> {
         Ok(self.store.records(session_id).await?.len() as u64 + 1)
     }
+}
+
+pub struct ForceRunJobExecutor<P, S> {
+    runtime: AgentRuntime<P, S>,
+    store: S,
+}
+
+impl<P, S> ForceRunJobExecutor<P, S>
+where
+    P: AgentProvider,
+    S: DurableJobStore,
+{
+    pub fn new(runtime: AgentRuntime<P, S>, store: S) -> Self {
+        Self { runtime, store }
+    }
+
+    pub async fn force_run_job(&self, job_id: &str) -> Result<JobRunRecord, RuntimeError> {
+        let definition = self
+            .store
+            .job_definition(job_id)
+            .await?
+            .ok_or_else(|| RuntimeError::Store(format!("job `{job_id}` is not defined")))?;
+
+        if !definition.enabled {
+            return Err(RuntimeError::Store(format!("job `{job_id}` is disabled")));
+        }
+
+        let run_id = new_record_id();
+        let session_id = definition
+            .session_id
+            .clone()
+            .unwrap_or_else(|| format!("job:{}:run:{}", definition.job_id, run_id));
+        let started_sequence = self.store.records(&session_id).await?.len() as u64 + 1;
+        let mut run = JobRunRecord {
+            run_id,
+            job_id: definition.job_id.clone(),
+            session_id: session_id.clone(),
+            status: JobRunStatus::Queued,
+            started_sequence,
+            completed_sequence: None,
+            output_summary: None,
+            final_text: None,
+            error: None,
+            trace_session_id: session_id.clone(),
+        };
+        self.store.put_job_run(run.clone()).await?;
+
+        run.status = JobRunStatus::Running;
+        self.store.put_job_run(run.clone()).await?;
+
+        let result = self
+            .runtime
+            .run_turn(TurnInput {
+                session_id: session_id.clone(),
+                agent_id: definition.agent_id,
+                user_message: definition.prompt,
+            })
+            .await;
+
+        run.completed_sequence = Some(self.store.records(&session_id).await?.len() as u64);
+        match result {
+            Ok(output) => {
+                run.status = JobRunStatus::Succeeded;
+                run.output_summary = Some(output.final_text.clone());
+                run.final_text = Some(output.final_text);
+                run.error = None;
+            }
+            Err(error) => {
+                run.status = JobRunStatus::Failed;
+                run.output_summary = None;
+                run.final_text = None;
+                run.error = Some(error.to_string());
+            }
+        }
+        self.store.put_job_run(run.clone()).await?;
+
+        Ok(run)
+    }
+}
+
+pub async fn replay_job_run<S>(store: &S, run_id: &str) -> Result<JobRunReplay, RuntimeError>
+where
+    S: DurableJobStore,
+{
+    let run = store
+        .job_run(run_id)
+        .await?
+        .ok_or_else(|| RuntimeError::Store(format!("job run `{run_id}` is not defined")))?;
+    let trace = replay_session_trace(store, &run.trace_session_id).await?;
+    Ok(JobRunReplay { run, trace })
 }
 
 fn new_record_id() -> String {

--- a/crates/core/seidrum-agent-runtime/tests/durable_jobs.rs
+++ b/crates/core/seidrum-agent-runtime/tests/durable_jobs.rs
@@ -1,0 +1,215 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use seidrum_agent_runtime::{
+    replay_job_run, AgentProvider, AgentRuntime, DurableJobStore, ForceRunJobExecutor,
+    JobDefinition, JobRunStatus, ProviderRequest, ProviderResponse, RedbTurnStore, RuntimeConfig,
+    RuntimeError,
+};
+use serde_json::json;
+
+#[derive(Clone)]
+struct ScriptedProvider {
+    responses: Arc<Mutex<VecDeque<Result<ProviderResponse, RuntimeError>>>>,
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: impl IntoIterator<Item = Result<ProviderResponse, RuntimeError>>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AgentProvider for ScriptedProvider {
+    async fn complete(&self, request: ProviderRequest) -> Result<ProviderResponse, RuntimeError> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .push(request);
+        self.responses
+            .lock()
+            .expect("responses lock poisoned")
+            .pop_front()
+            .expect("scripted response should exist")
+    }
+}
+
+fn job_definition(job_id: &str) -> JobDefinition {
+    JobDefinition {
+        job_id: job_id.to_string(),
+        agent_id: "agent-1".to_string(),
+        session_id: Some("session-job-1".to_string()),
+        prompt: "run the durable job".to_string(),
+        schedule_spec: Some("once:manual".to_string()),
+        enabled: true,
+        metadata: json!({ "source": "test" }),
+    }
+}
+
+#[tokio::test]
+async fn durable_jobs_persist_definitions_across_reopen() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_job_definition(job_definition("job-1"))
+        .await
+        .expect("job definition should persist");
+    drop(store);
+
+    let reopened = RedbTurnStore::open(&path).expect("store should reopen");
+    let loaded = reopened
+        .job_definition("job-1")
+        .await
+        .expect("definition lookup should succeed")
+        .expect("definition should exist after reopen");
+    let listed = reopened
+        .list_job_definitions()
+        .await
+        .expect("definitions should list");
+
+    assert_eq!(loaded.job_id, "job-1");
+    assert_eq!(loaded.agent_id, "agent-1");
+    assert_eq!(loaded.session_id.as_deref(), Some("session-job-1"));
+    assert_eq!(loaded.schedule_spec.as_deref(), Some("once:manual"));
+    assert!(loaded.enabled);
+    assert_eq!(loaded.metadata, json!({ "source": "test" }));
+    assert_eq!(listed, vec![loaded]);
+}
+
+#[tokio::test]
+async fn force_run_job_persists_succeeded_run_and_trace() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_job_definition(job_definition("job-1"))
+        .await
+        .expect("job definition should persist");
+    let provider = ScriptedProvider::new([Ok(ProviderResponse::final_text("job finished"))]);
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default());
+    let executor = ForceRunJobExecutor::new(runtime, store.clone());
+
+    let run = executor
+        .force_run_job("job-1")
+        .await
+        .expect("job should force-run");
+
+    assert_eq!(run.job_id, "job-1");
+    assert_eq!(run.status, JobRunStatus::Succeeded);
+    assert_eq!(run.session_id, "session-job-1");
+    assert_eq!(run.final_text.as_deref(), Some("job finished"));
+    assert_eq!(run.output_summary.as_deref(), Some("job finished"));
+    assert_eq!(run.error, None);
+    assert_eq!(run.trace_session_id, "session-job-1");
+    assert!(run.started_sequence > 0);
+    assert!(run.completed_sequence.unwrap() >= run.started_sequence);
+
+    let persisted = store
+        .job_run(&run.run_id)
+        .await
+        .expect("run lookup should succeed")
+        .expect("run should persist");
+    assert_eq!(persisted, run);
+    let job_runs = store
+        .list_job_runs("job-1")
+        .await
+        .expect("job runs should list");
+    assert_eq!(job_runs, vec![run.clone()]);
+    assert_eq!(provider.requests().len(), 1);
+
+    let trace = seidrum_agent_runtime::replay_session_trace(&store, "session-job-1")
+        .await
+        .expect("trace should replay");
+    assert_eq!(trace.records.len(), 2);
+}
+
+#[tokio::test]
+async fn force_run_job_records_provider_failure_as_failed_run() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_job_definition(job_definition("job-1"))
+        .await
+        .expect("job definition should persist");
+    let provider =
+        ScriptedProvider::new([Err(RuntimeError::Provider("provider down".to_string()))]);
+    let runtime = AgentRuntime::new(provider, store.clone(), RuntimeConfig::default());
+    let executor = ForceRunJobExecutor::new(runtime, store.clone());
+
+    let run = executor
+        .force_run_job("job-1")
+        .await
+        .expect("provider failure should be recorded, not dropped");
+
+    assert_eq!(run.status, JobRunStatus::Failed);
+    assert_eq!(run.final_text, None);
+    assert_eq!(run.error.as_deref(), Some("provider error: provider down"));
+    assert_eq!(run.trace_session_id, "session-job-1");
+
+    let persisted = store
+        .job_run(&run.run_id)
+        .await
+        .expect("run lookup should succeed")
+        .expect("failed run should persist");
+    assert_eq!(persisted.status, JobRunStatus::Failed);
+    assert_eq!(
+        persisted.error.as_deref(),
+        Some("provider error: provider down")
+    );
+
+    let trace = seidrum_agent_runtime::replay_session_trace(&store, "session-job-1")
+        .await
+        .expect("partial failure trace should replay");
+    assert_eq!(trace.records.len(), 1);
+}
+
+#[tokio::test]
+async fn job_run_replay_loads_trace_without_provider_or_tool() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_job_definition(job_definition("job-1"))
+        .await
+        .expect("job definition should persist");
+    let provider = ScriptedProvider::new([Ok(ProviderResponse::final_text("job finished"))]);
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default());
+    let executor = ForceRunJobExecutor::new(runtime, store.clone());
+    let run = executor
+        .force_run_job("job-1")
+        .await
+        .expect("job should force-run");
+    assert_eq!(provider.requests().len(), 1);
+    drop(executor);
+    drop(store);
+
+    let replay_store = RedbTurnStore::open(&path).expect("store should reopen");
+    let replay = replay_job_run(&replay_store, &run.run_id)
+        .await
+        .expect("job run should replay");
+
+    assert_eq!(replay.run.run_id, run.run_id);
+    assert_eq!(replay.run.status, JobRunStatus::Succeeded);
+    assert_eq!(replay.trace.session_id, "session-job-1");
+    assert_eq!(replay.trace.records.len(), 2);
+    assert_eq!(
+        provider.requests().len(),
+        1,
+        "replay must not call provider"
+    );
+}


### PR DESCRIPTION
## Summary
- add durable job definition and job run records on the runtime store seam
- persist job definitions/runs in redb alongside runtime traces
- add force-run executor and replay API that links job runs to session traces without provider/tool calls

## Test plan
- RED captured: cargo test -p seidrum-agent-runtime --test durable_jobs -- --nocapture failed on missing durable job APIs before implementation
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p seidrum-agent-runtime
- cargo test --workspace (initial transient eventbus SSRF test failure; targeted rerun passed; full rerun passed)
- cargo clippy --workspace --all-targets -- -D warnings

## Out of scope
- real cron parsing/daemon loop
- Telegram/external delivery
- external provider/tool/network calls