### PR TITLE
feat(agent-runtime): add secure channel continuation

### DIFF
--- a/crates/core/seidrum-agent-runtime/src/lib.rs
+++ b/crates/core/seidrum-agent-runtime/src/lib.rs
@@ -46,6 +46,48 @@ pub enum RuntimeEvent {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChannelKind {
+    Telegram,
+    Other(String),
+}
+
+impl ChannelKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Telegram => "telegram",
+            Self::Other(kind) => kind.as_str(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelContinuationIdentity {
+    pub provider: ChannelKind,
+    pub chat_id: String,
+    pub thread_id: Option<String>,
+    pub user_id: Option<String>,
+    pub message_id: Option<String>,
+    pub correlation_id: Option<String>,
+}
+
+impl ChannelContinuationIdentity {
+    pub fn session_id(&self) -> String {
+        let base = format!("channel:{}:chat:{}", self.provider.as_str(), self.chat_id);
+        match &self.thread_id {
+            Some(thread_id) if !thread_id.is_empty() => format!("{base}:thread:{thread_id}"),
+            _ => base,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelTurnInput {
+    pub origin: ChannelContinuationIdentity,
+    pub agent_id: String,
+    pub user_message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
     pub id: String,
@@ -118,6 +160,88 @@ pub trait AgentProvider: Send + Sync + Clone + 'static {
 #[async_trait]
 pub trait ToolExecutor: Send + Sync + 'static {
     async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolPermissionDecision {
+    Allow,
+    Deny { reason: String },
+    RequireApproval { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolAuthorizationRequest {
+    pub call_id: String,
+    pub tool_name: String,
+    pub arguments: serde_json::Value,
+    pub session_id: Option<String>,
+    pub channel_origin: Option<ChannelContinuationIdentity>,
+}
+
+#[async_trait]
+pub trait ToolAuthorizationBoundary: Send + Sync + 'static {
+    async fn authorize(&self, request: ToolAuthorizationRequest) -> ToolPermissionDecision;
+}
+
+pub struct SecureToolExecutor<E, B> {
+    inner: E,
+    boundary: B,
+    session_id: Option<String>,
+    channel_origin: Option<ChannelContinuationIdentity>,
+}
+
+impl<E, B> SecureToolExecutor<E, B> {
+    pub fn new(inner: E, boundary: B) -> Self {
+        Self {
+            inner,
+            boundary,
+            session_id: None,
+            channel_origin: None,
+        }
+    }
+
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn with_channel_origin(mut self, origin: ChannelContinuationIdentity) -> Self {
+        self.channel_origin = Some(origin);
+        self
+    }
+}
+
+#[async_trait]
+impl<E, B> ToolExecutor for SecureToolExecutor<E, B>
+where
+    E: ToolExecutor,
+    B: ToolAuthorizationBoundary,
+{
+    async fn execute(&self, call: ToolCall) -> Result<ToolResult, RuntimeError> {
+        let request = ToolAuthorizationRequest {
+            call_id: call.id.clone(),
+            tool_name: call.name.clone(),
+            arguments: call.arguments.clone(),
+            session_id: self.session_id.clone(),
+            channel_origin: self.channel_origin.clone(),
+        };
+
+        match self.boundary.authorize(request).await {
+            ToolPermissionDecision::Allow => self.inner.execute(call).await,
+            ToolPermissionDecision::Deny { reason } => Ok(ToolResult {
+                call_id: call.id,
+                tool_name: call.name,
+                content: format!("tool authorization denied: {reason}"),
+                is_error: true,
+            }),
+            ToolPermissionDecision::RequireApproval { reason } => Ok(ToolResult {
+                call_id: call.id,
+                tool_name: call.name,
+                content: format!("tool authorization requires approval: {reason}"),
+                is_error: true,
+            }),
+        }
+    }
 }
 
 #[async_trait]
@@ -735,6 +859,18 @@ where
         Err(RuntimeError::IterationLimit(
             self.config.max_tool_iterations,
         ))
+    }
+
+    pub async fn run_channel_turn(
+        &self,
+        input: ChannelTurnInput,
+    ) -> Result<TurnOutput, RuntimeError> {
+        self.run_turn(TurnInput {
+            session_id: input.origin.session_id(),
+            agent_id: input.agent_id,
+            user_message: input.user_message,
+        })
+        .await
     }
 
     async fn execute_tool(&self, call: ToolCall) -> ToolResult {

--- a/crates/core/seidrum-agent-runtime/tests/secure_channel.rs
+++ b/crates/core/seidrum-agent-runtime/tests/secure_channel.rs
@@ -1,0 +1,264 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use seidrum_agent_runtime::{
+    AgentProvider, AgentRuntime, ChannelContinuationIdentity, ChannelKind, ChannelTurnInput,
+    InMemoryTurnStore, ProviderRequest, ProviderResponse, RuntimeConfig, RuntimeStore,
+    SecureToolExecutor, StoredTurnRecord, ToolAuthorizationBoundary, ToolAuthorizationRequest,
+    ToolCall, ToolExecutor, ToolPermissionDecision, ToolResult,
+};
+use serde_json::json;
+
+#[derive(Clone)]
+struct ScriptedProvider {
+    responses: Arc<Mutex<VecDeque<ProviderResponse>>>,
+    requests: Arc<Mutex<Vec<ProviderRequest>>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: impl IntoIterator<Item = ProviderResponse>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ProviderRequest> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AgentProvider for ScriptedProvider {
+    async fn complete(
+        &self,
+        request: ProviderRequest,
+    ) -> Result<ProviderResponse, seidrum_agent_runtime::RuntimeError> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .push(request);
+        self.responses
+            .lock()
+            .expect("responses lock poisoned")
+            .pop_front()
+            .ok_or_else(|| {
+                seidrum_agent_runtime::RuntimeError::Provider("no scripted response".to_string())
+            })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingTool {
+    calls: Arc<Mutex<Vec<ToolCall>>>,
+}
+
+impl RecordingTool {
+    fn new() -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls(&self) -> Vec<ToolCall> {
+        self.calls.lock().expect("calls lock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RecordingTool {
+    async fn execute(
+        &self,
+        call: ToolCall,
+    ) -> Result<ToolResult, seidrum_agent_runtime::RuntimeError> {
+        self.calls
+            .lock()
+            .expect("calls lock poisoned")
+            .push(call.clone());
+        Ok(ToolResult {
+            call_id: call.id,
+            tool_name: call.name,
+            content: "tool ran".to_string(),
+            is_error: false,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct StaticAuthorizationBoundary {
+    decision: ToolPermissionDecision,
+    requests: Arc<Mutex<Vec<ToolAuthorizationRequest>>>,
+}
+
+impl StaticAuthorizationBoundary {
+    fn new(decision: ToolPermissionDecision) -> Self {
+        Self {
+            decision,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ToolAuthorizationRequest> {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl ToolAuthorizationBoundary for StaticAuthorizationBoundary {
+    async fn authorize(&self, request: ToolAuthorizationRequest) -> ToolPermissionDecision {
+        self.requests
+            .lock()
+            .expect("requests lock poisoned")
+            .push(request);
+        self.decision.clone()
+    }
+}
+
+fn telegram_origin(thread_id: Option<&str>) -> ChannelContinuationIdentity {
+    ChannelContinuationIdentity {
+        provider: ChannelKind::Telegram,
+        chat_id: "chat-42".to_string(),
+        thread_id: thread_id.map(str::to_string),
+        user_id: Some("user-7".to_string()),
+        message_id: Some("msg-99".to_string()),
+        correlation_id: Some("corr-1".to_string()),
+    }
+}
+
+#[test]
+fn telegram_origin_maps_to_stable_session_with_thread() {
+    let origin = telegram_origin(Some("topic-3"));
+    let same_thread_different_message = ChannelContinuationIdentity {
+        message_id: Some("msg-100".to_string()),
+        correlation_id: Some("corr-2".to_string()),
+        ..origin.clone()
+    };
+    let different_thread = telegram_origin(Some("topic-4"));
+    let no_thread = telegram_origin(None);
+
+    assert_eq!(
+        origin.session_id(),
+        same_thread_different_message.session_id()
+    );
+    assert_eq!(
+        origin.session_id(),
+        "channel:telegram:chat:chat-42:thread:topic-3"
+    );
+    assert_ne!(origin.session_id(), different_thread.session_id());
+    assert_eq!(no_thread.session_id(), "channel:telegram:chat:chat-42");
+}
+
+#[tokio::test]
+async fn channel_turn_runs_through_runtime_without_bypassing_boundaries() {
+    let provider = ScriptedProvider::new([ProviderResponse::final_text("hello from channel")]);
+    let store = InMemoryTurnStore::default();
+    let runtime = AgentRuntime::new(provider.clone(), store.clone(), RuntimeConfig::default());
+    let origin = telegram_origin(Some("topic-3"));
+
+    let output = runtime
+        .run_channel_turn(ChannelTurnInput {
+            origin: origin.clone(),
+            agent_id: "agent-1".to_string(),
+            user_message: "hi".to_string(),
+        })
+        .await
+        .expect("channel turn should run");
+
+    assert_eq!(output.session_id, origin.session_id());
+    assert_eq!(output.final_text, "hello from channel");
+    assert_eq!(provider.requests()[0].session_id, origin.session_id());
+    let records = store
+        .records(&origin.session_id())
+        .await
+        .expect("records load");
+    assert!(matches!(records[0], StoredTurnRecord::UserMessage { .. }));
+}
+
+#[tokio::test]
+async fn secure_tool_executor_allows_authorized_tool() {
+    let tool = RecordingTool::new();
+    let boundary = StaticAuthorizationBoundary::new(ToolPermissionDecision::Allow);
+    let executor = SecureToolExecutor::new(tool.clone(), boundary.clone())
+        .with_session_id("session-1")
+        .with_channel_origin(telegram_origin(Some("topic-3")));
+
+    let result = executor
+        .execute(ToolCall {
+            id: "call-1".to_string(),
+            name: "echo".to_string(),
+            arguments: json!({"text": "ping"}),
+        })
+        .await
+        .expect("authorized tool runs");
+
+    assert_eq!(result.content, "tool ran");
+    assert!(!result.is_error);
+    assert_eq!(tool.calls().len(), 1);
+    let requests = boundary.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].session_id.as_deref(), Some("session-1"));
+    assert_eq!(requests[0].tool_name, "echo");
+    assert_eq!(
+        requests[0].channel_origin.as_ref().unwrap().session_id(),
+        "channel:telegram:chat:chat-42:thread:topic-3"
+    );
+}
+
+#[tokio::test]
+async fn secure_tool_executor_records_denied_tool_as_error_result() {
+    let tool = RecordingTool::new();
+    let boundary = StaticAuthorizationBoundary::new(ToolPermissionDecision::Deny {
+        reason: "not allowed in this channel".to_string(),
+    });
+    let executor = SecureToolExecutor::new(tool.clone(), boundary.clone());
+
+    let result = executor
+        .execute(ToolCall {
+            id: "call-1".to_string(),
+            name: "dangerous".to_string(),
+            arguments: json!({}),
+        })
+        .await
+        .expect("denial is a tool error result, not a runtime abort");
+
+    assert!(result.is_error);
+    assert_eq!(result.tool_name, "dangerous");
+    assert!(result.content.contains("tool authorization denied"));
+    assert!(result.content.contains("not allowed in this channel"));
+    assert!(tool.calls().is_empty());
+    assert_eq!(boundary.requests().len(), 1);
+}
+
+#[tokio::test]
+async fn approval_required_tool_decision_is_explicit_and_non_executing() {
+    let tool = RecordingTool::new();
+    let boundary = StaticAuthorizationBoundary::new(ToolPermissionDecision::RequireApproval {
+        reason: "requires human approval".to_string(),
+    });
+    let executor = SecureToolExecutor::new(tool.clone(), boundary.clone());
+
+    let result = executor
+        .execute(ToolCall {
+            id: "call-2".to_string(),
+            name: "send_notification".to_string(),
+            arguments: json!({"text": "hi"}),
+        })
+        .await
+        .expect("approval requirement is surfaced as tool error result");
+
+    assert!(result.is_error);
+    assert_eq!(result.tool_name, "send_notification");
+    assert!(result
+        .content
+        .contains("tool authorization requires approval"));
+    assert!(result.content.contains("requires human approval"));
+    assert!(tool.calls().is_empty());
+    assert_eq!(boundary.requests().len(), 1);
+}


### PR DESCRIPTION
## Summary
- add Telegram-style channel continuation identity and deterministic session mapping
- add channel-originated run_turn helper for AgentRuntime
- add mockable tool authorization boundary and SecureToolExecutor wrapper for allow/deny/approval-required decisions

## TDD / RED
- cargo test -p seidrum-agent-runtime --test secure_channel failed before implementation with unresolved imports for ChannelContinuationIdentity, ChannelKind, ChannelTurnInput, ToolAuthorizationBoundary, ToolAuthorizationRequest, ToolPermissionDecision, and SecureToolExecutor

## Test plan
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p seidrum-agent-runtime --test secure_channel
- cargo test -p seidrum-agent-runtime
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

## Notes
- no real Telegram network calls, tokens, secrets, daemon loop, dashboard, or approval UI
- preserves denied/approval-required calls as tool error results so runtime loop semantics continue