### PR TITLE
feat(runtime): add outbound delivery inspection

### DIFF
--- a/crates/core/seidrum-agent-runtime/src/lib.rs
+++ b/crates/core/seidrum-agent-runtime/src/lib.rs
@@ -281,6 +281,271 @@ pub trait AuthorizationAuditStore: Send + Sync + Clone + 'static {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OutboundDeliveryStatus {
+    Queued,
+    Sent,
+    Failed,
+    RetryScheduled,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundDeliveryRecord {
+    pub delivery_id: String,
+    pub session_id: String,
+    pub channel_origin: Option<ChannelContinuationIdentity>,
+    pub payload_text: String,
+    pub status: OutboundDeliveryStatus,
+    pub attempt_count: u32,
+    pub max_attempts: u32,
+    pub retry_after: Option<String>,
+    pub last_error: Option<String>,
+    pub linked_runtime_event_id: Option<String>,
+    pub provider_message_id: Option<String>,
+}
+
+impl OutboundDeliveryRecord {
+    pub fn queued(
+        delivery_id: impl Into<String>,
+        session_id: impl Into<String>,
+        channel_origin: Option<ChannelContinuationIdentity>,
+        payload_text: impl Into<String>,
+        linked_runtime_event_id: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            delivery_id: delivery_id.into(),
+            session_id: session_id.into(),
+            channel_origin,
+            payload_text: payload_text.into(),
+            status: OutboundDeliveryStatus::Queued,
+            attempt_count: 0,
+            max_attempts: 3,
+            retry_after: None,
+            last_error: None,
+            linked_runtime_event_id: linked_runtime_event_id.map(Into::into),
+            provider_message_id: None,
+        }
+    }
+
+    pub fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    pub fn mark_sent(&mut self, provider_message_id: Option<impl Into<String>>) {
+        self.status = OutboundDeliveryStatus::Sent;
+        self.attempt_count += 1;
+        self.retry_after = None;
+        self.last_error = None;
+        self.provider_message_id = provider_message_id.map(Into::into);
+    }
+
+    pub fn mark_cancelled(&mut self, reason: impl Into<String>) {
+        self.status = OutboundDeliveryStatus::Cancelled;
+        self.retry_after = None;
+        self.last_error = Some(reason.into());
+    }
+}
+
+#[async_trait]
+pub trait OutboundDeliveryStore: Send + Sync + Clone + 'static {
+    async fn put_outbound_delivery(
+        &self,
+        record: OutboundDeliveryRecord,
+    ) -> Result<(), RuntimeError>;
+
+    async fn outbound_delivery(
+        &self,
+        delivery_id: &str,
+    ) -> Result<Option<OutboundDeliveryRecord>, RuntimeError>;
+
+    async fn list_outbound_deliveries(&self) -> Result<Vec<OutboundDeliveryRecord>, RuntimeError>;
+
+    async fn outbound_deliveries_for_session(
+        &self,
+        session_id: &str,
+        status: Option<OutboundDeliveryStatus>,
+    ) -> Result<Vec<OutboundDeliveryRecord>, RuntimeError> {
+        Ok(self
+            .list_outbound_deliveries()
+            .await?
+            .into_iter()
+            .filter(|record| record.session_id == session_id)
+            .filter(|record| status.is_none_or(|status| record.status == status))
+            .collect())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundRetryPolicy {
+    max_attempts: u32,
+    backoff_schedule: Vec<String>,
+}
+
+impl OutboundRetryPolicy {
+    pub fn new(
+        max_attempts: u32,
+        backoff_schedule: impl IntoIterator<Item = impl ToString>,
+    ) -> Self {
+        Self {
+            max_attempts,
+            backoff_schedule: backoff_schedule
+                .into_iter()
+                .map(|value| value.to_string())
+                .collect(),
+        }
+    }
+
+    pub fn record_failure(
+        &self,
+        delivery: &mut OutboundDeliveryRecord,
+        error: impl Into<String>,
+    ) -> Result<(), RuntimeError> {
+        delivery.attempt_count += 1;
+        delivery.last_error = Some(error.into());
+        let max_attempts = delivery.max_attempts.min(self.max_attempts);
+        if delivery.attempt_count >= max_attempts {
+            delivery.status = OutboundDeliveryStatus::Failed;
+            delivery.retry_after = None;
+        } else {
+            delivery.status = OutboundDeliveryStatus::RetryScheduled;
+            let backoff_index = delivery.attempt_count.saturating_sub(1) as usize;
+            delivery.retry_after = self
+                .backoff_schedule
+                .get(backoff_index)
+                .cloned()
+                .or_else(|| self.backoff_schedule.last().cloned());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeOutboundDeliverySink {
+    result: Result<String, String>,
+}
+
+impl FakeOutboundDeliverySink {
+    pub fn successful(provider_message_id: impl Into<String>) -> Self {
+        Self {
+            result: Ok(provider_message_id.into()),
+        }
+    }
+
+    pub fn failing(error: impl Into<String>) -> Self {
+        Self {
+            result: Err(error.into()),
+        }
+    }
+
+    fn deliver(&self, _delivery: &OutboundDeliveryRecord) -> Result<String, String> {
+        self.result.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeOutboundDeliveryExecutor<S> {
+    store: S,
+    sink: FakeOutboundDeliverySink,
+    retry_policy: OutboundRetryPolicy,
+}
+
+impl<S> FakeOutboundDeliveryExecutor<S>
+where
+    S: OutboundDeliveryStore,
+{
+    pub fn new(
+        store: S,
+        sink: FakeOutboundDeliverySink,
+        retry_policy: OutboundRetryPolicy,
+    ) -> Self {
+        Self {
+            store,
+            sink,
+            retry_policy,
+        }
+    }
+
+    pub async fn dispatch_one(
+        &self,
+        delivery_id: &str,
+    ) -> Result<OutboundDeliveryRecord, RuntimeError> {
+        let mut delivery = self
+            .store
+            .outbound_delivery(delivery_id)
+            .await?
+            .ok_or_else(|| {
+                RuntimeError::Store(format!("delivery `{delivery_id}` is not defined"))
+            })?;
+        match self.sink.deliver(&delivery) {
+            Ok(provider_message_id) => delivery.mark_sent(Some(provider_message_id)),
+            Err(error) => self.retry_policy.record_failure(&mut delivery, error)?,
+        }
+        self.store.put_outbound_delivery(delivery.clone()).await?;
+        Ok(delivery)
+    }
+}
+
+pub async fn enqueue_outbound_response<S>(
+    store: &S,
+    event: &RuntimeEvent,
+    channel_origin: Option<ChannelContinuationIdentity>,
+) -> Result<OutboundDeliveryRecord, RuntimeError>
+where
+    S: OutboundDeliveryStore,
+{
+    let RuntimeEvent::OutboundResponse {
+        session_id,
+        agent_id,
+        text,
+    } = event;
+    let delivery = OutboundDeliveryRecord::queued(
+        new_record_id(),
+        session_id.clone(),
+        channel_origin,
+        text.clone(),
+        Some(format!("runtime:{session_id}:{agent_id}")),
+    );
+    store.put_outbound_delivery(delivery.clone()).await?;
+    Ok(delivery)
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeInspection {
+    pub session_id: String,
+    pub trace: RuntimeTrace,
+    pub authorization_audits: Vec<AuthorizationAuditRecord>,
+    pub outbound_deliveries: Vec<OutboundDeliveryRecord>,
+}
+
+pub async fn inspect_runtime_session<S>(
+    store: &S,
+    session_id: &str,
+) -> Result<RuntimeInspection, RuntimeError>
+where
+    S: RuntimeStore + AuthorizationAuditStore + OutboundDeliveryStore,
+{
+    Ok(RuntimeInspection {
+        session_id: session_id.to_string(),
+        trace: replay_session_trace(store, session_id).await?,
+        authorization_audits: store.authorization_audits_for_session(session_id).await?,
+        outbound_deliveries: store
+            .outbound_deliveries_for_session(session_id, None)
+            .await?,
+    })
+}
+
+pub async fn append_inspection_authorization_audit<S>(
+    store: &S,
+    record: AuthorizationAuditRecord,
+) -> Result<(), RuntimeError>
+where
+    S: AuthorizationAuditStore,
+{
+    store.append_authorization_audit(record).await
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryAuthorizationAuditStore {
     inner: Arc<Mutex<Vec<AuthorizationAuditRecord>>>,
@@ -762,6 +1027,8 @@ const JOB_DEFINITIONS_TABLE: redb::TableDefinition<&str, &[u8]> =
 const JOB_RUNS_TABLE: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new("job_runs");
 const AUTHORIZATION_AUDITS_TABLE: redb::TableDefinition<u64, &[u8]> =
     redb::TableDefinition::new("authorization_audits");
+const OUTBOUND_DELIVERIES_TABLE: redb::TableDefinition<&str, &[u8]> =
+    redb::TableDefinition::new("outbound_deliveries");
 
 #[derive(Debug, Clone)]
 pub struct RedbTurnStore {
@@ -796,6 +1063,13 @@ impl RedbTurnStore {
                 .map_err(|error| {
                     RuntimeError::Store(format!(
                         "failed to open authorization audits table: {error}"
+                    ))
+                })?;
+            write_txn
+                .open_table(OUTBOUND_DELIVERIES_TABLE)
+                .map_err(|error| {
+                    RuntimeError::Store(format!(
+                        "failed to open outbound deliveries table: {error}"
                     ))
                 })?;
         }
@@ -946,6 +1220,93 @@ impl AuthorizationAuditStore for RedbTurnStore {
             })?);
         }
         records.sort_by_key(|record: &AuthorizationAuditRecord| record.sequence);
+        Ok(records)
+    }
+}
+
+#[async_trait]
+impl OutboundDeliveryStore for RedbTurnStore {
+    async fn put_outbound_delivery(
+        &self,
+        record: OutboundDeliveryRecord,
+    ) -> Result<(), RuntimeError> {
+        let serialized = serde_json::to_vec(&record).map_err(|error| {
+            RuntimeError::Store(format!("failed to serialize outbound delivery: {error}"))
+        })?;
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb write: {error}")))?;
+        {
+            let mut table = write_txn
+                .open_table(OUTBOUND_DELIVERIES_TABLE)
+                .map_err(|error| {
+                    RuntimeError::Store(format!(
+                        "failed to open outbound deliveries table: {error}"
+                    ))
+                })?;
+            table
+                .insert(record.delivery_id.as_str(), serialized.as_slice())
+                .map_err(|error| {
+                    RuntimeError::Store(format!("failed to insert outbound delivery: {error}"))
+                })?;
+        }
+        write_txn.commit().map_err(|error| {
+            RuntimeError::Store(format!("failed to commit outbound delivery: {error}"))
+        })?;
+        Ok(())
+    }
+
+    async fn outbound_delivery(
+        &self,
+        delivery_id: &str,
+    ) -> Result<Option<OutboundDeliveryRecord>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn
+            .open_table(OUTBOUND_DELIVERIES_TABLE)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to open outbound deliveries table: {error}"))
+            })?;
+        table
+            .get(delivery_id)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to read outbound delivery: {error}"))
+            })?
+            .map(|data| {
+                serde_json::from_slice(data.value()).map_err(|error| {
+                    RuntimeError::Store(format!("failed to deserialize outbound delivery: {error}"))
+                })
+            })
+            .transpose()
+    }
+
+    async fn list_outbound_deliveries(&self) -> Result<Vec<OutboundDeliveryRecord>, RuntimeError> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|error| RuntimeError::Store(format!("failed to begin redb read: {error}")))?;
+        let table = read_txn
+            .open_table(OUTBOUND_DELIVERIES_TABLE)
+            .map_err(|error| {
+                RuntimeError::Store(format!("failed to open outbound deliveries table: {error}"))
+            })?;
+        let mut records = Vec::new();
+        for entry in table.iter().map_err(|error| {
+            RuntimeError::Store(format!("failed to iterate outbound deliveries: {error}"))
+        })? {
+            let (_, data) = entry.map_err(|error| {
+                RuntimeError::Store(format!("failed to read outbound delivery: {error}"))
+            })?;
+            records.push(serde_json::from_slice(data.value()).map_err(|error| {
+                RuntimeError::Store(format!("failed to deserialize outbound delivery: {error}"))
+            })?);
+        }
+        records.sort_by(|left: &OutboundDeliveryRecord, right| {
+            left.delivery_id.cmp(&right.delivery_id)
+        });
         Ok(records)
     }
 }

--- a/crates/core/seidrum-agent-runtime/tests/m3c_delivery_inspection.rs
+++ b/crates/core/seidrum-agent-runtime/tests/m3c_delivery_inspection.rs
@@ -1,0 +1,242 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use seidrum_agent_runtime::{
+    append_inspection_authorization_audit, enqueue_outbound_response, inspect_runtime_session,
+    AgentProvider, AgentRuntime, AuthorizationAuditRecord, ChannelContinuationIdentity,
+    ChannelKind, FakeOutboundDeliveryExecutor, FakeOutboundDeliverySink, OutboundDeliveryRecord,
+    OutboundDeliveryStatus, OutboundDeliveryStore, OutboundRetryPolicy, ProviderRequest,
+    ProviderResponse, RedbTurnStore, RuntimeConfig, RuntimeError, RuntimeEvent,
+    ToolPermissionDecision,
+};
+
+#[derive(Clone)]
+struct ScriptedProvider {
+    responses: Arc<Mutex<VecDeque<ProviderResponse>>>,
+}
+
+impl ScriptedProvider {
+    fn new(responses: impl IntoIterator<Item = ProviderResponse>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentProvider for ScriptedProvider {
+    async fn complete(&self, _request: ProviderRequest) -> Result<ProviderResponse, RuntimeError> {
+        self.responses
+            .lock()
+            .expect("responses lock poisoned")
+            .pop_front()
+            .ok_or_else(|| RuntimeError::Provider("no scripted response".to_string()))
+    }
+}
+
+fn telegram_origin() -> ChannelContinuationIdentity {
+    ChannelContinuationIdentity {
+        provider: ChannelKind::Telegram,
+        chat_id: "chat-42".to_string(),
+        thread_id: Some("topic-7".to_string()),
+        user_id: Some("user-9".to_string()),
+        message_id: Some("msg-1".to_string()),
+        correlation_id: Some("corr-1".to_string()),
+    }
+}
+
+#[tokio::test]
+async fn outbound_delivery_records_persist_across_reopen() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let origin = telegram_origin();
+
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_outbound_delivery(OutboundDeliveryRecord::queued(
+            "delivery-1",
+            "session-1",
+            Some(origin.clone()),
+            "hello telegram",
+            Some("trace-1"),
+        ))
+        .await
+        .expect("delivery should persist");
+    drop(store);
+
+    let reopened = RedbTurnStore::open(&path).expect("store should reopen");
+    let records = reopened
+        .outbound_deliveries_for_session("session-1", None)
+        .await
+        .expect("delivery records should load after reopen");
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].delivery_id, "delivery-1");
+    assert_eq!(records[0].session_id, "session-1");
+    assert_eq!(records[0].channel_origin.as_ref(), Some(&origin));
+    assert_eq!(records[0].payload_text, "hello telegram");
+    assert_eq!(records[0].status, OutboundDeliveryStatus::Queued);
+    assert_eq!(records[0].attempt_count, 0);
+    assert_eq!(records[0].max_attempts, 3);
+    assert_eq!(
+        records[0].linked_runtime_event_id.as_deref(),
+        Some("trace-1")
+    );
+}
+
+#[tokio::test]
+async fn channel_outbound_response_enqueues_delivery_without_network() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    let origin = telegram_origin();
+    let runtime = AgentRuntime::new(
+        ScriptedProvider::new([ProviderResponse::final_text("delivery text")]),
+        store.clone(),
+        RuntimeConfig::default(),
+    );
+
+    let output = runtime
+        .run_channel_turn(seidrum_agent_runtime::ChannelTurnInput {
+            origin: origin.clone(),
+            agent_id: "agent-1".to_string(),
+            user_message: "hello".to_string(),
+        })
+        .await
+        .expect("channel turn should run");
+    let delivery = enqueue_outbound_response(&store, &output.events[0], Some(origin.clone()))
+        .await
+        .expect("outbound response should enqueue without network");
+
+    let queued = store
+        .outbound_deliveries_for_session(&origin.session_id(), Some(OutboundDeliveryStatus::Queued))
+        .await
+        .expect("queued deliveries should load");
+    assert_eq!(delivery.payload_text, "delivery text");
+    assert_eq!(delivery.channel_origin.as_ref(), Some(&origin));
+    assert_eq!(queued, vec![delivery]);
+}
+
+#[tokio::test]
+async fn delivery_retry_policy_marks_retry_then_failed_after_max_attempts() {
+    let mut delivery = OutboundDeliveryRecord::queued(
+        "delivery-1",
+        "session-1",
+        Some(telegram_origin()),
+        "payload",
+        None::<String>,
+    )
+    .with_max_attempts(2);
+    let policy = OutboundRetryPolicy::new(2, [10, 20]);
+
+    policy
+        .record_failure(&mut delivery, "temporary outage")
+        .expect("first failure should schedule retry");
+    assert_eq!(delivery.status, OutboundDeliveryStatus::RetryScheduled);
+    assert_eq!(delivery.attempt_count, 1);
+    assert_eq!(delivery.retry_after.as_deref(), Some("10"));
+    assert_eq!(delivery.last_error.as_deref(), Some("temporary outage"));
+
+    policy
+        .record_failure(&mut delivery, "still down")
+        .expect("second failure should exhaust attempts");
+    assert_eq!(delivery.status, OutboundDeliveryStatus::Failed);
+    assert_eq!(delivery.attempt_count, 2);
+    assert_eq!(delivery.retry_after, None);
+    assert_eq!(delivery.last_error.as_deref(), Some("still down"));
+}
+
+#[tokio::test]
+async fn fake_delivery_executor_marks_sent_without_network() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    store
+        .put_outbound_delivery(OutboundDeliveryRecord::queued(
+            "delivery-1",
+            "session-1",
+            Some(telegram_origin()),
+            "payload",
+            None::<String>,
+        ))
+        .await
+        .expect("delivery should persist");
+
+    let executor = FakeOutboundDeliveryExecutor::new(
+        store.clone(),
+        FakeOutboundDeliverySink::successful("fake-message-1"),
+        OutboundRetryPolicy::new(3, [1, 2, 3]),
+    );
+    let updated = executor
+        .dispatch_one("delivery-1")
+        .await
+        .expect("fake dispatch should update delivery");
+
+    assert_eq!(updated.status, OutboundDeliveryStatus::Sent);
+    assert_eq!(updated.attempt_count, 1);
+    assert_eq!(updated.last_error, None);
+    assert_eq!(
+        updated.provider_message_id.as_deref(),
+        Some("fake-message-1")
+    );
+}
+
+#[tokio::test]
+async fn inspection_loads_trace_audit_and_delivery_for_session() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("runtime.redb");
+    let store = RedbTurnStore::open(&path).expect("store should open");
+    let origin = telegram_origin();
+    let session_id = origin.session_id();
+    let runtime = AgentRuntime::new(
+        ScriptedProvider::new([ProviderResponse::final_text("inspect me")]),
+        store.clone(),
+        RuntimeConfig::default(),
+    );
+
+    let output = runtime
+        .run_channel_turn(seidrum_agent_runtime::ChannelTurnInput {
+            origin: origin.clone(),
+            agent_id: "agent-1".to_string(),
+            user_message: "hello".to_string(),
+        })
+        .await
+        .expect("channel turn should run");
+    enqueue_outbound_response(&store, &output.events[0], Some(origin.clone()))
+        .await
+        .expect("delivery should enqueue");
+    append_inspection_authorization_audit(
+        &store,
+        AuthorizationAuditRecord {
+            audit_id: "audit-1".to_string(),
+            sequence: 1,
+            decision: ToolPermissionDecision::Allow,
+            tool_name: "safe-tool".to_string(),
+            call_id: "call-1".to_string(),
+            session_id: Some(session_id.clone()),
+            channel_origin: Some(origin),
+            reason: None,
+        },
+    )
+    .await
+    .expect("audit should persist");
+
+    let inspection = inspect_runtime_session(&store, &session_id)
+        .await
+        .expect("inspection should load without boundaries");
+
+    assert_eq!(inspection.session_id, session_id);
+    assert_eq!(inspection.trace.records.len(), 2);
+    assert_eq!(
+        inspection.trace.outbound_events,
+        vec![RuntimeEvent::OutboundResponse {
+            session_id: session_id.clone(),
+            agent_id: "agent-1".to_string(),
+            text: "inspect me".to_string(),
+        }]
+    );
+    assert_eq!(inspection.authorization_audits.len(), 1);
+    assert_eq!(inspection.outbound_deliveries.len(), 1);
+    assert_eq!(inspection.outbound_deliveries[0].payload_text, "inspect me");
+}


### PR DESCRIPTION
## Summary
- add durable outbound delivery records/status/retry state to `RedbTurnStore`
- add deterministic enqueue/retry/fake delivery executor helpers without network calls
- add library runtime inspection API aggregating trace, authorization audit, and delivery records for a session

## Test plan
- RED captured: `cargo test -p seidrum-agent-runtime outbound_delivery_records_persist_across_reopen --test m3c_delivery_inspection` failed on missing outbound delivery/inspection APIs before implementation
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test -p seidrum-agent-runtime --test m3c_delivery_inspection`
- `cargo test -p seidrum-agent-runtime`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Constraints
- no real Telegram API calls
- no provider credentials/secrets
- no external network delivery path
- no dashboard/HTTP server/daemon loop
